### PR TITLE
Mini-DSL for optional secondary files.

### DIFF
--- a/schema_salad/metaschema/metaschema.yml
+++ b/schema_salad/metaschema/metaschema.yml
@@ -131,6 +131,10 @@ $graph:
       type: boolean?
       doc: |
         Field must be expanded based on the the Schema Salad type DSL.
+    - name: secondaryFilesDSL
+      type: boolean?
+      doc: |
+        Field must be expanded based on the the Schema Salad secondary file DSL.
     - name: subscope
       type: string?
       doc: |

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -18,7 +18,7 @@ from rdflib.graph import Graph
 from rdflib.namespace import OWL, RDF, RDFS
 from rdflib.plugins.parsers.notation3 import BadSyntax
 from ruamel import yaml
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
+from ruamel.yaml.comments import CommentedMap, CommentedSeq, LineCol
 from six import StringIO, string_types, iteritems
 from six.moves import range, urllib
 from typing_extensions import Text  # pylint: disable=unused-import
@@ -327,6 +327,7 @@ class Loader(object):
         self.mapPredicate = {}          # type: Dict[Text, Text]
         self.type_dsl_fields = set()    # type: Set[Text]
         self.subscopes = {}             # type: Dict[Text, Text]
+        self.secondaryFile_dsl_fields = set()  # type: Set[Text]
 
         self.add_context(ctx)
 
@@ -685,8 +686,9 @@ class Loader(object):
 
     def _type_dsl(self,
                   t,        # type: Union[Text, Dict, List]
-                  lc,
-                  filename):
+                  lc,       # type: LineCol
+                  filename  # type: Text
+    ):
         # type: (...) -> Union[Text, Dict[Text, Text], List[Union[Text, Dict[Text, Text]]]]
 
         if not isinstance(t, string_types):
@@ -731,7 +733,14 @@ class Loader(object):
         second.lc.filename = filename
         return second
 
-    def _apply_dsl(self, datum, d, loader, lc, filename):
+    def _apply_dsl(self,
+                   datum,      # type: Union[Text, Dict[Any, Any], List[Any]]
+                   d,          # type: Text
+                   loader,     # type: Loader
+                   lc,         # type: LineCol
+                   filename    # type: Text
+    ):
+        # type: (...) -> Union[Text, Dict[Any, Any], List[Any]]
         if d in loader.type_dsl_fields:
             return self._type_dsl(datum, lc, filename)
         elif d in loader.secondaryFile_dsl_fields:

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -457,37 +457,42 @@ class Loader(object):
             if value == u"@id":
                 self.identifiers.append(key)
                 self.identity_links.add(key)
-            elif isinstance(value, MutableMapping) and value.get(u"@type") == u"@id":
-                self.url_fields.add(key)
-                if u"refScope" in value:
-                    self.scoped_ref_fields[key] = value[u"refScope"]
-                if value.get(u"identity", False):
-                    self.identity_links.add(key)
-            elif isinstance(value, MutableMapping) and value.get(u"@type") == u"@vocab":
-                self.url_fields.add(key)
-                self.vocab_fields.add(key)
-                if u"refScope" in value:
-                    self.scoped_ref_fields[key] = value[u"refScope"]
-                if value.get(u"typeDSL"):
-                    self.type_dsl_fields.add(key)
-            if value.get(u"secondaryFileDSL"):
-                self.secondaryFile_dsl_fields.add(key)
-            if isinstance(value, MutableMapping) and value.get(u"noLinkCheck"):
-                self.nolinkcheck.add(key)
+            elif isinstance(value, MutableMapping):
+                if value.get(u"@type") == u"@id":
+                    self.url_fields.add(key)
+                    if u"refScope" in value:
+                        self.scoped_ref_fields[key] = value[u"refScope"]
+                    if value.get(u"identity", False):
+                        self.identity_links.add(key)
 
-            if isinstance(value, MutableMapping) and value.get(u"mapSubject"):
-                self.idmap[key] = value[u"mapSubject"]
+                if value.get(u"@type") == u"@vocab":
+                    self.url_fields.add(key)
+                    self.vocab_fields.add(key)
+                    if u"refScope" in value:
+                        self.scoped_ref_fields[key] = value[u"refScope"]
+                    if value.get(u"typeDSL"):
+                        self.type_dsl_fields.add(key)
 
-            if isinstance(value, MutableMapping) and value.get(u"mapPredicate"):
-                self.mapPredicate[key] = value[u"mapPredicate"]
+                if value.get(u"secondaryFileDSL"):
+                    self.secondaryFile_dsl_fields.add(key)
 
