### PR TITLE
Corrects initializer to FileCache when no TMP or HOME

### DIFF
--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -290,7 +290,7 @@ class Loader(object):
             else:
                 self.session = CacheControl(
                     requests.Session(),
-                    cache=FileCache("/tmp", ".cache", "salad"))
+                    cache=FileCache(os.path.join("/tmp", ".cache", "salad")))
         else:
             self.session = session
 


### PR DESCRIPTION
This else case was missing a wrapping `os.path.join()`

Fixes #158