### PR TITLE
typing_extensions are part of Python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ rdflib-jsonld==0.4.0
 mistune>=0.8.1,<0.9
 CacheControl==0.11.7
 lockfile==0.12.2
-typing-extensions

--- a/schema_salad/codegen.py
+++ b/schema_salad/codegen.py
@@ -2,7 +2,7 @@
 import sys
 from typing import Any, Dict, List, MutableMapping, Optional, Union
 
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 from . import schema

--- a/schema_salad/codegen_base.py
+++ b/schema_salad/codegen_base.py
@@ -2,7 +2,7 @@
 import collections
 from typing import (Any, Dict, List, MutableSequence, Optional, Union)
 
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 from . import schema

--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -4,7 +4,7 @@ from typing import MutableSequence
 
 from six import string_types
 from six.moves import cStringIO, urllib
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 from . import schema

--- a/schema_salad/jsonld_context.py
+++ b/schema_salad/jsonld_context.py
@@ -11,7 +11,7 @@ from rdflib import Graph, URIRef
 from rdflib.namespace import RDF, RDFS
 import six
 from six.moves import urllib
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 from .ref_resolver import ContextType  # pylint: disable=unused-import

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -16,7 +16,7 @@ from rdflib.plugin import register
 from ruamel.yaml.comments import CommentedMap
 import six
 from six.moves import urllib
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 from . import codegen, jsonld_context, schema, validate

--- a/schema_salad/makedoc.py
+++ b/schema_salad/makedoc.py
@@ -16,7 +16,7 @@ import mistune
 import six
 from six import StringIO
 from six.moves import range, urllib
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 from . import schema

--- a/schema_salad/metaschema.py
+++ b/schema_salad/metaschema.py
@@ -12,7 +12,7 @@ from typing import (Any, AnyStr, Callable, Dict, List, MutableMapping,
 import ruamel.yaml
 import six
 from ruamel.yaml.comments import CommentedBase, CommentedMap, CommentedSeq
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 
@@ -202,7 +202,7 @@ from typing import (Any, Dict, List, MutableMapping, MutableSequence, Sequence,
 from ruamel import yaml
 from six import iteritems, string_types, text_type
 from six.moves import StringIO, urllib
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -4,7 +4,7 @@ from typing import IO, Any, Dict, List, MutableMapping, MutableSequence, Union
 from pkg_resources import resource_stream
 from six import itervalues, iteritems
 from six.moves import cStringIO
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 from . import schema

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -7,7 +7,7 @@ from typing import (Any, Dict, List, MutableMapping, MutableSequence, Sequence,
 from ruamel import yaml
 from six import iteritems, string_types, text_type
 from six.moves import StringIO, urllib
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -21,7 +21,7 @@ from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from six import StringIO, string_types, iteritems
 from six.moves import range, urllib
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 
 from . import validate
 from .sourceline import SourceLine, add_lc_filename, relname, strip_dup_lineno

--- a/schema_salad/schema.py
+++ b/schema_salad/schema.py
@@ -11,7 +11,7 @@ from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from six import iteritems, string_types
 from six.moves import urllib
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 
 from schema_salad.utils import (add_dictlist, aslist, convert_to_dict, flatten,
                                 json_dumps)

--- a/schema_salad/sourceline.py
+++ b/schema_salad/sourceline.py
@@ -9,7 +9,7 @@ from typing import (Any, AnyStr, Callable, Dict, List, MutableMapping,
 import ruamel.yaml
 import six
 from ruamel.yaml.comments import CommentedBase, CommentedMap, CommentedSeq
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 

--- a/schema_salad/utils.py
+++ b/schema_salad/utils.py
@@ -5,7 +5,7 @@ import os
 from typing import IO, Any, AnyStr, Dict, List, Mapping, MutableSequence, Union
 
 import six
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 

--- a/schema_salad/validate.py
+++ b/schema_salad/validate.py
@@ -10,7 +10,7 @@ import six
 from .avro.schema import \
     Schema  # pylint: disable=unused-import, no-name-in-module, import-error
 from six.moves import range, urllib
-from typing_extensions import Text  # pylint: disable=unused-import
+from typing import Text  # pylint: disable=unused-import
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 from .sourceline import SourceLine, bullets, indent, strip_dup_lineno

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ install_requires = [
     'CacheControl >= 0.11.7, < 0.12',
     'lockfile >= 0.9',
     'six >= 1.8.0',
-    'typing-extensions']
+    # 'typing-extensions'
+    ]
 
 extras_require={
     ':python_version<"3.7"': ['typing >= 3.6.4'],


### PR DESCRIPTION
typing_extensions no longer work with 3.7 - at least in my build tree. Maybe merge later.