### PR TITLE
Extended CI Testing and Python 2.6 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .tox/
+.eggs
+*.egg-info/
+*pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ os:
   - linux
 env:
   - TOX_ENV=py27-lint
+  - TOX_ENV=py26-lint
+  - TOX_ENV=py27-unit
+  - TOX_ENV=py26-unit
 
 install:
   - pip install tox

--- a/schema_salad/jsonld_context.py
+++ b/schema_salad/jsonld_context.py
@@ -32,8 +32,9 @@ def pred(datatype, field, name, context, defaultBase, namespaces):
 
     if field and "jsonldPredicate" in field:
         if isinstance(field["jsonldPredicate"], dict):
-            v = {("@"+k[1:] if k.startswith("_") else k): v
-                 for k,v in field["jsonldPredicate"].items() }
+            v = {}
+            for k, val in field["jsonldPredicate"].items():
+                v[("@"+k[1:] if k.startswith("_") else k)] = val
         else:
             v = field["jsonldPredicate"]
     elif "jsonldPredicate" in datatype:

--- a/schema_salad/makedoc.py
+++ b/schema_salad/makedoc.py
@@ -460,7 +460,8 @@ if __name__ == "__main__":
                 s.append(j)
 
     primitiveType = args.primtype
-
-    redirect = {r.split("=")[0]:r.split("=")[1] for r in args.redirect} if args.redirect else {}
+    redirect = {}
+    for r in (args.redirect or []):
+        redirect[r.split("=")[0]] = r.split("=")[1]
     renderlist = args.only if args.only else []
     avrold_doc(s, sys.stdout, renderlist, redirect, args.brand, args.brandlink)

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -162,7 +162,7 @@ class Loader(object):
         self.vocab = {}
         self.rvocab = {}
 
-        self.ctx.update({k: v for k,v in newcontext.iteritems() if k != "@context"})
+        self.ctx.update(_copy_dict_without_key(newcontext, "@context"))
 
         _logger.debug("ctx is %s", self.ctx)
 
@@ -266,7 +266,7 @@ class Loader(object):
                 raise RuntimeError("Reference `%s` is not in the index.  Index contains:\n  %s" % (url, "\n  ".join(self.idx)))
 
         if "$graph" in obj:
-            metadata = {k: v for k,v in obj.items() if k != "$graph"}
+            metadata = _copy_dict_without_key(obj, "$graph")
             obj = obj["$graph"]
             return obj, metadata
         else:
@@ -314,7 +314,7 @@ class Loader(object):
                 loader = newctx
 
             if "$graph" in document:
-                metadata = {k: v for k,v in document.items() if k != "$graph"}
+                metadata = _copy_dict_without_key(document, "$graph")
                 document = document["$graph"]
                 metadata, _ = loader.resolve_all(metadata, base_url, file_base)
 
@@ -500,3 +500,11 @@ class Loader(object):
             else:
                 raise errors[0]
         return
+
+
+def _copy_dict_without_key(from_dict, filtered_key):
+    new_dict = {}
+    for key, value in from_dict.items():
+        if key != filtered_key:
+            new_dict[key] = value
+    return new_dict

--- a/schema_salad/schema.py
+++ b/schema_salad/schema.py
@@ -301,16 +301,18 @@ def extend_and_specialize(items, loader):
     """Apply 'extend' and 'specialize' to fully materialize derived record
     types."""
 
-    types = {t["name"]: t for t in items}
+    types = {}
+    for t in items:
+        types[t["name"]] = t
     n = []
 
     for t in items:
         t = copy.deepcopy(t)
         if "extends" in t:
+            spec = {}
             if "specialize" in t:
-                spec = {sp["specializeFrom"]: sp["specializeTo"] for sp in aslist(t["specialize"])}
-            else:
-                spec = {}
+                for sp in aslist(t["specialize"]):
+                    spec[sp["specializeFrom"]] = sp["specializeTo"]
 
             exfields = []
             exsym = []
@@ -357,7 +359,9 @@ def extend_and_specialize(items, loader):
 
         n.append(t)
 
-    ex_types = {t["name"]: t for t in n}
+    ex_types = {}
+    for t in n:
+        ex_types[t["name"]] = t
 
     extended_by = {}
     for t in n:
@@ -380,7 +384,10 @@ def make_avro_schema(j, loader):
 
     j = extend_and_specialize(j, loader)
 
-    j2 = make_valid_avro(j, {t["name"]: t for t in j}, set())
+    name_dict = {}
+    for t in j:
+        name_dict[t["name"]] = t
+    j2 = make_valid_avro(j, name_dict, set())
 
     j3 = [t for t in j2 if isinstance(t, dict) and not t.get("abstract") and t.get("type") != "documentation"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,14 @@
 [tox]
-envlist = py27-lint
+envlist = py27-lint,py26-lint
 skipsdist = True
 
 [testenv:py27-lint]
 commands = flake8 schema_salad
 whitelist_externals = flake8
 deps = flake8
+
+[testenv:py26-lint]
+commands = flake8 schema_salad
+whitelist_externals = flake8
+deps = flake8
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-lint,py26-lint
+envlist = py27-lint,py26-lint,py27-unit,py26-unit
 skipsdist = True
 
 [testenv:py27-lint]
@@ -12,3 +12,8 @@ commands = flake8 schema_salad
 whitelist_externals = flake8
 deps = flake8
 
+[testenv:py27-unit]
+commands = python setup.py test
+
+[testenv:py26-unit]
+commands = python setup.py test


### PR DESCRIPTION
The CI testing is probably un-controversial.

Python 2.6 is no longer supported by the Python project and dictionary comprehensions are cleaner in most cases then what I replaced them with - but these inconveniences are small compared to the fact that:
 - RHEL 6 is still pervasive at academic institutions including HPC centers we would like to run CWL workflows.
 - The Galaxy project still provides wide support for Python 2.6 including the core project and Planemo. I'd like unconditional support for cwl in both applications so I'd like cwltool to support Python 2.6 and hence this project.

Fixes https://github.com/common-workflow-language/galaxy/issues/19, xref https://github.com/galaxyproject/planemo/issues/411. 