### PR TITLE
Add checks for redundant fields in codegen-ed code

### DIFF
--- a/schema_salad/codegen.py
+++ b/schema_salad/codegen.py
@@ -89,7 +89,16 @@ def codegen(lang,             # type: str
 
                 cg.declare_field(fieldpred, tl, f.get("doc"), optional)
 
-            cg.end_class(rec["name"])
+            field_names = []
+            for f in rec.get("fields", []):
+                jld = f.get("jsonldPredicate")
+                name = f["name"]
+                if isinstance(jld, dict):
+                    if "_id" in jld and jld["_id"][0] != "@":
+                        name = jld["_id"]
+                field_names.append(shortname(name))
+
+            cg.end_class(rec["name"], field_names)
 
     rootType = list(documentRoots)
     rootType.append({

--- a/schema_salad/codegen_base.py
+++ b/schema_salad/codegen_base.py
@@ -38,8 +38,8 @@ class CodeGenBase(object):
         # type: (Text, List[Text], Text, bool) -> None
         raise NotImplementedError()
 
-    def end_class(self, classname):
-        # type: (Text) -> None
+    def end_class(self, classname, field_names):
+        # type: (Text, List[Text]) -> None
         raise NotImplementedError()
 
     def type_loader(self, t):

--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -68,7 +68,7 @@ public class {cls}Impl implements {cls} {{
     void Load() {
 """)
 
-    def end_class(self, classname):
+    def end_class(self, classname, field_names):
         with open(os.path.join(self.outdir, "%s.java" % self.current_class), "a") as f:
             f.write("""
 }


### PR DESCRIPTION
This request fixes #156.

## Problem
The source of #156 is that the codegen-ed parser does not check for redundant fields.

For example, let us consider the following CWL file (`echo.cwl` in #156).
```cwl
requirements:
  - class: DockerRequirement
    dockerPull: docker/whalesay
class: CommandLineTool
cwlVersion: v1.0
baseCommand: cowsay
inputs:
  - id: input
    type: string
    inputBinding: {}
outputs:
  output:
    type: stdout
stdout: output
```

The codegen-ed parser tries to apply the parser for `*Requirements` (i.e. `InlineJavascriptRequirement`, `SchemaDefRequirement`, ...) iteratively.
If it fails to apply the parser for a requirement `R` (i.e. a parser for `R` throws an exception), it tries to apply other parsers for `*Requirement`.
If it successfully applies the parser for a requirement `R`, the codegen-ed parser treat the given requirement object as `R`.

In the example, the codegen-ed parser first tries to apply the parser for `InlineJavascriptRequirements`.
It checks there exists mandatory `class` and optional `expressionLib` but does not check there are no redundant fields for `InlineJavascriptRequirement`.
Therefore the codegen-ed parser accidentally treats the requirement object as `InlineJavascriptRequirement` instead of `DockerRequirement`.

## How to solve the problem in this request
This request adds a check to disallow redundant fields.

Note: This code rejects the extended fields (e.g. `s:author` field as shown in [section 17 in user guide](http://www.commonwl.org/user_guide/17-metadata/)) but it will be fixed in other request.
