### PR TITLE
schema_salad/main.py: --version now correctly prints version

### DIFF
--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -87,7 +87,7 @@ def main(argsl=None):  # type: (List[str]) -> int
 
     if args.version is None and args.schema is None:
         print('%s: error: too few arguments' % sys.argv[0])
-        exit(0)
+        return 1
 
     if args.quiet:
         _logger.setLevel(logging.WARN)

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -62,8 +62,6 @@ def main(argsl=None):  # type: (List[str]) -> int
         "--print-index", action="store_true", help="Print node index")
     exgroup.add_argument("--print-metadata",
                          action="store_true", help="Print document metadata")
-    exgroup.add_argument("--version", action="store_true",
-                         help="Print version")
 
     exgroup = parser.add_mutually_exclusive_group()
     exgroup.add_argument("--strict", action="store_true", help="Strict validation (unrecognized or out of place fields are error)",
@@ -79,10 +77,17 @@ def main(argsl=None):  # type: (List[str]) -> int
     exgroup.add_argument("--debug", action="store_true",
                          help="Print even more logging")
 
-    parser.add_argument("schema", type=str)
+    parser.add_argument("schema", type=str, nargs="?", default=None)
     parser.add_argument("document", type=str, nargs="?", default=None)
+    parser.add_argument("--version", "-v", action="store_true",
+                        help="Print version", default=None)
+
 
     args = parser.parse_args(argsl)
+
+    if args.version is None and args.schema is None:
+        print('%s: error: too few arguments' % sys.argv[0])
+        exit(0)
 
     if args.quiet:
         _logger.setLevel(logging.WARN)
@@ -92,10 +97,10 @@ def main(argsl=None):  # type: (List[str]) -> int
     pkg = pkg_resources.require("schema_salad")
     if pkg:
         if args.version:
-            print("%s %s" % (sys.argv[0], pkg[0].version))
+            print("%s Current version: %s" % (sys.argv[0], pkg[0].version))
             return 0
         else:
-            _logger.info("%s %s", sys.argv[0], pkg[0].version)
+            _logger.info("%s Current version: %s", sys.argv[0], pkg[0].version)
 
     # Get the metaschema to validate the schema
     metaschema_names, metaschema_doc, metaschema_loader = schema.get_metaschema()

--- a/schema_salad/tests/test_cli_args.py
+++ b/schema_salad/tests/test_cli_args.py
@@ -1,0 +1,40 @@
+import unittest
+import sys
+
+import schema_salad.main as cli_parser
+
+""" for capturing print() output """
+from contextlib import contextmanager
+from StringIO import StringIO
+
+@contextmanager
+def captured_output():
+    new_out, new_err = StringIO(), StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_err
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+
+
+""" test different sets of command line arguments"""
+class ParseCliArgs(unittest.TestCase):
+
+    def test_version(self):
+        args = [["--version"], ["-v"]]
+        for arg in args:
+            with captured_output() as (out, err):
+                cli_parser.main(arg)
+
+            response = out.getvalue().strip()  # capture output and strip newline
+            self.assertTrue("Current version" in response)
+
+    def test_empty_input(self):
+        # running schema_salad tool wihtout any args
+        args = []
+        with captured_output() as (out, err):
+            cli_parser.main(args)
+
+        response = out.getvalue().strip()
+        self.assertTrue("error: too few arguments" in response)


### PR DESCRIPTION
``--version`` does not need to go in a mutually exclusive group. added ``nargs`` to make positional arguments optional.

``` bash
(venv) manu@hp:~/github/schema_salad$ schema-salad-tool -h
usage: schema-salad-tool [-h] [--rdf-serializer RDF_SERIALIZER]
                         [--print-jsonld-context | --print-rdfs | --print-avro | --print-rdf | --print-pre | --print-index | --print-metadata]
                         [--strict | --non-strict]
                         [--verbose | --quiet | --debug] [--version]
                         [schema] [document]

positional arguments:
  schema
  document

optional arguments:
  -h, --help            show this help message and exit
  --rdf-serializer RDF_SERIALIZER
                        Output RDF serialization format used by --print-rdf
                        (one of turtle (default), n3, nt, xml)
  --print-jsonld-context
                        Print JSON-LD context for schema
  --print-rdfs          Print RDF schema
  --print-avro          Print Avro schema
  --print-rdf           Print corresponding RDF graph for document
  --print-pre           Print document after preprocessing
  --print-index         Print node index
  --print-metadata      Print document metadata
  --strict              Strict validation (unrecognized or out of place fields
                        are error)
  --non-strict          Lenient validation (ignore unrecognized fields)
  --verbose             Default logging
  --quiet               Only print warnings and errors.
  --debug               Print even more logging
  --version, -v         Print version

(venv) manu@hp:~/github/schema_salad$ schema-salad-tool -v
/home/manu/github/schema_salad/venv/bin/schema-salad-tool Current version: 2.4.20170308171942
(venv) manu@hp:~/github/schema_salad$ schema-salad-tool --version
/home/manu/github/schema_salad/venv/bin/schema-salad-tool Current version: 2.4.20170308171942
```