### PR TITLE
Unscoped ids

### DIFF
--- a/schema_salad/jsonld_context.py
+++ b/schema_salad/jsonld_context.py
@@ -175,3 +175,51 @@ def salad_to_jsonld_context(j, schema_ctx):
         process_type(t, g, context, defaultBase, namespaces, defaultPrefix)
 
     return (context, g)
+
+def fix_jsonld_ids(obj, ids):
+    if isinstance(obj, dict):
+        for i in ids:
+            if i in obj:
+                obj["@id"] = obj[i]
+        for v in obj.values():
+            fix_jsonld_ids(v, ids)
+    if isinstance(obj, list):
+        for i in obj:
+            fix_jsonld_ids(i, ids)
+
+def makerdf(workflow, wf, ctx):
+    # type: (Union[str, unicode], Union[List[Dict[unicode, Any]], Dict[unicode, Any]], Loader.ContextType) -> Graph
+    prefixes = {}
+    idfields = []
+    for k,v in ctx.iteritems():
+        if isinstance(v, dict):
+            url = v["@id"]
+        else:
+            url = v
+        if url == "@id":
+            idfields.append(k)
+        doc_url, frg = urlparse.urldefrag(url)
+        if "/" in frg:
+            p, _ = frg.split("/")
+            prefixes[p] = u"%s#%s/" % (doc_url, p)
+
+    if isinstance(wf, list):
+        wf = {
+            "@context": ctx,
+            "@graph": wf
+        }
+    else:
+        wf["@context"] = ctx
+
+    fix_jsonld_ids(wf, idfields)
+
+    g = Graph().parse(data=json.dumps(wf), format='json-ld', location=workflow)
+
+    # Bug in json-ld loader causes @id fields to be added to the graph
+    for s,p,o in g.triples((None, URIRef("@id"), None)):
+        g.remove((s, p, o))
+
+    for k2,v2 in prefixes.iteritems():
+        g.namespace_manager.bind(k2, v2)
+
+    return g

--- a/schema_salad/jsonld_context.py
+++ b/schema_salad/jsonld_context.py
@@ -177,6 +177,7 @@ def salad_to_jsonld_context(j, schema_ctx):
     return (context, g)
 
 def fix_jsonld_ids(obj, ids):
+    # type: (Union[Dict[unicode, Any], List[Dict[unicode, Any]]], List[unicode]) -> None
     if isinstance(obj, dict):
         for i in ids:
             if i in obj:
@@ -184,8 +185,8 @@ def fix_jsonld_ids(obj, ids):
         for v in obj.values():
             fix_jsonld_ids(v, ids)
     if isinstance(obj, list):
-        for i in obj:
-            fix_jsonld_ids(i, ids)
+        for entry in obj:
+            fix_jsonld_ids(entry, ids)
 
 def makerdf(workflow, wf, ctx):
     # type: (Union[str, unicode], Union[List[Dict[unicode, Any]], Dict[unicode, Any]], Loader.ContextType) -> Graph

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -23,7 +23,7 @@ register('json-ld', Parser, 'rdflib_jsonld.parser', 'JsonLDParser')
 
 
 def printrdf(workflow, wf, ctx, sr):
-    # type: (str, Union[List, Dict[Any, Any], str, unicode], Dict[unicode, Any], str) -> None
+    # type: (str, Union[List[Dict[unicode, Any]], Dict[unicode, Any]], Dict[unicode, Any], str) -> None
     g = jsonld_context.makerdf(workflow, wf, ctx)
     print(g.serialize(format=sr))
 
@@ -209,8 +209,12 @@ def main(argsl=None):  # type: (List[str]) -> int
 
     # Optionally convert the document to RDF
     if args.print_rdf:
-        printrdf(args.document, document, schema_ctx, args.rdf_serializer)
-        return 0
+        if isinstance(document, (dict, list)):
+            printrdf(args.document, document, schema_ctx, args.rdf_serializer)
+            return 0
+        else:
+            print("Document must be a dictionary or list.")
+            return 1
 
     if args.print_metadata:
         print(json.dumps(doc_metadata, indent=4))

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -24,8 +24,7 @@ register('json-ld', Parser, 'rdflib_jsonld.parser', 'JsonLDParser')
 
 def printrdf(workflow, wf, ctx, sr):
     # type: (str, Union[List, Dict[Any, Any], str, unicode], Dict[unicode, Any], str) -> None
