### PR TITLE
Add space between filename and message for `--print-oneline`

### DIFF
--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -68,15 +68,15 @@ def chunk_messages(message):  # type: (str) -> List[Tuple[int, str]]
         lst = [mat.group(3)]+chun[1:]
         if [x for x in lst if item_regex.match(x)]:
             for item in regex_chunk(lst, item_regex):
-                msg = re.sub(item_regex, ' ', "\n".join(item))
-                arr.append((indent, place+re.sub(r'[\n\s]+',
+                msg = re.sub(item_regex, '', "\n".join(item))
+                arr.append((indent, place+' '+re.sub(r'[\n\s]+',
+                                                     ' ',
+                                                     msg)))
+        else:
+            msg = re.sub(item_regex, '', "\n".join(lst))
+            arr.append((indent, place+' '+re.sub(r'[\n\s]+',
                                                  ' ',
                                                  msg)))
-        else:
-            msg = re.sub(item_regex, ' ', "\n".join(lst))
-            arr.append((indent, place+re.sub(r'[\n\s]+',
-                                             ' ',
-                                             msg)))
     return arr
 
 

--- a/schema_salad/tests/test_print_oneline.py
+++ b/schema_salad/tests/test_print_oneline.py
@@ -83,6 +83,6 @@ class TestPrintOneline(unittest.TestCase):
                 if '\\' in fullpath:
                     fullpath = '/'+fullpath.replace('\\', '/')
                 self.assertEqual(len(msgs), 1)
-                self.assertTrue(msgs[0].endswith(src+':13:5:Field `type` references unknown identifier `Filea`, tried file://%s#Filea' % (fullpath)))
+                self.assertTrue(msgs[0].endswith(src+':13:5: Field `type` references unknown identifier `Filea`, tried file://%s#Filea' % (fullpath)))
                 print("\n", e)
                 raise


### PR DESCRIPTION
As I described in #141, the output with `--print-oneline` for `test18.cwl` needs a space between the place where the error happens and the error message.
This request fixes `main.py` and the test case for `--print-oneline`.

Before:
```console
test18.cwl:13:5:Field `type` references unknown identifier `Filea`, tried file:///Users/tom-tan/repos/schema_salad/schema_salad/tests/test_schema/test18.cwl#Filea
```

After merging this request:
```console
test18.cwl:13:5: Field `type` references unknown identifier `Filea`, tried file:///Users/tom-tan/repos/schema_salad/schema_salad/tests/test_schema/test18.cwl#Filea
```