### PR TITLE
Better itemize handling for `--print-oneline`

### DIFF
--- a/schema_salad/tests/test_print_oneline.py
+++ b/schema_salad/tests/test_print_oneline.py
@@ -20,8 +20,9 @@ class TestPrintOneline(unittest.TestCase):
                 load_and_validate(document_loader, avsc_names,
                                   six.text_type(get_data("tests/test_schema/"+src)), True)
             except ValidationException as e:
-                msgs = to_one_line_messages(str(e)).split("\n")
+                msgs = to_one_line_messages(str(e)).splitlines()
                 self.assertEqual(len(msgs), 2)
+                m = re.match(r'^(.+:\d+:\d+:)(.+)$', msgs[0])
                 self.assertTrue(msgs[0].endswith(src+":11:7: invalid field `invalid_field`, expected one of: 'loadContents', 'position', 'prefix', 'separate', 'itemSeparator', 'valueFrom', 'shellQuote'"))
                 self.assertTrue(msgs[1].endswith(src+":12:7: invalid field `another_invalid_field`, expected one of: 'loadContents', 'position', 'prefix', 'separate', 'itemSeparator', 'valueFrom', 'shellQuote'"))
                 print("\n", e)
@@ -44,5 +45,23 @@ class TestPrintOneline(unittest.TestCase):
                 if '\\' in fullpath:
                     fullpath = '/'+fullpath.replace('\\', '/')
                 self.assertEqual(msg, 'while scanning a simple key in "file://%s", line 9, column 7 could not find expected \':\' in "file://%s", line 10, column 1' % (fullpath, fullpath))
+                print("\n", e)
+                raise
+
+    def test_print_oneline_for_errors_in_the_same_line(self):
+        # Issue #136
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        src = "test17.cwl"
+        with self.assertRaises(ValidationException):
+            try:
+                load_and_validate(document_loader, avsc_names,
+                                  six.text_type(get_data("tests/test_schema/"+src)), True)
+            except ValidationException as e:
+                msgs = to_one_line_messages(str(e)).splitlines()
+                self.assertEqual(len(msgs), 2)
+                self.assertTrue(msgs[0].endswith(src+":13:5: missing required field `id`"))
+                self.assertTrue(msgs[1].endswith(src+":13:5: invalid field `aa`, expected one of: 'label', 'secondaryFiles', 'format', 'streamable', 'doc', 'id', 'outputBinding', 'type'"))
                 print("\n", e)
                 raise

--- a/schema_salad/tests/test_schema/test17.cwl
+++ b/schema_salad/tests/test_schema/test17.cwl
@@ -1,0 +1,13 @@
+class: CommandLineTool
+cwlVersion: v1.0
+baseCommand: cowsay
+inputs:
+  - id: input
+    type: string?
+    inputBinding:
+      position: 0
+outputs:
+  - id: output
+    type: string?
+    outputBinding: {}
+  - aa: moa


### PR DESCRIPTION
This request fix to show a better message for `--print-oneline` in which it handles itemize better.

Here is the example:

```yaml
class: CommandLineTool
cwlVersion: v1.0
baseCommand: cowsay
inputs:
  - id: input
    type: string?
    inputBinding:
      position: 0
outputs:
  - id: output
    type: string?
    outputBinding: {}
  - aa: moa
```

Without `--print-oneline`, we see the following messages:
```console
While validating document `echo.cwl`:
echo.cwl:1:1: Object `echo.cwl` is not valid because
                tried `CommandLineTool` but
echo.cwl:9:1:     the `outputs` field is not valid because
echo.cwl:13:5:       item is invalid because
                       * missing required field `id`
                       * invalid field `aa`, expected one of: 'label', 'secondaryFiles',
                       'streamable', 'doc', 'id', 'outputBinding', 'format', 'type'
```

We expect for `--print-oneline` to show the following messages:
- echo.cwl:14:5: item is invalid because missing required field `id`
- echo.cwl:14:5: item is invalid because invalid field `aa`, expected one of: 'label', 'secondaryFiles', 'streamable', 'doc', 'id', 'outputBinding', 'format', 'type'

However, we actually see:
```console
While validating document `echo.cwl`:
echo.cwl:14:5: item is invalid because * missing required field `id` * invalid field `aa`, expected one of: 'label', 'secondaryFiles', 'streamable', 'doc', 'id', 'outputBinding', 'format', 'type'
```
in which itemize for the same line are accidentally shown in the same line.

After merging this request:
```console
While validating document `echo.cwl`:
echo.cwl:13:5: missing required field `id`
echo.cwl:13:5: invalid field `aa`, expected one of: 'label', 'secondaryFiles', 'streamable', 'doc', 'id', 'outputBinding', 'format', 'type'
```

It is not the best but is reasonable enough, I guess.
For better `--print-oneline`, we have to modify `validate.py` to hold the error messages before formatting.
Although it needs much effort, the gain is not so much.

