### PR TITLE
Pin ruamel.yaml less hard.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-ruamel.yaml==0.12.4
+ruamel.yaml>=0.12.4
 rdflib>=4.1.
 rdflib-jsonld>=0.3.0
 mistune

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ else:
 
 install_requires = [
     'requests',
-    'ruamel.yaml == 0.12.4',
+    'ruamel.yaml >= 0.12.4',
     'rdflib >= 4.1.0',
     'rdflib-jsonld >= 0.3.0',
     'mistune',


### PR DESCRIPTION
Hi ya'll,

The tests pass with ruamel.yaml 0.12.13, and pinning it specifically 0.12.4 makes it tough to solve some dependency problems for the bioconda install, so I pinned it less hard.