### PR TITLE
Add --print-oneline option

### DIFF
--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -40,13 +40,15 @@ def printrdf(workflow,  # type: str
     g = jsonld_context.makerdf(workflow, wf, ctx)
     print(g.serialize(format=sr))
 
+
 def chunk_messages(msg):  # type: (str) -> List[Tuple[int, str]]
     arr = []
     lst = msg.split("\n")
-    while len(lst):
+    while lst:
         fst = lst[0]
         indent = len(re.match(r'^.+:\d+:\d+:(\s+)', fst).group(1))
-        elem = "\n".join([fst]+list(itertools.takewhile(lambda x: x.startswith(' '), lst[1:])))
+        rst = list(itertools.takewhile(lambda x: x.startswith(' '), lst[1:]))
+        elem = "\n".join([fst]+rst)
         elem = re.sub(r'[\n\s]+', ' ', elem)
         # remove unnecessary '*' for itemize if exists
         elem = re.sub(r'^(.+:\d+:\d+: )\* ', r'\1', elem)
@@ -54,18 +56,19 @@ def chunk_messages(msg):  # type: (str) -> List[Tuple[int, str]]
         lst = list(itertools.dropwhile(lambda x: x.startswith(' '), lst[1:]))
     return arr
 
-def to_one_line_messages(msg):  # type: (str) -> str
+
+def to_one_line_messages(message):  # type: (str) -> str
     ret = []
     max_elem = (0, '')
-    for (indent, msg) in chunk_messages(msg):
+    for (indent, msg) in chunk_messages(message):
         if indent > max_elem[0]:
             max_elem = (indent, msg)
         else:
             ret.append(max_elem[1])
             max_elem = (indent, msg)
-    else:
-        ret.append(max_elem[1])
+    ret.append(max_elem[1])
     return "\n".join(ret)
+
 
 def main(argsl=None):  # type: (List[str]) -> int
     if argsl is None:
@@ -92,8 +95,8 @@ def main(argsl=None):  # type: (List[str]) -> int
         "--print-index", action="store_true", help="Print node index")
     exgroup.add_argument("--print-metadata",
                          action="store_true", help="Print document metadata")
