### PR TITLE
Optional skip_schemas

### DIFF
--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -97,7 +97,8 @@ def merge_properties(a, b):  # type: (List[Any], List[Any]) -> Dict[Any, Any]
 def SubLoader(loader):  # type: (Loader) -> Loader
     return Loader(loader.ctx, schemagraph=loader.graph,
                   foreign_properties=loader.foreign_properties, idx=loader.idx,
-                  cache=loader.cache, fetcher_constructor=loader.fetcher_constructor)
+                  cache=loader.cache, fetcher_constructor=loader.fetcher_constructor,
+                  skip_schemas=loader.skip_schemas)
 
 class Fetcher(object):
     def fetch_text(self, url):    # type: (unicode) -> unicode
@@ -179,7 +180,8 @@ class Loader(object):
                  idx=None,                  # type: Dict[unicode, Union[CommentedMap, CommentedSeq, unicode, None]]
                  cache=None,                # type: Dict[unicode, Any]
                  session=None,              # type: requests.sessions.Session
-                 fetcher_constructor=None   # type: Callable[[Dict[unicode, unicode], requests.sessions.Session], Fetcher]
+                 fetcher_constructor=None,  # type: Callable[[Dict[unicode, unicode], requests.sessions.Session], Fetcher]
+                 skip_schemas=None          # type: bool
                  ):
         # type: (...) -> None
 
@@ -204,6 +206,11 @@ class Loader(object):
             self.cache = cache
         else:
             self.cache = {}
+
+        if skip_schemas is not None:
+            self.skip_schemas = skip_schemas
+        else:
+            self.skip_schemas = False
 
         if session is None:
             if "HOME" in os.environ:
@@ -305,6 +312,8 @@ class Loader(object):
 
     def add_schemas(self, ns, base_url):
         # type: (Union[List[unicode], unicode], unicode) -> None
+        if self.skip_schemas:
+            return
         for sch in aslist(ns):
             fetchurl = self.fetcher.urljoin(base_url, sch)
             if fetchurl not in self.cache:


### PR DESCRIPTION
Fixes common-workflow-language/cwltool#433

I would ideally also then want to remove "Did you include a $schemas section" from `validate.py` - but we don't know if the user want to do a strict vs non-strict.