### PR TITLE
flake8 got more strict

### DIFF
--- a/schema_salad/makedoc.py
+++ b/schema_salad/makedoc.py
@@ -222,9 +222,10 @@ class RenderType(object):
                 raise
 
         for entry in alltypes:
-            if (entry["name"] in renderlist or
-                    ((not renderlist) and ("extends" not in entry) and
-                     ("docParent" not in entry) and ("docAfter" not in entry))):
+            if (entry["name"] in renderlist
+                    or ((not renderlist) and ("extends" not in entry)
+                        and ("docParent" not in entry)
+                        and ("docAfter" not in entry))):
                 self.render_type(entry, 1)
 
     def typefmt(self,

--- a/schema_salad/metaschema.py
+++ b/schema_salad/metaschema.py
@@ -13,7 +13,6 @@ import ruamel.yaml
 import six
 from ruamel.yaml.comments import CommentedBase, CommentedMap, CommentedSeq
 from typing_extensions import Text  # pylint: disable=unused-import
-
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 
@@ -196,15 +195,14 @@ class SourceLine(object):
 
 import copy
 import re
-import uuid
+import uuid  # pylint: disable=unused-import
 from typing import (Any, Dict, List, MutableMapping, MutableSequence, Sequence,
                     Union)
 
-import six
 from ruamel import yaml
+from six import iteritems, string_types, text_type
 from six.moves import StringIO, urllib
 from typing_extensions import Text  # pylint: disable=unused-import
-
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 
@@ -262,7 +260,7 @@ class LoadingOptions(object):
         if namespaces is not None:
             self.vocab = self.vocab.copy()
             self.rvocab = self.rvocab.copy()
-            for k,v in six.iteritems(namespaces):
+            for k,v in iteritems(namespaces):
                 self.vocab[k] = v
                 self.rvocab[v] = k
 
@@ -293,7 +291,7 @@ def expand_url(url,                 # type: Union[str, Text]
                ):
     # type: (...) -> Text
 
-    if not isinstance(url, six.string_types):
+    if not isinstance(url, string_types):
         return url
 
     url = Text(url)
@@ -391,7 +389,7 @@ class _ArrayLoader(_Loader):
                 else:
                     r.append(lf)
             except ValidationException as e:
-                errors.append(SourceLine(doc, i, str).makeError(six.text_type(e)))
+                errors.append(SourceLine(doc, i, str).makeError(text_type(e)))
         if errors:
             raise ValidationException("\n".join(errors))
         return r
@@ -454,13 +452,13 @@ class _URILoader(_Loader):
         if isinstance(doc, MutableSequence):
             doc = [expand_url(i, baseuri, loadingOptions,
                             self.scoped_id, self.vocab_term, self.scoped_ref) for i in doc]
-        if isinstance(doc, six.string_types):
+        if isinstance(doc, string_types):
             doc = expand_url(doc, baseuri, loadingOptions,
                              self.scoped_id, self.vocab_term, self.scoped_ref)
         return self.inner.load(doc, baseuri, loadingOptions)
 
 class _TypeDSLLoader(_Loader):
-    typeDSLregex = re.compile(u"^([^[?]+)(\[\])?(\?)?$")
+    typeDSLregex = re.compile(r"^([^[?]+)(\[\])?(\?)?$")
 
     def __init__(self, inner, refScope):
         # type: (_Loader, Union[int, None]) -> None
@@ -492,7 +490,7 @@ class _TypeDSLLoader(_Loader):
         if isinstance(doc, MutableSequence):
             r = []
             for d in doc:
-                if isinstance(d, six.string_types):
+                if isinstance(d, string_types):
                     resolved = self.resolve(d, baseuri, loadingOptions)
                     if isinstance(resolved, MutableSequence):
                         for i in resolved:
@@ -504,7 +502,7 @@ class _TypeDSLLoader(_Loader):
                 else:
                     r.append(d)
             doc = r
-        elif isinstance(doc, six.string_types):
+        elif isinstance(doc, string_types):
             doc = self.resolve(doc, baseuri, loadingOptions)
 
         return self.inner.load(doc, baseuri, loadingOptions)
@@ -539,7 +537,7 @@ class _IdMapLoader(_Loader):
 
 
 def _document_load(loader, doc, baseuri, loadingOptions):
-    if isinstance(doc, six.string_types):
+    if isinstance(doc, string_types):
         return _document_load_by_url(loader, loadingOptions.fetcher.urljoin(baseuri, doc), loadingOptions)
 
     if isinstance(doc, MutableMapping):
@@ -610,7 +608,7 @@ def save_relative_uri(uri, base_url, scoped_id, ref_scope, relative_uris):
         return uri
     if isinstance(uri, MutableSequence):
         return [save_relative_uri(u, base_url, scoped_id, ref_scope, relative_uris) for u in uri]
-    elif isinstance(uri, six.text_type):
+    elif isinstance(uri, text_type):
         urisplit = urllib.parse.urlsplit(uri)
         basesplit = urllib.parse.urlsplit(base_url)
         if urisplit.scheme == basesplit.scheme and urisplit.netloc == basesplit.netloc:

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -263,7 +263,7 @@ class _URILoader(_Loader):
         return self.inner.load(doc, baseuri, loadingOptions)
 
 class _TypeDSLLoader(_Loader):
-    typeDSLregex = re.compile(u"^([^[?]+)(\[\])?(\?)?$")
+    typeDSLregex = re.compile(r"^([^[?]+)(\[\])?(\?)?$")
 
     def __init__(self, inner, refScope):
         # type: (_Loader, Union[int, None]) -> None

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -213,8 +213,8 @@ class DefaultFetcher(Fetcher):
                     # .. carrying over any #fragment (?query just in case..)
                     return urllib.parse.urlunsplit(
                         ("file", netloc, path_with_drive, split.query, split.fragment))
-                if (not split.scheme and not netloc and
-                        split.path and split.path.startswith("/")):
+                if (not split.scheme and not netloc and split.path
+                        and split.path.startswith("/")):
                     # Relative - but does it have a drive?
                     base_drive = _re_drive.match(basesplit.path)
                     drive = _re_drive.match(split.path)
@@ -365,10 +365,9 @@ class Loader(object):
     def _add_properties(self, s):  # type: (Text) -> None
         for _, _, rng in self.graph.triples((s, RDFS.range, None)):
             literal = ((Text(rng).startswith(
-                u"http://www.w3.org/2001/XMLSchema#") and
-                not Text(rng) == u"http://www.w3.org/2001/XMLSchema#anyURI")
-                or Text(rng) ==
-                u"http://www.w3.org/2000/01/rdf-schema#Literal")
+                u"http://www.w3.org/2001/XMLSchema#")
+                and not Text(rng) == u"http://www.w3.org/2001/XMLSchema#anyURI")
+                or Text(rng) == u"http://www.w3.org/2000/01/rdf-schema#Literal")
             if not literal:
                 self.url_fields.add(Text(s))
         self.foreign_properties.add(Text(s))
