### PR TITLE
Fix error message for resolve_ref with --print-oneline

### DIFF
--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -276,7 +276,7 @@ def main(argsl=None):  # type: (List[str]) -> int
         document, doc_metadata = document_loader.resolve_ref(uri)
     except validate.ValidationException as e:
         msg = strip_dup_lineno(six.text_type(e))
-        msg = to_one_line_messages(msg) if args.print_oneline else msg
+        msg = to_one_line_messages(str(msg)) if args.print_oneline else msg
         _logger.error("Document `%s` failed validation:\n%s",
                       args.document, msg, exc_info=args.debug)
         return 1

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -274,7 +274,13 @@ def main(argsl=None):  # type: (List[str]) -> int
         if not urllib.parse.urlparse(uri)[0]:
             doc = "file://" + os.path.abspath(uri)
         document, doc_metadata = document_loader.resolve_ref(uri)
-    except (validate.ValidationException, RuntimeError) as e:
+    except validate.ValidationException as e:
+        msg = strip_dup_lineno(six.text_type(e))
+        msg = to_one_line_messages(msg) if args.print_oneline else msg
+        _logger.error("Document `%s` failed validation:\n%s",
+                      args.document, msg, exc_info=args.debug)
+        return 1
+    except RuntimeError as e:
         msg = strip_dup_lineno(six.text_type(e))
         msg = re.sub(r'[\s\n]+', ' ', msg) if args.print_oneline else msg
         _logger.error("Document `%s` failed validation:\n%s",

--- a/schema_salad/tests/test_print_oneline.py
+++ b/schema_salad/tests/test_print_oneline.py
@@ -65,3 +65,24 @@ class TestPrintOneline(unittest.TestCase):
                 self.assertTrue(msgs[1].endswith(src+":13:5: invalid field `aa`, expected one of: 'label', 'secondaryFiles', 'format', 'streamable', 'doc', 'id', 'outputBinding', 'type'"))
                 print("\n", e)
                 raise
+
+    def test_print_oneline_for_errors_in_resolve_ref(self):
+        # Issue #141
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        src = "test18.cwl"
+        fullpath = normpath(get_data("tests/test_schema/"+src))
+        with self.assertRaises(ValidationException):
+            try:
+                load_and_validate(document_loader, avsc_names,
+                                  six.text_type(fullpath), True)
+            except ValidationException as e:
+                msgs = to_one_line_messages(strip_dup_lineno(six.text_type(e))).splitlines()
+                # convert Windows path to Posix path
+                if '\\' in fullpath:
+                    fullpath = '/'+fullpath.replace('\\', '/')
+                self.assertEqual(len(msgs), 1)
+                self.assertTrue(msgs[0].endswith(src+':13:5:Field `type` references unknown identifier `Filea`, tried file://%s#Filea' % (fullpath)))
+                print("\n", e)
+                raise

--- a/schema_salad/tests/test_print_oneline.py
+++ b/schema_salad/tests/test_print_oneline.py
@@ -78,7 +78,7 @@ class TestPrintOneline(unittest.TestCase):
                 load_and_validate(document_loader, avsc_names,
                                   six.text_type(fullpath), True)
             except ValidationException as e:
-                msgs = to_one_line_messages(strip_dup_lineno(six.text_type(e))).splitlines()
+                msgs = to_one_line_messages(str(strip_dup_lineno(six.text_type(e)))).splitlines()
                 # convert Windows path to Posix path
                 if '\\' in fullpath:
                     fullpath = '/'+fullpath.replace('\\', '/')

--- a/schema_salad/tests/test_schema/test18.cwl
+++ b/schema_salad/tests/test_schema/test18.cwl
@@ -1,0 +1,13 @@
+class: CommandLineTool
+cwlVersion: v1.0
+baseCommand: echo
+inputs:
+  - id: input
+    type: string?
+    inputBinding: {}
+outputs:
+  - id: output
+    type: string?
+    outputBinding: {}
+  - id: output1
+    type: Filea


### PR DESCRIPTION
`salad-schema-tool` with `--print-oneline` prints unintended oneline output with the following CWL file.

```yaml
class: CommandLineTool
cwlVersion: v1.0
baseCommand: echo
inputs:
  - id: input
    type: string?
    inputBinding: {}
outputs:
  - id: output
    type: string?
    outputBinding: {}
  - id: output1
    type: Filea
```

Without `--print-oneline` (actual output):
```console
test18.cwl:8:1: checking field `outputs`
test18.cwl:12:5:   checking object `test18.cwl#output1`
test18.cwl:13:5:     Field `type` references unknown identifier `Filea`, tried
                     file:///Users/tom-tan/repos/schema_salad/schema_salad/tests/test_schema/test18.cwl#Filea
```

Expected with `--print-oneline`:
```console
test18.cwl:13:5: Field `type` references unknown identifier `Filea`, tried file:///Users/tom-tan/repos/schema_salad/schema_salad/tests/test_schema/test18.cwl#Filea
```

Actual with `--print-oneline`:
```console
test18.cwl:8:1: checking field `outputs` test18.cwl:12:5: checking object `test18.cwl#output1` test18.cwl:13:5: Field `type` references unknown identifier `Filea`, tried file:///Users/tom-tan/repos/schema_salad/schema_salad/tests/test_schema/test18.cwl#Filea
```

The reason why it is just a joined string is that `ValidationException` thrown in [this line](https://github.com/common-workflow-language/schema_salad/blob/master/schema_salad/main.py#L276) does not formatted by `to_one_line_messages`.
This request fixes this issue.

After merging this request:
```console
test18.cwl:13:5:Field `type` references unknown identifier `Filea`, tried file:///Users/tom-tan/repos/schema_salad/schema_salad/tests/test_schema/test18.cwl#Filea
```

Note: There should be a space between `test18.cwl:13:5:` and `Field ...` but it will be done by other request.

~I will add a test case for it soon.~ Now this request includes a test case.