### PR TITLE
Improve debugging: missing filename and bad lists

### DIFF
--- a/schema_salad/sourceline.py
+++ b/schema_salad/sourceline.py
@@ -150,13 +150,13 @@ class SourceLine(object):
             return self.raise_type(msg)
         errs = []
         if self.key is None or self.item.lc.data is None or self.key not in self.item.lc.data:
-            lead = "%s:%i:%i:" % (self.item.lc.filename,
-                                  self.item.lc.line+1,
-                                  self.item.lc.col+1)
+            lead = "%s:%i:%i:" % (self.item.lc.filename if hasattr(self.item.lc, "filename") else "",
+                                  (self.item.lc.line or 0)+1,
+                                  (self.item.lc.col or 0)+1)
         else:
-            lead = "%s:%i:%i:" % (self.item.lc.filename,
-                                  self.item.lc.data[self.key][0]+1,
-                                  self.item.lc.data[self.key][1]+1)
+            lead = "%s:%i:%i:" % (self.item.lc.filename if hasattr(self.item.lc, "filename") else "",
+                                  (self.item.lc.data[self.key][0] or 0)+1,
+                                  (self.item.lc.data[self.key][1] or 0)+1)
         for m in msg.splitlines():
             if lineno_re.match(m):
                 errs.append(m)

--- a/schema_salad/validate.py
+++ b/schema_salad/validate.py
@@ -180,8 +180,8 @@ def validate_ex(expected_schema,            # type: Schema
             return True
         else:
             if raise_ex:
-                raise ValidationException(u"the value is not a list, expected list of %s" % (
-                    friendly(expected_schema.items)))
+                raise ValidationException(u"the value %s is not a list, expected list of %s" % (
+                    vpformat(datum), friendly(expected_schema.items)))
             else:
                 return False
     elif isinstance(expected_schema, avro.schema.UnionSchema):


### PR DESCRIPTION
These are debugging helpers for problematic CWL inputs, helping with
ongoing work debugging CWL Toil runs on AWS.

- Avoids failing on LineCol inputs that do not have file and
  position references. Without this in place the missing `filename` and
  None attributes for `line` and `col` obscure the real error message.
  Fixes common-workflow-language/cwltool#264
- Prints out value of a CWL data item that is not an expected list.