### PR TITLE
Refactor Windows relative path support

### DIFF
--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -182,7 +182,7 @@ class DefaultFetcher(Fetcher):
         basesplit = urllib.parse.urlsplit(base_url)
         split = urllib.parse.urlsplit(url)
         if (basesplit.scheme and basesplit.scheme != "file" and split.scheme == "file"):
-            raise ValueError("Not resolving potential remote exploit %s from base %s" % (url, base_url))            
+            raise ValueError("Not resolving potential remote exploit %s from base %s" % (url, base_url))
 
         if sys.platform == 'win32':
             if (base_url == url):
@@ -199,7 +199,7 @@ class DefaultFetcher(Fetcher):
                 # as urllib seems to not be quite up to the job
 
                 # netloc MIGHT appear in equivalents of UNC Strings
-                # \\server1.example.com\path as 
+                # \\server1.example.com\path as
                 # file:///server1.example.com/path
                 # https://tools.ietf.org/html/rfc8089#appendix-E.3.2
                 # (TODO: test this)
@@ -213,21 +213,21 @@ class DefaultFetcher(Fetcher):
                     path_with_drive = urllib.parse.urlunsplit((split.scheme, '', split.path,'', ''))
                     # Compose new file:/// URI with path_with_drive
                     # .. carrying over any #fragment (?query just in case..)
