### PR TITLE
Use copy.copy(CommentedMap) instead of CommentedMap.copy()

### DIFF
--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -581,7 +581,7 @@ class Loader(object):
                         metadata = _copy_dict_without_key(resolved_obj, u"$graph")
                         return resolved_obj[u"$graph"], metadata
                     else:
-                        return resolved_obj, metadata.copy()
+                        return resolved_obj, copy.copy(metadata)
                 else:
                     raise ValueError(u"Expected CommentedMap, got %s: `%s`"
                                      % (type(metadata), Text(metadata)))
@@ -643,9 +643,9 @@ class Loader(object):
                 metadata = _copy_dict_without_key(resolved_obj, u"$graph")
                 return resolved_obj[u"$graph"], metadata
             else:
-                return resolved_obj, metadata.copy()
+                return resolved_obj, copy.copy(metadata)
         else:
-            return resolved_obj, metadata.copy()
+            return resolved_obj, copy.copy(metadata)
 
     def _resolve_idmap(self,
                        document,    # type: CommentedMap
@@ -999,7 +999,7 @@ class Loader(object):
             loader.validate_links(document, u"", all_doc_ids,
                                   strict_foreign_properties=strict_foreign_properties)
 
-        return document, metadata.copy()
+        return document, copy.copy(metadata)
 
     def fetch(self, url, inject_ids=True):  # type: (Text, bool) -> Any
         if url in self.idx:


### PR DESCRIPTION
Because CommentedMap.copy() returns a dict!  Argh!