-    exgroup.add_argument("--print-oneline",
-                         action="store_true", help="Print each error message in oneline")
+    exgroup.add_argument("--print-oneline", action="store_true",
+                         help="Print each error message in oneline")
 
     exgroup = parser.add_mutually_exclusive_group()
     exgroup.add_argument("--strict", action="store_true", help="Strict validation (unrecognized or out of place fields are error)",

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -40,7 +40,7 @@ def printrdf(workflow,  # type: str
     g = jsonld_context.makerdf(workflow, wf, ctx)
     print(g.serialize(format=sr))
 
-def chunk_messages(msg): # type: (str) -> List[Tuple[int, str]]
+def chunk_messages(msg):  # type: (str) -> List[Tuple[int, str]]
     arr = []
     lst = msg.split("\n")
     while len(lst):
@@ -54,7 +54,7 @@ def chunk_messages(msg): # type: (str) -> List[Tuple[int, str]]
         lst = list(itertools.dropwhile(lambda x: x.startswith(' '), lst[1:]))
     return arr
 
-def to_one_line_messages(msg): # type: (str) -> str
+def to_one_line_messages(msg):  # type: (str) -> str
     ret = []
     max_elem = (0, '')
     for (indent, msg) in chunk_messages(msg):


### PR DESCRIPTION
This request adds `--print-oneline` option to print each error message in oneline.
It makes us easier to develop tools that integrate the validators and IDEs (or editors): for example, [on-the-fly syntax checker in Emacs](http://www.flycheck.org/) for Common Workflow Language.

I confirmed this request does not introduce new errors in `make mypy2` and `make mypy3`.

## Motivation:

Currently `schema_salad_tool` prints good error messages with indents and newlines for user-readability.

For instance:
```console
$ schema_salad_tool /path/to/v1.0/CommonWorkflowLanguage.yml sample.cwl
While validating document `sample.cwl`:
sample.cwl:3:1: Object `sample.cwl` is not valid because
                  tried `CommandLineTool` but
sample.cwl:6:1:     the `inputs` field is not valid because
sample.cwl:7:3:       item is invalid because
sample.cwl:9:5:         the `inputBinding` field is not valid because
                          tried CommandLineBinding but
sample.cwl:11:7:             * invalid field `invalid_field`, expected one of:
                             'loadContents', 'position', 'prefix', 'separate', 'itemSeparator',
                             'valueFrom', 'shellQuote'
sample.cwl:12:7:             * invalid field `another_invalid_field`, expected one of:
                             'loadContents', 'position', 'prefix', 'separate', 'itemSeparator',
                             'valueFrom', 'shellQuote'
```

However, this format is not good for developers who want to integrate `schema-salad-tool` with our development tools.
It would be nice if `schema_salad_tool` provides a feature to print the error messages that can be easily processed by computers.

For example, if the messages can be easily parsed by regular expressions we can add an on-the-fly syntax checking feature using Flycheck (de facto on-the-fly checker for Emacs) in a straightforward way.
Otherwise we should define our own parser for this purpose.
I guess similar situations will happen in other editors such as Vim and Atom.

After merging this request, we can use `--print-oneline` for this purpose:
```console
$ schema_salad_tool /path/to/v1.0/CommonWorkflowLanguage.yml sample.cwl --print-oneline
While validating document `sample.cwl`:
sample.cwl:11:7: invalid field `invalid_field`, expected one of: 'loadContents', 'position', 'prefix', 'separate', 'itemSeparator', 'valueFrom', 'shellQuote'
sample.cwl:12:7: invalid field `another_invalid_field`, expected one of: 'loadContents', 'position', 'prefix', 'separate', 'itemSeparator', 'valueFrom', 'shellQuote'
```

## Implementation

I added two helper function for this request.

- `chuck_messages` returns a list with a tuple that contains the number of spaces after filename and the message in which spaces and newlines are removed.

  Here is the sample output (I added newlines for readability):

```python
[(1, 'sample.cwl:3:1: Object `sample.cwl` is not valid because tried `CommandLineTool` but'),
 (5, 'sample.cwl:6:1: the `inputs` field is not valid because'),
 (7, 'sample.cwl:7:3: item is invalid because'),
 (9, 'sample.cwl:9:5: the `inputBinding` field is not valid because tried CommandLineBinding but'),
 (13, "sample.cwl:11:7: invalid field `invalid_field`, expected one of: 'loadContents', 'position', 'prefix', 'separate', 'itemSeparator', 'valueFrom', 'shellQuote'"),
 (13, "sample.cwl:12:7: invalid field `another_invalid_field`, expected one of: 'loadContents', 'position', 'prefix', 'separate', 'itemSeparator', 'valueFrom', 'shellQuote'")]
```

- `to_one_line_messages` returns a string in which each line contains the message and the place where the error occurs. It internally uses `chunk_messages`.

```python
"sample.cwl:11:7: invalid field `invalid_field`, expected one of: 'loadContents', 'position', 'prefix', 'separate', 'itemSeparator', 'valueFrom', 'shellQuote'
sample.cwl:12:7: invalid field `another_invalid_field`, expected one of: 'loadContents', 'position', 'prefix', 'separate', 'itemSeparator', 'valueFrom', 'shellQuote'"
```

Note: I used the following CWL file for the example:

```yaml
#!/usr/bin/env cwl-runner

cwlVersion: v1.0
class: CommandLineTool
baseCommand: echo
inputs:
  message:
    type: string
    inputBinding:
      position: 1
      invalid_field: it_is_invalid_field
      another_invalid_field: invalid
outputs: []
```