-            if isinstance(value, MutableMapping) and u"@id" in value:
-                self.vocab[key] = value[u"@id"]
+                if value.get(u"noLinkCheck"):
+                    self.nolinkcheck.add(key)
+
+                if value.get(u"mapSubject"):
+                    self.idmap[key] = value[u"mapSubject"]
+
+                if value.get(u"mapPredicate"):
+                    self.mapPredicate[key] = value[u"mapPredicate"]
+
+                if value.get(u"@id"):
+                    self.vocab[key] = value[u"@id"]
+
+                if value.get(u"subscope"):
+                    self.subscopes[key] = value[u"subscope"]
+
             elif isinstance(value, string_types):
                 self.vocab[key] = value
-
-            if isinstance(value, MutableMapping) and value.get(u"subscope"):
-                self.subscopes[key] = value[u"subscope"]
 
         for k, v in self.vocab.items():
             self.rvocab[self.expand_url(v, u"", scoped_id=False)] = k

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -473,7 +473,7 @@ class Loader(object):
                     if value.get(u"typeDSL"):
                         self.type_dsl_fields.add(key)
 
-                if value.get(u"secondaryFileDSL"):
+                if value.get(u"secondaryFilesDSL"):
                     self.secondaryFile_dsl_fields.add(key)
 
                 if value.get(u"noLinkCheck"):
@@ -740,9 +740,9 @@ class Loader(object):
             return datum
 
     def _resolve_dsl(self,
-                          document,  # type: CommentedMap
-                          loader     # type: Loader
-                          ):
+                     document,  # type: CommentedMap
+                     loader     # type: Loader
+    ):
         # type: (...) -> None
         fields = list(loader.type_dsl_fields)
         fields.extend(loader.secondaryFile_dsl_fields)

--- a/schema_salad/tests/metaschema-pre.yml
+++ b/schema_salad/tests/metaschema-pre.yml
@@ -363,6 +363,14 @@
                 "doc": "Field must be expanded based on the the Schema Salad type DSL.\n"
             },
             {
+                    "doc": "Field must be expanded based on the the Schema Salad secondary file DSL.\n",
+                    "name": "https://w3id.org/cwl/salad#JsonldPredicate/secondaryFilesDSL",
+                    "type": [
+                      "null",
+                      "boolean"
+                    ]
+            },
+            {
                 "name": "https://w3id.org/cwl/salad#JsonldPredicate/subscope",
                 "type": [
                     "null",

--- a/schema_salad/tests/test_examples.py
+++ b/schema_salad/tests/test_examples.py
@@ -265,6 +265,27 @@ class TestSchemas(unittest.TestCase):
         self.assertEqual(
             {'type': ['null', {'items': 'File', 'type': 'array'}]}, ra)
 
+    def test_secondaryFile_dsl_ref(self):
+        ldr = schema_salad.ref_resolver.Loader({})
+        ldr.add_context({
+            "secondaryFiles": {
+                "secondaryFileDSL": True
+            }
+        })
+
+        ra, _ = ldr.resolve_all(cmap({"secondaryFiles": ".foo"}), "")
+        self.assertEqual({"secondaryFiles": {'pattern': '.foo', 'required': None}}, ra)
+
+        ra, _ = ldr.resolve_all(cmap({"secondaryFiles": ".foo?"}), "")
+        self.assertEqual({"secondaryFiles": {'pattern': '.foo', 'required': False}}, ra)
+
+        ra, _ = ldr.resolve_all(cmap({"secondaryFiles": [".foo"]}), "")
+        self.assertEqual({"secondaryFiles": [{'pattern': '.foo', 'required': None}]}, ra)
+
+        ra, _ = ldr.resolve_all(cmap({"secondaryFiles": [".foo?"]}), "")
+        self.assertEqual({"secondaryFiles": [{'pattern': '.foo', 'required': False}]}, ra)
+
+
     def test_scoped_id(self):
         ldr = schema_salad.ref_resolver.Loader({})
         ctx = {

--- a/schema_salad/tests/test_examples.py
+++ b/schema_salad/tests/test_examples.py
@@ -269,7 +269,7 @@ class TestSchemas(unittest.TestCase):
         ldr = schema_salad.ref_resolver.Loader({})
         ldr.add_context({
             "secondaryFiles": {
-                "secondaryFileDSL": True
+                "secondaryFilesDSL": True
             }
         })
 


### PR DESCRIPTION
Add `secondaryFilesDSL` which behaves similarly to `typeDSL` in expanding a compact string into an object.