-    g = Graph().parse(data=json.dumps(wf), format='json-ld',
-                      location=workflow, context=ctx)
+    g = jsonld_context.makerdf(workflow, wf, ctx)
     print(g.serialize(format=sr))
 
 

--- a/schema_salad/metaschema/metaschema_base.yml
+++ b/schema_salad/metaschema/metaschema_base.yml
@@ -43,19 +43,19 @@ $graph:
   type: record
   doc: A field of a record.
   fields:
-    - name: name
+    name:
       type: string
       jsonldPredicate: "@id"
       doc: |
         The name of the field
 
-    - name: doc
+    doc:
       type: string?
       doc: |
         A documentation string for this field
       jsonldPredicate: "sld:doc"
 
-    - name: type
+    type:
       type:
         - PrimitiveType
         - RecordSchema
@@ -81,7 +81,7 @@ $graph:
 - name: RecordSchema
   type: record
   fields:
-    - name: type
+    type:
       doc: "Must be `record`"
       type:
         name: Record_symbol
@@ -93,9 +93,12 @@ $graph:
         _type: "@vocab"
         typeDSL: true
         refScope: 2
-    - name: "fields"
+    fields:
       type: RecordField[]?
-      jsonldPredicate: "sld:fields"
+      jsonldPredicate:
+        _id: sld:fields
+        mapSubject: name
+        mapPredicate: type
       doc: "Defines the fields of the record."
 
 
@@ -104,7 +107,7 @@ $graph:
   doc: |
     Define an enumerated type.
   fields:
-    - name: type
+    type:
       doc: "Must be `enum`"
       type:
         name: Enum_symbol
@@ -116,7 +119,7 @@ $graph:
         _type: "@vocab"
         typeDSL: true
         refScope: 2
-    - name: "symbols"
+    symbols:
       type: string[]
       jsonldPredicate:
         _id: "sld:symbols"
@@ -128,7 +131,7 @@ $graph:
 - name: ArraySchema
   type: record
   fields:
-    - name: type
+    type:
       doc: "Must be `array`"
       type:
         name: Array_symbol
@@ -140,7 +143,7 @@ $graph:
         _type: "@vocab"
         typeDSL: true
         refScope: 2
-    - name: items
+    items:
       type:
         - PrimitiveType
         - RecordSchema

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -135,8 +135,9 @@ class Loader(object):
                 frg = splitbase.fragment + u"/" + split.path
             else:
                 frg = split.path
+            pt = splitbase.path if splitbase.path else "/"
             url = urlparse.urlunsplit(
-                (splitbase.scheme, splitbase.netloc, splitbase.path, splitbase.query, frg))
+                (splitbase.scheme, splitbase.netloc, pt, splitbase.query, frg))
         elif scoped_ref is not None and not split.fragment:
             pass
         else:

--- a/schema_salad/schema.py
+++ b/schema_salad/schema.py
@@ -97,7 +97,11 @@ def get_metaschema():
             "@type": "@id",
             "refScope": 1
         },
-        "fields": "sld:fields",
+        "fields": {
+            "@id": "sld:fields",
+            "mapSubject": "name",
+            "mapPredicate": "type"
+        },
         "float": "http://www.w3.org/2001/XMLSchema#float",
         "identity": "https://w3id.org/cwl/salad#JsonldPredicate/identity",
         "int": "http://www.w3.org/2001/XMLSchema#int",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires.append("avro")  # TODO: remove me once cwltool is
 extras_require = {}               # TODO: to be removed when the above is added
 
 setup(name='schema-salad',
-      version='1.12',
+      version='1.13',
       description='Schema Annotations for Linked Avro Data (SALAD)',
       long_description=open(README).read(),
       author='Common workflow language working group',


### PR DESCRIPTION
Add test to support "unscoped" identifiers, these are object identifiers that follow the normal relative URI reference path join rules instead of schema salad's scoped document fragment identifiers.  This is used for the "location" field of File and Directory.