### PR TITLE
Use the temporary fork of `future`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 typing==3.6.4 ; python_version < "3.7"
 avro-cwl==1.8.4 ; python_version >= "3"
-future ; python_version >= "3"
+future-nodefix ; python_version >= "3"
 avro==1.8.1 ; python_version < "3"
 ruamel.yaml>=0.12.4, <= 0.15.77
 rdflib==4.2.2

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = [
 extras_require={
     ':python_version<"3"': ['avro == 1.8.1'],
     ':python_version<"3.7"': ['typing >= 3.6.4'],
-    ':python_version>="3"': ['future', 'avro-cwl == 1.8.4']  # fork of avro for working with python3
+    ':python_version>="3"': ['future-nodefix', 'avro-cwl == 1.8.4']  # fork of avro for working with python3
 }
 
 setup(name='schema-salad',


### PR DESCRIPTION
https://github.com/drjrm3/python-future-nodefix/tree/11686ab4956adb3045c35c07755ec2a0fd384fba#explanation

This PR should be reversed when https://github.com/PythonCharmers/python-future/pull/335 (or similar) is merged and a new release of `future` is made; the reversal should include a `>=` on that new version.