### PR TITLE
use io.open instead of builtin open

### DIFF
--- a/schema_salad/makedoc.py
+++ b/schema_salad/makedoc.py
@@ -8,6 +8,7 @@ import copy
 import re
 import sys
 import logging
+from io import open
 
 from . import schema
 from .utils import add_dictlist, aslist
@@ -516,11 +517,11 @@ def main():  # type: () -> None
 
     s = []  # type: List[Dict[Text, Any]]
     a = args.schema
-    with open(a, 'rb') as f:
+    with open(a, encoding='utf-8') as f:
         if a.endswith("md"):
             s.append({"name": os.path.splitext(os.path.basename(a))[0],
                       "type": "documentation",
-                      "doc": f.read().decode("utf-8")
+                      "doc": f.read()
                       })
         else:
             uri = "file://" + os.path.abspath(a)

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -5,6 +5,7 @@ import json
 import hashlib
 import logging
 import collections
+from io import open
 
 import six
 from six.moves import range
@@ -145,9 +146,8 @@ class DefaultFetcher(Fetcher):
                 # remove the leading /.
                 if os.path.isabs(path[1:]):  # checking if pathis valid after removing front / or not
                     path = path[1:]
-                with open(urllib.request.url2pathname(str(path)), 'rb') as fp:
-                    read = fp.read()
-                return read.decode("utf-8")
+                with open(urllib.request.url2pathname(str(path)), encoding='utf-8') as fp:
+                    return fp.read()
 
             except (OSError, IOError) as e:
                 if e.filename == path:


### PR DESCRIPTION
Leads to more consistant behaviour across py2 and py3
also, specify encoding in the open command rather than
reading raw bytes and manually decoding