### PR TITLE
Copying metadata to be backwards compatible was a mistake.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ COVBASE=coverage run --branch --append --source=${MODULE} \
 
 # Updating the Major & Minor version below?
 # Don't forget to update setup.py as well
-VERSION=3.2.$(shell date +%Y%m%d%H%M%S --utc --date=`git log --first-parent \
+VERSION=4.0.$(shell date +%Y%m%d%H%M%S --utc --date=`git log --first-parent \
 	--max-count=1 --format=format:%cI`)
 
 ## all         : default task

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -581,7 +581,7 @@ class Loader(object):
                         metadata = _copy_dict_without_key(resolved_obj, u"$graph")
                         return resolved_obj[u"$graph"], metadata
                     else:
-                        return resolved_obj, copy.copy(metadata)
+                        return resolved_obj, metadata
                 else:
                     raise ValueError(u"Expected CommentedMap, got %s: `%s`"
                                      % (type(metadata), Text(metadata)))
@@ -643,9 +643,9 @@ class Loader(object):
                 metadata = _copy_dict_without_key(resolved_obj, u"$graph")
                 return resolved_obj[u"$graph"], metadata
             else:
-                return resolved_obj, copy.copy(metadata)
+                return resolved_obj, metadata
         else:
-            return resolved_obj, copy.copy(metadata)
+            return resolved_obj, metadata
 
     def _resolve_idmap(self,
                        document,    # type: CommentedMap
@@ -999,7 +999,7 @@ class Loader(object):
             loader.validate_links(document, u"", all_doc_ids,
                                   strict_foreign_properties=strict_foreign_properties)
 
-        return document, copy.copy(metadata)
+        return document, metadata
 
     def fetch(self, url, inject_ids=True):  # type: (Text, bool) -> Any
         if url in self.idx:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ extras_require={
 }
 
 setup(name='schema-salad',
-      version='3.2',  # update the VERSION prefix in the Makefile as well 🙂
+      version='4.0',  # update the VERSION prefix in the Makefile as well 🙂
       description='Schema Annotations for Linked Avro Data (SALAD)',
       long_description=open(README).read(),
       author='Common workflow language working group',


### PR DESCRIPTION
Turns out copy.copy() on a CommentedMap doesn't do the same thing across 2.7 and 3+

Also I realized because resolve_all()/resolve_ref() are called recursively it would tend to inefficiently make a lot of unnecessary copies.