### PR TITLE
Remove pathlib2 because it is only used for one thing 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 typing==3.5.2.2 ; python_version>="2.7"
 avro-python3 ; python_version>="3"
 avro==1.8.1 ; python_version<"3"
-pathlib2==2.1.0
 ruamel.yaml==0.13.7
 rdflib==4.2.1
 rdflib-jsonld==0.4.0

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,7 @@ install_requires = [
     'mistune >= 0.7.3, < 0.8',
     'typing >= 3.5.2, < 3.6',
     'CacheControl >= 0.11.7, < 0.12',
-    'lockfile >= 0.9',
-    'pathlib2 >= 2.1.0']
+    'lockfile >= 0.9']
 
 install_requires.append("avro")  # TODO: remove me once cwltool is
 # available in Debian Stable, Ubuntu 12.04 LTS


### PR DESCRIPTION
Pathlib2 creates dependency issues that outweigh its benefit.