@@ -653,7 +652,7 @@ class Loader(object):
 
                     document[idmapField] = ls
 
-    typeDSLregex = re.compile(u"^([^[?]+)(\[\])?(\?)?$")
+    typeDSLregex = re.compile(Text(r"^([^[?]+)(\[\])?(\?)?$"))
 
     def _type_dsl(self,
                   t,        # type: Union[Text, Dict, List]

--- a/schema_salad/validate.py
+++ b/schema_salad/validate.py
@@ -220,8 +220,10 @@ def validate_ex(expected_schema,                  # type: Schema
                 continue
             elif isinstance(datum, MutableMapping) and not isinstance(s, avro.schema.RecordSchema):
                 continue
-            elif (isinstance(datum, (bool, six.integer_types, float, six.string_types)) and  # type: ignore
-                  isinstance(s, (avro.schema.ArraySchema, avro.schema.RecordSchema))):
+            elif (isinstance(  # type: ignore
+                    datum, (bool, six.integer_types, float, six.string_types))
+                    and isinstance(s, (avro.schema.ArraySchema,
+                                       avro.schema.RecordSchema))):
                 continue
             elif datum is not None and s.type == "null":
                 continue


### PR DESCRIPTION
Fixes
```
schema_salad/metaschema.py:463:16: W605 invalid escape sequence '\['
schema_salad/metaschema.py:463:18: W605 invalid escape sequence '\]'
schema_salad/metaschema.py:463:23: W605 invalid escape sequence '\?'
schema_salad/python_codegen_support.py:266:16: W605 invalid escape sequence '\['
schema_salad/python_codegen_support.py:266:18: W605 invalid escape sequence '\]'
schema_salad/python_codegen_support.py:266:23: W605 invalid escape sequence '\?'
schema_salad/validate.py:223:19: W504 line break after binary operator
schema_salad/ref_resolver.py:216:25: W504 line break after binary operator
schema_salad/ref_resolver.py:368:17: W504 line break after binary operator
schema_salad/ref_resolver.py:370:17: W504 line break after binary operator
schema_salad/ref_resolver.py:656:16: W605 invalid escape sequence '\['
schema_salad/ref_resolver.py:656:18: W605 invalid escape sequence '\]'
schema_salad/ref_resolver.py:656:23: W605 invalid escape sequence '\?'
schema_salad/makedoc.py:225:21: W504 line break after binary operator
schema_salad/makedoc.py:226:22: W504 line break after binary operator
```