### PR TITLE
Fix for pylint

### DIFF
--- a/schema_salad/makedoc.py
+++ b/schema_salad/makedoc.py
@@ -324,10 +324,10 @@ class RenderType(object):
 
         if f["type"] != "documentation":
             lines = []
-            for l in f["doc"].splitlines():
-                if len(l) > 0 and l[0] == "#":
-                    l = ("#" * depth) + l
-                lines.append(l)
+            for line in f["doc"].splitlines():
+                if len(line) > 0 and line[0] == "#":
+                    line = ("#" * depth) + line
+                lines.append(line)
             f["doc"] = "\n".join(lines)
 
             _, frg = urllib.parse.urldefrag(f["name"])

--- a/schema_salad/tests/test_examples.py
+++ b/schema_salad/tests/test_examples.py
@@ -22,9 +22,9 @@ from ruamel.yaml.comments import CommentedSeq, CommentedMap
 
 class TestSchemas(unittest.TestCase):
     def test_schemas(self):
-        l = schema_salad.ref_resolver.Loader({})
+        loader = schema_salad.ref_resolver.Loader({})
 
-        ra, _ = l.resolve_all(cmap({
+        ra, _ = loader.resolve_all(cmap({
             u"$schemas": [schema_salad.ref_resolver.file_uri(get_data("tests/EDAM.owl"))],
             u"$namespaces": {u"edam": u"http://edamontology.org/"},
             u"edam:has_format": u"edam:format_1915"
@@ -389,7 +389,7 @@ class SourceLineTest(unittest.TestCase):
                 raise Exception("Whoops")
         except TestExp as e:
             self.assertTrue(str(e).endswith("frag.yml:3:3: Whoops"))
-        except:
+        except Exception:
             self.assertFail()
 
         try:
@@ -397,7 +397,7 @@ class SourceLineTest(unittest.TestCase):
                 raise Exception("Whoops")
         except TestExp as e:
             self.assertTrue(str(e).splitlines()[0].endswith("frag.yml:3:3: Traceback (most recent call last):"))
-        except:
+        except Exception:
             self.assertFail()
 
 

--- a/schema_salad/utils.py
+++ b/schema_salad/utils.py
@@ -27,18 +27,18 @@ def flatten(l, ltypes=(list, tuple)):
         return [l]
 
     ltype = type(l)
-    l = list(l)
+    lst = list(l)
     i = 0
-    while i < len(l):
-        while isinstance(l[i], ltypes):
-            if not l[i]:
-                l.pop(i)
+    while i < len(lst):
+        while isinstance(lst[i], ltypes):
+            if not lst[i]:
+                lst.pop(i)
                 i -= 1
                 break
             else:
-                l[i:i + 1] = l[i]
+                lst[i:i + 1] = lst[i]
         i += 1
-    return ltype(l)
+    return ltype(lst)
 
 # Check if we are on windows OS
 def onWindows():


### PR DESCRIPTION
This request fixes the following errors by pylint.

```console
schema_salad/makedoc.py:329:21: E741 ambiguous variable name 'l'
schema_salad/utils.py:30:5: E741 ambiguous variable name 'l'
schema_salad/tests/test_examples.py:25:9: E741 ambiguous variable name 'l'
schema_salad/tests/test_examples.py:392:9: E722 do not use bare except'
schema_salad/tests/test_examples.py:400:9: E722 do not use bare except'
```

Here are more details:
> schema_salad/makedoc.py:329:21: E741 ambiguous variable name 'l'

- `l` -> `line`
  - There is a variable named `lines` near this code. Other name may be better.


> schema_salad/utils.py:30:5: E741 ambiguous variable name 'l'

- `l` -> `lst`

> schema_salad/tests/test_examples.py:25:9: E741 ambiguous variable name 'l'

- `l` -> `loader`

> schema_salad/tests/test_examples.py:392:9: E722 do not use bare except'
> schema_salad/tests/test_examples.py:400:9: E722 do not use bare except'

- `except:` -> `except Exception:`
  - See also: https://docs.python.org/3.1/howto/doanddont.html#except