-                    return urllib.parse.urlunsplit(("file", netloc, 
+                    return urllib.parse.urlunsplit(("file", netloc,
                                         path_with_drive, split.query, split.fragment))
-                if (not split.scheme and not netloc and 
+                if (not split.scheme and not netloc and
                     split.path and split.path.startswith("/")):
                     # Relative - but does it have a drive?
                     base_drive = _re_drive.match(basesplit.path)
                     drive = _re_drive.match(split.path)
-                    if base_drive and not drive:                        
+                    if base_drive and not drive:
                         # Keep drive letter from base_url
                         # https://tools.ietf.org/html/rfc8089#appendix-E.2.1
                         # e.g. urljoin("file:///D:/bar/a.txt", "/foo/b.txt") == file:///D:/foo/b.txt
                         path_with_drive = "/%s:%s" % (base_drive.group(1), split.path)
-                        return urllib.parse.urlunsplit(("file", netloc, path_with_drive, 
-                                                   split.query, split.fragment))                    
-                        
+                        return urllib.parse.urlunsplit(("file", netloc, path_with_drive,
+                                                   split.query, split.fragment))
+
                 # else: fall-through to resolve as relative URI
             elif has_drive:
                 # Base is http://something but url is C:/something - which urllib would wrongly

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -41,6 +41,8 @@ DocumentType = TypeVar('DocumentType', CommentedSeq, CommentedMap)
 DocumentOrStrType = TypeVar(
     'DocumentOrStrType', CommentedSeq, CommentedMap, six.text_type)
 
+_re_drive = re.compile(r"/([a-zA-Z]):")
+
 def file_uri(path, split_frag=False):  # type: (str, bool) -> str
     if path.startswith("file://"):
         return path
@@ -177,23 +179,62 @@ class DefaultFetcher(Fetcher):
             raise ValueError('Unsupported scheme in url: %s' % url)
 
     def urljoin(self, base_url, url):  # type: (Text, Text) -> Text
+        basesplit = urllib.parse.urlsplit(base_url)
+        split = urllib.parse.urlsplit(url)
+        if (basesplit.scheme and basesplit.scheme != "file" and split.scheme == "file"):
+            raise ValueError("Not resolving potential remote exploit %s from base %s" % (url, base_url))            
 
-        # On windows urljoin consider drive name as scheme and forces it over base url's scheme,
-        # here we are forcing base url's scheme over url
         if sys.platform == 'win32':
             if (base_url == url):
                 return url
             basesplit = urllib.parse.urlsplit(base_url)
-            if basesplit.scheme:
-                split = urllib.parse.urlsplit(url)
-                if split.scheme:
-                    if split.scheme in ['http','https','file']:
-                        url = urllib.parse.urlunsplit(('', split.netloc, split.path, split.query, split.fragment))
-                    else:
-                        url= urllib.parse.urlunsplit((basesplit.scheme, split.netloc, urllib.parse.urlunsplit((split.scheme, '', split.path,'', '')), split.query, split.fragment))
-            return urllib.parse.urljoin(base_url, url)
-        else:
-            return urllib.parse.urljoin(base_url, url)
+            # note that below might split
+            # "C:" with "C" as URI scheme
+            split = urllib.parse.urlsplit(url)
+
+            has_drive = split.scheme and len(split.scheme) == 1
+
+            if basesplit.scheme == "file":
+                # Special handling of relative file references on Windows
+                # as urllib seems to not be quite up to the job
+
+                # netloc MIGHT appear in equivalents of UNC Strings
+                # \\server1.example.com\path as 
+                # file:///server1.example.com/path
+                # https://tools.ietf.org/html/rfc8089#appendix-E.3.2
+                # (TODO: test this)
+                netloc = split.netloc or basesplit.netloc
+
+                # Check if url is a local path like "C:/Users/fred"
+                # or actually an absolute URI like http://example.com/fred
+                if has_drive:
+                    # Assume split.scheme is actually a drive, e.g. "C:"
+                    # so we'll recombine into a path
+                    path_with_drive = urllib.parse.urlunsplit((split.scheme, '', split.path,'', ''))
+                    # Compose new file:/// URI with path_with_drive
+                    # .. carrying over any #fragment (?query just in case..)
+                    return urllib.parse.urlunsplit(("file", netloc, 
+                                        path_with_drive, split.query, split.fragment))
+                if (not split.scheme and not netloc and 
+                    split.path and split.path.startswith("/")):
+                    # Relative - but does it have a drive?
+                    base_drive = _re_drive.match(basesplit.path)
+                    drive = _re_drive.match(split.path)
+                    if base_drive and not drive:                        
+                        # Keep drive letter from base_url
+                        # https://tools.ietf.org/html/rfc8089#appendix-E.2.1
+                        # e.g. urljoin("file:///D:/bar/a.txt", "/foo/b.txt") == file:///D:/foo/b.txt
+                        path_with_drive = "/%s:%s" % (base_drive.group(1), split.path)
+                        return urllib.parse.urlunsplit(("file", netloc, path_with_drive, 
+                                                   split.query, split.fragment))                    
+                        
+                # else: fall-through to resolve as relative URI
+            elif has_drive:
+                # Base is http://something but url is C:/something - which urllib would wrongly
+                # resolve as an absolute path that could later be used to access local files
+                raise ValueError("Not resolving potential remote exploit %s from base %s" % (url, base_url))
+
+        return urllib.parse.urljoin(base_url, url)
 
 class Loader(object):
     def __init__(self,
@@ -256,7 +297,6 @@ class Loader(object):
         else:
             self.fetcher_constructor = DefaultFetcher
         self.fetcher = self.fetcher_constructor(self.cache, self.session)
-
         self.fetch_text = self.fetcher.fetch_text
         self.check_exists = self.fetcher.check_exists
 

--- a/schema_salad/tests/test_ref_resolver.py
+++ b/schema_salad/tests/test_ref_resolver.py
@@ -95,7 +95,7 @@ def test_DefaultFetcher_urljoin_win32(tmp_dir_fixture):
         # resolving absolute non-drive URIs still works
         url = fetcher.urljoin("file:///C:/Users/fred/foo.cwl", "http://example.com/bar/soup.cwl")
         assert url == "http://example.com/bar/soup.cwl"
-        # and of course relative paths from http:// 
+        # and of course relative paths from http://
         url = fetcher.urljoin("http://example.com/fred/foo.cwl", "soup.cwl")
         assert url == "http://example.com/fred/soup.cwl"
 
@@ -106,7 +106,7 @@ def test_DefaultFetcher_urljoin_win32(tmp_dir_fixture):
 
         # Security concern - can't resolve file: from http:
         with pytest.raises(ValueError):
-            url = fetcher.urljoin("http://example.com/fred/foo.cwl", "file:///c:/bar/soup.cwl")        
+            url = fetcher.urljoin("http://example.com/fred/foo.cwl", "file:///c:/bar/soup.cwl")
         # Drive-relative -- should NOT return "absolute" URI c:/bar/soup.cwl"
         # as that is a potential remote exploit
         with pytest.raises(ValueError):
@@ -137,7 +137,7 @@ def test_DefaultFetcher_urljoin_linux(tmp_dir_fixture):
         # relative from root
         url = fetcher.urljoin("file:///home/fred/foo.cwl", "/baz/soup.cwl")
         assert url == "file:///baz/soup.cwl"
- 
+
         url = fetcher.urljoin("file:///home/fred/foo.cwl", "http://example.com/bar/soup.cwl")
         assert url == "http://example.com/bar/soup.cwl"
 
@@ -150,10 +150,10 @@ def test_DefaultFetcher_urljoin_linux(tmp_dir_fixture):
 
         # Security concern - can't resolve file: from http:
         with pytest.raises(ValueError):
-            url = fetcher.urljoin("http://example.com/fred/foo.cwl", "file:///bar/soup.cwl")        
+            url = fetcher.urljoin("http://example.com/fred/foo.cwl", "file:///bar/soup.cwl")
 
         # But this one is not "dangerous" on Linux
-        fetcher.urljoin("http://example.com/fred/foo.cwl", "c:/bar/soup.cwl")            
+        fetcher.urljoin("http://example.com/fred/foo.cwl", "c:/bar/soup.cwl")
 
     finally:
-        sys.platform = actual_platform        
+        sys.platform = actual_platform

--- a/schema_salad/tests/test_ref_resolver.py
+++ b/schema_salad/tests/test_ref_resolver.py
@@ -53,3 +53,107 @@ def test_Loader_initialisation_with_neither_TMP_HOME_set(tmp_dir_fixture):
 
     loader = Loader(ctx={})
     assert isinstance(loader.session, Session)
+
+def test_DefaultFetcher_urljoin_win32(tmp_dir_fixture):
+    import os
+    import sys
+    from schema_salad.ref_resolver import DefaultFetcher
+    from requests import Session
+
+    # Ensure HOME is set.
+    os.environ["HOME"] = tmp_dir_fixture
+
+    actual_platform = sys.platform
+    try:
+        # For this test always pretend we're on Windows
+        sys.platform = "win32"
+        fetcher = DefaultFetcher({}, None)
+        # Relative path, same folder
+        url = fetcher.urljoin("file:///C:/Users/fred/foo.cwl", "soup.cwl")
+        assert url == "file:///C:/Users/fred/soup.cwl"
+        # Relative path, sub folder
+        url = fetcher.urljoin("file:///C:/Users/fred/foo.cwl", "foo/soup.cwl")
+        assert url == "file:///C:/Users/fred/foo/soup.cwl"
+        # relative climb-up path
+        url = fetcher.urljoin("file:///C:/Users/fred/foo.cwl", "../alice/soup.cwl")
+        assert url == "file:///C:/Users/alice/soup.cwl"
+
+        # Path with drive: should not be treated as relative to directory
+        # Note: \ would already have been converted to / by resolve_ref()
+        url = fetcher.urljoin("file:///C:/Users/fred/foo.cwl", "c:/bar/soup.cwl")
+        assert url == "file:///c:/bar/soup.cwl"
+        # /C:/  (regular URI absolute path)
+        url = fetcher.urljoin("file:///C:/Users/fred/foo.cwl", "/c:/bar/soup.cwl")
+        assert url == "file:///c:/bar/soup.cwl"
+        # Relative, change drive
+        url = fetcher.urljoin("file:///C:/Users/fred/foo.cwl", "D:/baz/soup.cwl")
+        assert url == "file:///d:/baz/soup.cwl"
+        # Relative from root of base's D: drive
+        url = fetcher.urljoin("file:///d:/baz/soup.cwl", "/foo/soup.cwl")
+        assert url == "file:///d:/foo/soup.cwl"
+
+        # resolving absolute non-drive URIs still works
+        url = fetcher.urljoin("file:///C:/Users/fred/foo.cwl", "http://example.com/bar/soup.cwl")
+        assert url == "http://example.com/bar/soup.cwl"
+        # and of course relative paths from http:// 
+        url = fetcher.urljoin("http://example.com/fred/foo.cwl", "soup.cwl")
+        assert url == "http://example.com/fred/soup.cwl"
+
+        # Stay on http:// and same host
+        url = fetcher.urljoin("http://example.com/fred/foo.cwl", "/bar/soup.cwl")
+        assert url == "http://example.com/bar/soup.cwl"
+
+
+        # Security concern - can't resolve file: from http:
+        with pytest.raises(ValueError):
+            url = fetcher.urljoin("http://example.com/fred/foo.cwl", "file:///c:/bar/soup.cwl")        
+        # Drive-relative -- should NOT return "absolute" URI c:/bar/soup.cwl"
+        # as that is a potential remote exploit
+        with pytest.raises(ValueError):
+            url = fetcher.urljoin("http://example.com/fred/foo.cwl", "c:/bar/soup.cwl")
+
+    finally:
+        sys.platform = actual_platform
+
+def test_DefaultFetcher_urljoin_linux(tmp_dir_fixture):
+    import os
+    import sys
+    from schema_salad.ref_resolver import DefaultFetcher
+    from requests import Session
+
+    # Ensure HOME is set.
+    os.environ["HOME"] = tmp_dir_fixture
+
+    actual_platform = sys.platform
+    try:
+        # Pretend it's Linux (e.g. not win32)
+        sys.platform = "linux2"
+        fetcher = DefaultFetcher({}, None)
+        url = fetcher.urljoin("file:///home/fred/foo.cwl", "soup.cwl")
+        assert url == "file:///home/fred/soup.cwl"
+
+        url = fetcher.urljoin("file:///home/fred/foo.cwl", "../alice/soup.cwl")
+        assert url == "file:///home/alice/soup.cwl"
+        # relative from root
+        url = fetcher.urljoin("file:///home/fred/foo.cwl", "/baz/soup.cwl")
+        assert url == "file:///baz/soup.cwl"
+ 
+        url = fetcher.urljoin("file:///home/fred/foo.cwl", "http://example.com/bar/soup.cwl")
+        assert url == "http://example.com/bar/soup.cwl"
+
+        url = fetcher.urljoin("http://example.com/fred/foo.cwl", "soup.cwl")
+        assert url == "http://example.com/fred/soup.cwl"
+
+        # Root-relative -- here relative to http host, not file:///
+        url = fetcher.urljoin("http://example.com/fred/foo.cwl", "/bar/soup.cwl")
+        assert url == "http://example.com/bar/soup.cwl"
+
+        # Security concern - can't resolve file: from http:
+        with pytest.raises(ValueError):
+            url = fetcher.urljoin("http://example.com/fred/foo.cwl", "file:///bar/soup.cwl")        
+
+        # But this one is not "dangerous" on Linux
+        fetcher.urljoin("http://example.com/fred/foo.cwl", "c:/bar/soup.cwl")            
+
+    finally:
+        sys.platform = actual_platform        


### PR DESCRIPTION
..as the previous code had buggy handling of resolving "http" URIs from
a "file" (e.g. a $schemas)

Also added unit tests and more special cases for relative drive:/ path
handling. UNC paths not tested - I don't think those work well anyway..

This fixes #129 and (for both windows and unix) #130