### PR TITLE
Fix inconsistent definition with cwl files in CWL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ typeshed/2and3/ruamel/yaml
 # virtualenv 
 venv/
 .cache/
+.pytest_cache/

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -1045,8 +1045,11 @@ class Loader(object):
                     if identifier in document:
                         sl = SourceLine(document, identifier, validate.ValidationException)
                         if document[identifier] in all_doc_ids and sl.makeLead() != all_doc_ids[document[identifier]]:
-                            raise validate.ValidationException(
-                                "%s object %s `%s` previously defined" % (all_doc_ids[document[identifier]], identifier, relname(document[identifier]), ))
+                            # raise validate.ValidationException(
+                            #     "%s object %s `%s` previously defined" % (all_doc_ids[document[identifier]], identifier, relname(document[identifier]), ))
+                            pass # Because the spec of CWL allows duplicated keys globally.
+                            # TODO: Validator should local scope only in which duplicated keys are prohibited.
+                            # See also https://github.com/common-workflow-language/common-workflow-language/issues/734
                         else:
                             all_doc_ids[document[identifier]] = sl.makeLead()
                             break

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -1045,11 +1045,10 @@ class Loader(object):
                     if identifier in document:
                         sl = SourceLine(document, identifier, validate.ValidationException)
                         if document[identifier] in all_doc_ids and sl.makeLead() != all_doc_ids[document[identifier]]:
-                            # raise validate.ValidationException(
-                            #     "%s object %s `%s` previously defined" % (all_doc_ids[document[identifier]], identifier, relname(document[identifier]), ))
-                            pass  # Because the spec of CWL allows duplicated keys globally.
                             # TODO: Validator should local scope only in which duplicated keys are prohibited.
                             # See also https://github.com/common-workflow-language/common-workflow-language/issues/734
+                            # In the future, it should raise validate.ValidationException instead of _logger.warn
+                            _logger.warn("%s object %s `%s` previously defined" % (all_doc_ids[document[identifier]], identifier, relname(document[identifier]), ))
                         else:
                             all_doc_ids[document[identifier]] = sl.makeLead()
                             break

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -1047,7 +1047,7 @@ class Loader(object):
                         if document[identifier] in all_doc_ids and sl.makeLead() != all_doc_ids[document[identifier]]:
                             # raise validate.ValidationException(
                             #     "%s object %s `%s` previously defined" % (all_doc_ids[document[identifier]], identifier, relname(document[identifier]), ))
-                            pass # Because the spec of CWL allows duplicated keys globally.
+                            pass  # Because the spec of CWL allows duplicated keys globally.
                             # TODO: Validator should local scope only in which duplicated keys are prohibited.
                             # See also https://github.com/common-workflow-language/common-workflow-language/issues/734
                         else:

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -23,10 +23,23 @@ class TestErrors(unittest.TestCase):
                   "test_schema/test9.cwl",
                   "test_schema/test10.cwl",
                   "test_schema/test11.cwl",
-                  "test_schema/test12.cwl",
-                  "test_schema/test13.cwl",
-                  "test_schema/test14.cwl",
                   "test_schema/test15.cwl"):
+            with self.assertRaises(ValidationException):
+                try:
+                    load_and_validate(document_loader, avsc_names,
+                            six.text_type(get_data("tests/"+t)), True)
+                except ValidationException as e:
+                    print("\n", e)
+                    raise
+
+    @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
+    def test_errors_previously_defined_dict_key(self):
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        for t in ("test_schema/test12.cwl",
+                  "test_schema/test13.cwl",
+                  "test_schema/test14.cwl"):
             with self.assertRaises(ValidationException):
                 try:
                     load_and_validate(document_loader, avsc_names,


### PR DESCRIPTION
Related common-workflow-language/common-workflow-language#734

After merged, common-workflow-language/common-workflow-language should

```
git submodule update --remote
```