### PR TITLE
Unify the error message format for invalid YAML

### DIFF
--- a/schema_salad/tests/test_print_oneline.py
+++ b/schema_salad/tests/test_print_oneline.py
@@ -85,7 +85,7 @@ class TestPrintOneline(unittest.TestCase):
                 raise
 
     def test_for_invalid_yaml1(self):
-        # Issue ???
+        # Issue 143
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
             get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
 
@@ -104,7 +104,7 @@ class TestPrintOneline(unittest.TestCase):
                 raise
 
     def test_for_invalid_yaml2(self):
-        # Issue ???
+        # Issue 143
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
             get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
 

--- a/schema_salad/tests/test_schema/test19.cwl
+++ b/schema_salad/tests/test_schema/test19.cwl
@@ -1,0 +1,15 @@
+: aaa
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+inputs:
+  message:
+    type: string
+    inputBinding:
+      position: 1
+outputs:
+  hello_output:
+    type: File
+    outputBinding:
+      glob: hello-out.txt
+stdout: hello-out.txt


### PR DESCRIPTION
This request unifies the format for error message due to invalid YAMLs.

Currently `schema-salad-tool` uses the following format for error messages in most cases (e.g. `test15.cwl` in this repository):
```console
While validating document `test15.cwl`:
test15.cwl:3:1: Object `test15.cwl` is not valid because
                  tried `CommandLineTool` but
test15.cwl:6:1:     the `inputs` field is not valid because
test15.cwl:7:3:       item is invalid because
test15.cwl:9:5:         the `inputBinding` field is not valid because
                          tried CommandLineBinding but
test15.cwl:11:7:             * invalid field `invalid_field`, expected one of:
                             'loadContents', 'position', 'prefix', 'separate', 'itemSeparator',
                             'valueFrom', 'shellQuote'
test15.cwl:12:7:             * invalid field `another_invalid_field`, expected one of:
                             'loadContents', 'position', 'prefix', 'separate', 'itemSeparator',
                             'valueFrom', 'shellQuote'
```

However, when the input is invalid YAML, the output format of `schema-salad-tool` is quite different from the above example.

For instance, `schema-salad-tool` prints the following output for `test16.cwl` in this repository:
```console
Document `test16.cwl` failed validation:
while scanning a simple key
  in "file:///Users/tom-tan/repos/schema_salad/schema_salad/tests/test_schema/test16.cwl", line 9, column 7
could not find expected ':'
  in "file:///Users/tom-tan/repos/schema_salad/schema_salad/tests/test_schema/test16.cwl", line 10, column 1
```

After merging this request:
```console
Document `test16.cwl` failed validation:
test16.cwl:9:7: while scanning a simple key
test16.cwl:10:1:   could not find expected ':'
```

It provides more consistent messages for users and
it makes easier to integrate with `--print-oneline` option.

Here is another example (named `test19.cwl`) for this case.
```yaml
: aaa
cwlVersion: v1.0
class: CommandLineTool
baseCommand: echo
inputs:
  message:
    type: string
    inputBinding:
      position: 1
outputs:
  hello_output:
    type: File
    outputBinding:
      glob: hello-out.txt
stdout: hello-out.txt
```

Before this request:
```console
Document `test19.cwl` failed validation:
Syntax error while parsing a block mapping
expected <block end>, but found ':'
  in "file:///Users/tom-tan/repos/schema_salad/schema_salad/tests/test_schema/test19.cwl", line 1, column 1
```

After merging this request:
```console
Document `test19.cwl` failed validation:
test19.cwl:1:1: expected <block end>, but found ':'
```

The line `Syntax error while parsing a block mapping` is omitted
because the second and third lines are enough for users to search for
where and why the input is not valid.


### Implementation details

I just added `reformat_yaml_exception_message` to reformat the messages.
In `schema_salad.main`, it is called when `RuntimeError` is thrown in line 301.
I assumed that this `RuntimeError` has the same string as the string `ruamel.yaml.error.MarkedYAMLError` generates.

Ideally, I should catch `MarkedYAMLError` instead of `RuntimeError`.
However, `resolve_ref` throws an exception without its original exception type information.
To solve this issue, we need much larger pull request.
IMO this request is reasonable enough to unify the error messages.
