### PR TITLE
main: print string instead of bytes

### DIFF
--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -39,7 +39,7 @@ def printrdf(workflow,  # type: str
              ):
     # type: (...) -> None
     g = jsonld_context.makerdf(workflow, wf, ctx)
-    print(g.serialize(format=sr))
+    print(g.serialize(format=sr, encoding='utf-8').decode('utf-8'))
 
 
 def regex_chunk(lines, regex):


### PR DESCRIPTION
Fixes formatting of RDF output on Python 3.