### PR TITLE
Add tests for ValidationException

### DIFF
--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -78,7 +78,7 @@ class TestErrors(unittest.TestCase):
 ^.+test3\.cwl:5:1: checking field `outputs`
 ^.+test3\.cwl:6:3:   checking object\s+`.+test3\.cwl#bar`
 \s+Field `type` references\s+unknown identifier\s+`xstring`,\s+tried
-\s+file://.+/tests/test_schema/test3\.cwl#xstring$'''[1:],
+\s+file://.+/test_schema/test3\.cwl#xstring$'''[1:],
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')
 

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -113,6 +113,23 @@ class TestErrors(unittest.TestCase):
 .+test5\.cwl:7:9:         item is\s+invalid because
 \s+is not a\s+dict$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')
 
+    def test_error_message6(self):
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        t = "test_schema/test6.cwl"
+        with self.assertRaises(ValidationException) as e:
+            load_and_validate(document_loader, avsc_names,
+                              six.text_type(get_data("tests/"+t)), True)
+        self.assertTrue(re.match(r'''
+^.+test6\.cwl:2:1: Object `.+test6\.cwl` is not valid because
+\s+- tried `CommandLineTool` but
+\s+Missing 'class' field
+\s+- tried `ExpressionTool` but
+\s+Missing 'class' field
+\s+- tried `Workflow` but
+\s+Missing 'class' field$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')
+
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -92,8 +92,8 @@ class TestErrors(unittest.TestCase):
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
 ^.+test4\.cwl:5:1: checking field `outputs`
-.+test4\.cwl:6:3:   checking object `.+test4\.cwl#bar`
-\s+`type` field is int, expected string, list, or a dict.$'''[1:],
+.+test4\.cwl:6:3:   checking object\s+`.+test4\.cwl#bar`
+\s+`type` field is int,\s+expected string, list, or a\s+dict.$'''[1:],
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')
 

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -61,9 +61,10 @@ class TestErrors(unittest.TestCase):
             load_and_validate(document_loader, avsc_names,
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
-^.+test2\.cwl:2:1: Field `class` contains undefined reference to
-\s+`file://.+/xWorkflow`$'''[1:],
-                                 str(e.exception)), str(e.exception)+ ' is not matched.')
+^.+test2\.cwl:2:1: Field `class` contains\s+undefined reference to
+\s+`file://.+/schema-salad/schema_salad/tests/test_schema/xWorkflow`$'''[1:],
+                                 str(e.exception)),
+                        str(e.exception) + ' is not matched.')
 
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -76,7 +76,7 @@ class TestErrors(unittest.TestCase):
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
 ^.+test3\.cwl:5:1: checking field `outputs`
-^.+test3\.cwl:6:3:   checking object\s+`.+test3\.cwl#bar`
+.+test3\.cwl:6:3:   checking object\s+`.+test3\.cwl#bar`
 \s+Field `type` references\s+unknown identifier\s+`xstring`,\s+tried
 \s+file://.+/test_schema/test3\.cwl#xstring$'''[1:],
                                  str(e.exception)),

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -178,6 +178,21 @@ class TestErrors(unittest.TestCase):
 \s+value\s+is a\s+CommentedSeq,\s+expected\s+null\s+or\s+ScatterMethod$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')
 
+    def test_error_message11(self):
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        t = "test_schema/test11.cwl"
+        with self.assertRaises(ValidationException) as e:
+            load_and_validate(document_loader, avsc_names,
+                              six.text_type(get_data("tests/"+t)), True)
+        self.assertTrue(re.match(r'''
+^.+test11\.cwl:7:1: checking field `steps`
+.+test11\.cwl:8:3:   checking object\s+`.+test11\.cwl#step1`
+.+test11\.cwl:9:5:     Field `run` contains undefined reference to
+\s+`file://.+/tests/test_schema/blub\.cwl`$'''[1:],
+                                 str(e.exception)), str(e.exception) + ' is not matched.')
+
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -77,7 +77,7 @@ class TestErrors(unittest.TestCase):
         self.assertTrue(re.match(r'''
 ^.+test3\.cwl:5:1: checking field `outputs`
 .+test3\.cwl:6:3:   checking object\s+`.+test3\.cwl#bar`
-\s+Field `type` references\s+unknown identifier\s+`xstring`,\s+tried
+\s+Field `type`\s+references\s+unknown\s+identifier\s+`xstring`,\s+tried
 \s+file://.+/test_schema/test3\.cwl#xstring$'''[1:],
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -52,6 +52,19 @@ class TestErrors(unittest.TestCase):
 \s+\* missing\s+required\s+field\s+`steps`$'''[1:],
                                  str(e.exception)))
 
+    def test_error_message2(self):
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        t = "test_schema/test2.cwl"
+        with self.assertRaises(ValidationException) as e:
+            load_and_validate(document_loader, avsc_names,
+                              six.text_type(get_data("tests/"+t)), True)
+        self.assertTrue(re.match(r'''
+^.+test2\.cwl:2:1: Field `class` contains undefined reference to
+\s+`file://.+/xWorkflow`$'''[1:],
+                                 str(e.exception)))
+
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -75,7 +75,7 @@ class TestErrors(unittest.TestCase):
             load_and_validate(document_loader, avsc_names,
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
-^.+test3\.cwl:5:1: checking field `outputs`
+^.+test3\.cwl:5:1: checking field\s+`outputs`
 .+test3\.cwl:6:3:   checking object\s+`.+test3\.cwl#bar`
 \s+Field `type`\s+references\s+unknown\s+identifier\s+`xstring`,\s+tried
 \s+file://.+/test_schema/test3\.cwl#xstring$'''[1:],

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -93,7 +93,7 @@ class TestErrors(unittest.TestCase):
         self.assertTrue(re.match(r'''
 ^.+test4\.cwl:5:1: checking field `outputs`
 .+test4\.cwl:6:3:   checking object\s+`.+test4\.cwl#bar`
-\s+`type` field is int,\s+expected string, list, or a\s+dict.$'''[1:],
+\s+`type` field is int,\s+expected string, list, or\s+a\s+dict.$'''[1:],
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')
 

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -122,14 +122,13 @@ class TestErrors(unittest.TestCase):
             load_and_validate(document_loader, avsc_names,
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
-^.+test7\.cwl:2:1: Object `.+test7\.cwl` is\s+not valid because
+^.+test7\.cwl:2:1: Object\s+`.+test7\.cwl`\s+is\s+not valid because
 \s+tried `Workflow` but
-.+test7\.cwl:7:1:     the `steps` field is not valid because
-\s+tried array of <WorkflowStep> but
-.+test7\.cwl:8:3:         item is invalid because
-\s+\* missing required field `run`
-.+test7\.cwl:9:5:           \* invalid field `scatter_method`,\s+expected one of:\s+'id', 'in', 'out',\s+'requirements', 'hints', 'label', 'doc',
-\s+'run', 'scatter', 'scatterMethod'$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')
+.+test7\.cwl:7:1:     the `steps` field\s+is\s+not valid because
+\s+tried array of\s+<WorkflowStep> but
+.+test7\.cwl:8:3:         item is\s+invalid because
+\s+\* missing\s+required\s+field `run`
+.+test7\.cwl:9:5:           \* invalid\s+field\s+`scatter_method`,\s+expected one of:\s+'id', 'in', 'out',\s+'requirements',\s+'hints', 'label',\s+'doc',\s+'run',\s+'scatter',\s+'scatterMethod'$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')
 
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -141,7 +141,7 @@ class TestErrors(unittest.TestCase):
         self.assertTrue(re.match(r'''
 ^.+test8\.cwl:7:1: checking field `steps`
 .+test8\.cwl:8:3:   checking object\s+`.+test8\.cwl#step1`
-.+test8\.cwl:9:5:     Field `scatterMethod` contains undefined\s+reference to
+.+test8\.cwl:9:5:     Field\s+`scatterMethod`\s+contains\s+undefined\s+reference to
 \s+`file:///.+/tests/test_schema/abc`$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')
 

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -156,7 +156,7 @@ class TestErrors(unittest.TestCase):
         self.assertTrue(re.match(r'''
 ^.+test9\.cwl:7:1: checking field `steps`
 .+test9\.cwl:8:3:   checking object\s+`.+test9\.cwl#step1`
-.+test9\.cwl:9:5:     `scatterMethod` field is int, expected\s+string, list, or a dict.$'''[1:],
+.+test9\.cwl:9:5:     `scatterMethod`\s+field\s+is int,\s+expected\s+string,\s+list, or a dict.$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')
 
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -66,6 +66,22 @@ class TestErrors(unittest.TestCase):
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')
 
+    def test_error_message3(self):
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        t = "test_schema/test3.cwl"
+        with self.assertRaises(ValidationException) as e:
+            load_and_validate(document_loader, avsc_names,
+                              six.text_type(get_data("tests/"+t)), True)
+        self.assertTrue(re.match(r'''
+^.+test3\.cwl:5:1: checking field `outputs`
+^.+test3\.cwl:6:3:   checking object `test_schema/test3.cwl#bar`
+\s+Field `type` references unknown identifier `xstring`, tried
+\s+file://.+/schema_salad/tests/test_schema/test3.cwl#xstring$'''[1:],
+                                 str(e.exception)),
+                        str(e.exception) + ' is not matched.')
+
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -187,7 +187,7 @@ class TestErrors(unittest.TestCase):
             load_and_validate(document_loader, avsc_names,
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
-^.+test11\.cwl:7:1: checking field `steps`
+^.+test11\.cwl:7:1: checking field\s+`steps`
 .+test11\.cwl:8:3:   checking object\s+`.+test11\.cwl#step1`
 .+test11\.cwl:9:5:     Field `run`\s+contains\s+undefined\s+reference to
 \s+`file://.+/tests/test_schema/blub\.cwl`$'''[1:],

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -130,6 +130,21 @@ class TestErrors(unittest.TestCase):
 \s+\* missing\s+required\s+field `run`
 .+test7\.cwl:9:5:           \* invalid\s+field\s+`scatter_method`,\s+expected one of:\s+'id', 'in', 'out',\s+'requirements',\s+'hints', 'label',\s+'doc',\s+'run',\s+'scatter',\s+'scatterMethod'$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')
 
+    def test_error_message8(self):
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        t = "test_schema/test8.cwl"
+        with self.assertRaises(ValidationException) as e:
+            load_and_validate(document_loader, avsc_names,
+                              six.text_type(get_data("tests/"+t)), True)
+        self.assertTrue(re.match(r'''
+^.+test8\.cwl:7:1: checking field `steps`
+.+test8\.cwl:8:3:   checking object\s+`.+test8\.cwl#step1`
+.+test8\.cwl:9:5:     Field `scatterMethod` contains undefined\s+reference to
+\s+`file:///.+/tests/test_schema/abc`$'''[1:],
+                                 str(e.exception)), str(e.exception) + ' is not matched.')
+
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -78,7 +78,7 @@ class TestErrors(unittest.TestCase):
 ^.+test3\.cwl:5:1: checking field\s+`outputs`
 .+test3\.cwl:6:3:   checking object\s+`.+test3\.cwl#bar`
 \s+Field `type`\s+references\s+unknown\s+identifier\s+`xstring`,\s+tried
-\s+file://.+/schema_salad/tests/test_schema/test3\.cwl#xstring$'''[1:],
+\s+file://.+/tests/test_schema/test3\.cwl#xstring$'''[1:],
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')
 

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -189,7 +189,7 @@ class TestErrors(unittest.TestCase):
         self.assertTrue(re.match(r'''
 ^.+test11\.cwl:7:1: checking field `steps`
 .+test11\.cwl:8:3:   checking object\s+`.+test11\.cwl#step1`
-.+test11\.cwl:9:5:     Field `run` contains undefined reference to
+.+test11\.cwl:9:5:     Field `run`\s+contains\s+undefined\s+reference to
 \s+`file://.+/tests/test_schema/blub\.cwl`$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')
 

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -202,14 +202,14 @@ class TestErrors(unittest.TestCase):
             load_and_validate(document_loader, avsc_names,
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
-^.+test15\.cwl:3:1:\s+Object `.+test15\.cwl`\s+is not valid because
-\s+tried `CommandLineTool` but
-.+test15\.cwl:6:1:\s+the `inputs` field is not valid because
-.+test15\.cwl:7:3:\s+item is invalid because
-.+test15\.cwl:9:5:\s+the `inputBinding` field is not\s+valid because
-.+tried CommandLineBinding but
-.+test15\.cwl:11:7:             \* invalid field\s+`invalid_field`, expected one\s+of:\s+'loadContents', 'position', 'prefix',\s+'separate',\s+'itemSeparator',\s+'valueFrom', 'shellQuote'
-.+test15\.cwl:12:7:             \* invalid field\s+`another_invalid_field`,\s+expected one\s+of: 'loadContents', 'position',\s+'prefix',\s+'separate', 'itemSeparator',\s+'valueFrom', 'shellQuote'$'''[1:],
+^.+test15\.cwl:3:1:\s+Object\s+`.+test15\.cwl`\s+is not valid because
+\s+tried `CommandLineTool`\s+but
+.+test15\.cwl:6:1:\s+the `inputs` field\s+is not valid because
+.+test15\.cwl:7:3:\s+item is\s+invalid\s+because
+.+test15\.cwl:9:5:\s+the\s+`inputBinding`\s+field is not\s+valid\s+because
+.+tried\s+CommandLineBinding but
+.+test15\.cwl:11:7:             \*\s+invalid field\s+`invalid_field`, expected one\s+of:\s+'loadContents',\s+'position',\s+'prefix',\s+'separate',\s+'itemSeparator',\s+'valueFrom',\s+'shellQuote'
+.+test15\.cwl:12:7:             \*\s+invalid field\s+`another_invalid_field`,\s+expected one\s+of:\s+'loadContents',\s+'position',\s+'prefix',\s+'separate',\s+'itemSeparator',\s+'valueFrom',\s+'shellQuote'$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')
 
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -106,13 +106,12 @@ class TestErrors(unittest.TestCase):
             load_and_validate(document_loader, avsc_names,
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
-^.+test5\.cwl:2:1: Object `.+test5\.cwl` is\s+not valid because
+^.+test5\.cwl:2:1: Object\s+`.+test5\.cwl`\s+is\s+not valid because
 \s+tried `Workflow` but
-.+test5\.cwl:7:1:     the `steps` field is not valid because
-\s+tried array of <WorkflowStep> but
-.+test5\.cwl:7:9:         item is invalid because
-\s+is not a dict$'''[1:],
-                                 str(e.exception)),
+.+test5\.cwl:7:1:     the `steps` field is\s+not valid because
+\s+tried array of\s+<WorkflowStep> but
+.+test5\.cwl:7:9:         item is\s+invalid because
+\s+is not a dict$'''[1:], str(e.exception)),
                         str(e.exception) + ' is not matched.')
 
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -122,8 +122,8 @@ class TestErrors(unittest.TestCase):
             load_and_validate(document_loader, avsc_names,
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
-^.+test6\.cwl:2:1: Object `.+test6\.cwl` is not valid because
-\s+- tried `CommandLineTool` but
+^.+test6\.cwl:2:1: Object `.+test6\.cwl`\s+is\s+not valid because
+\s+- tried `CommandLineTool`\s+but
 \s+Missing 'class' field
 \s+- tried `ExpressionTool` but
 \s+Missing 'class' field

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -113,23 +113,6 @@ class TestErrors(unittest.TestCase):
 .+test5\.cwl:7:9:         item is\s+invalid because
 \s+is not a\s+dict$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')
 
-    def test_error_message6(self):
-        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
-            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
-
-        t = "test_schema/test6.cwl"
-        with self.assertRaises(ValidationException) as e:
-            load_and_validate(document_loader, avsc_names,
-                              six.text_type(get_data("tests/"+t)), True)
-        self.assertTrue(re.match(r'''
-^.+test6\.cwl:2:1: Object `.+test6\.cwl`\s+is\s+not valid because
-\s+- tried `CommandLineTool`\s+but
-\s+Missing 'class' field
-\s+- tried `ExpressionTool` but
-\s+Missing 'class' field
-\s+- tried `Workflow` but
-\s+Missing 'class' field$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')
-
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -139,7 +139,7 @@ class TestErrors(unittest.TestCase):
             load_and_validate(document_loader, avsc_names,
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
-^.+test8\.cwl:7:1: checking field `steps`
+^.+test8\.cwl:7:1: checking field\s+`steps`
 .+test8\.cwl:8:3:   checking object\s+`.+test8\.cwl#step1`
 .+test8\.cwl:9:5:     Field\s+`scatterMethod`\s+contains\s+undefined\s+reference to
 \s+`file:///.+/tests/test_schema/abc`$'''[1:],

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -76,9 +76,9 @@ class TestErrors(unittest.TestCase):
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
 ^.+test3\.cwl:5:1: checking field `outputs`
-^.+test3\.cwl:6:3:   checking object `test_schema/test3.cwl#bar`
-\s+Field `type` references unknown identifier `xstring`, tried
-\s+file://.+/schema_salad/tests/test_schema/test3.cwl#xstring$'''[1:],
+^.+test3\.cwl:6:3:   checking object\s+`.+test3\.cwl#bar`
+\s+Field `type` references\s+unknown identifier\s+`xstring`,\s+tried
+\s+file://.+/tests/test_schema/test3\.cwl#xstring$'''[1:],
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')
 

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -113,6 +113,24 @@ class TestErrors(unittest.TestCase):
 .+test5\.cwl:7:9:         item is\s+invalid because
 \s+is not a\s+dict$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')
 
+    def test_error_message7(self):
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        t = "test_schema/test7.cwl"
+        with self.assertRaises(ValidationException) as e:
+            load_and_validate(document_loader, avsc_names,
+                              six.text_type(get_data("tests/"+t)), True)
+        self.assertTrue(re.match(r'''
+^.+test7\.cwl:2:1: Object `.+test7\.cwl` is\s+not valid because
+\s+tried `Workflow` but
+.+test7\.cwl:7:1:     the `steps` field is not valid because
+\s+tried array of <WorkflowStep> but
+.+test7\.cwl:8:3:         item is invalid because
+\s+\* missing required field `run`
+.+test7\.cwl:9:5:           \* invalid field `scatter_method`,\s+expected one of:\s+'id', 'in', 'out',\s+'requirements', 'hints', 'label', 'doc',
+\s+'run', 'scatter', 'scatterMethod'$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')
+
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -193,6 +193,27 @@ class TestErrors(unittest.TestCase):
 \s+`file://.+/tests/test_schema/blub\.cwl`$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')
 
+    def test_error_message15(self):
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        t = "test_schema/test15.cwl"
+        with self.assertRaises(ValidationException) as e:
+            load_and_validate(document_loader, avsc_names,
+                              six.text_type(get_data("tests/"+t)), True)
+        self.assertTrue(re.match(r'''
+^.+test15\.cwl:3:1:  Object `.+test15\.cwl`\s+is not valid because
+\s+tried `CommandLineTool` but
+.+test15\.cwl:6:1:      the `inputs` field is not valid because
+.+test15\.cwl:7:3:        item is invalid because
+.+test15\.cwl:9:5:          the `inputBinding` field is not\s+valid because
+.+tried CommandLineBinding but
+.+test15\.cwl:11:7:             \* invalid field\s+`invalid_field`, expected one\s+of:
+\s+'loadContents', 'position', 'prefix',\s+'separate',\s+'itemSeparator',\s+'valueFrom', 'shellQuote'
+.+test15\.cwl:12:7:             \* invalid field\s+`another_invalid_field`,\s+expected one
+\s+of: 'loadContents', 'position',\s+'prefix',\s+'separate', 'itemSeparator',\s+'valueFrom', 'shellQuote'$'''[1:],
+                                 str(e.exception)), str(e.exception) + ' is not matched.')
+
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -108,7 +108,7 @@ class TestErrors(unittest.TestCase):
         self.assertTrue(re.match(r'''
 ^.+test5\.cwl:2:1: Object\s+`.+test5\.cwl`\s+is\s+not valid because
 \s+tried `Workflow` but
-.+test5\.cwl:7:1:     the `steps` field is\s+not valid because
+.+test5\.cwl:7:1:     the `steps` field\s+is\s+not valid because
 \s+tried array of\s+<WorkflowStep> but
 .+test5\.cwl:7:9:         item is\s+invalid because
 \s+is not a dict$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -111,8 +111,7 @@ class TestErrors(unittest.TestCase):
 .+test5\.cwl:7:1:     the `steps` field is\s+not valid because
 \s+tried array of\s+<WorkflowStep> but
 .+test5\.cwl:7:9:         item is\s+invalid because
-\s+is not a dict$'''[1:], str(e.exception)),
-                        str(e.exception) + ' is not matched.')
+\s+is not a dict$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')
 
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -168,14 +168,14 @@ class TestErrors(unittest.TestCase):
             load_and_validate(document_loader, avsc_names,
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
-^.+test10\.cwl:2:1: Object `.+test10\.cwl`\s+is not valid because
+^.+test10\.cwl:2:1: Object\s+`.+test10\.cwl`\s+is not valid because
 \s+tried `Workflow` but
-.+test10\.cwl:7:1:     the `steps` field is not valid because
-\s+tried array of <WorkflowStep> but
-.+test10\.cwl:8:3:         item is invalid because
-\s+\* missing required field `run`
-.+test10\.cwl:9:5:           \* the `scatterMethod` field is\s+not valid because
-\s+value is a CommentedSeq, expected null\s+or ScatterMethod$'''[1:],
+.+test10\.cwl:7:1:     the `steps`\s+field is\s+not valid\s+because
+\s+tried array of\s+<WorkflowStep> but
+.+test10\.cwl:8:3:         item is\s+invalid because
+\s+\* missing\s+required\s+field `run`
+.+test10\.cwl:9:5:           \* the\s+`scatterMethod`\s+field is\s+not valid\s+because
+\s+value is a\s+CommentedSeq, expected\s+null\s+or ScatterMethod$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')
 
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -107,11 +107,11 @@ class TestErrors(unittest.TestCase):
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
 ^.+test5\.cwl:2:1: Object\s+`.+test5\.cwl`\s+is\s+not valid because
-\s+tried `Workflow` but
-.+test5\.cwl:7:1:     the `steps` field\s+is\s+not valid because
-\s+tried array of\s+<WorkflowStep> but
+\s+tried `Workflow`\s+but
+.+test5\.cwl:7:1:     the `steps`\s+field\s+is\s+not valid\s+because
+\s+tried array\s+of\s+<WorkflowStep>\s+but
 .+test5\.cwl:7:9:         item is\s+invalid because
-\s+is not a dict$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')
+\s+is not a\s+dict$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')
 
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -63,7 +63,7 @@ class TestErrors(unittest.TestCase):
         self.assertTrue(re.match(r'''
 ^.+test2\.cwl:2:1: Field `class` contains undefined reference to
 \s+`file://.+/xWorkflow`$'''[1:],
-                                 str(e.exception)))
+                                 str(e.exception)), str(e.exception)+ ' is not matched.')
 
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -61,7 +61,7 @@ class TestErrors(unittest.TestCase):
             load_and_validate(document_loader, avsc_names,
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
-^.+test2\.cwl:2:1: Field `class` contains\s+undefined reference to
+^.+test2\.cwl:2:1: Field `class`\s+contains\s+undefined\s+reference to
 \s+`file://.+/schema_salad/tests/test_schema/xWorkflow`$'''[1:],
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -159,6 +159,25 @@ class TestErrors(unittest.TestCase):
 .+test9\.cwl:9:5:     `scatterMethod`\s+field\s+is int,\s+expected\s+string,\s+list, or a dict.$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')
 
+    def test_error_message10(self):
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        t = "test_schema/test10.cwl"
+        with self.assertRaises(ValidationException) as e:
+            load_and_validate(document_loader, avsc_names,
+                              six.text_type(get_data("tests/"+t)), True)
+        self.assertTrue(re.match(r'''
+^.+test10\.cwl:2:1: Object `.+test10\.cwl`\s+is not valid because
+\s+tried `Workflow` but
+.+test10\.cwl:7:1:     the `steps` field is not valid because
+\s+tried array of <WorkflowStep> but
+.+test10\.cwl:8:3:         item is invalid because
+\s+\* missing required field `run`
+.+test10\.cwl:9:5:           \* the `scatterMethod` field is\s+not valid because
+\s+value is a CommentedSeq, expected null\s+or ScatterMethod$'''[1:],
+                                 str(e.exception)), str(e.exception) + ' is not matched.')
+
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -123,9 +123,9 @@ class TestErrors(unittest.TestCase):
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
 ^.+test7\.cwl:2:1: Object\s+`.+test7\.cwl`\s+is\s+not valid because
-\s+tried `Workflow` but
-.+test7\.cwl:7:1:     the `steps` field\s+is\s+not valid because
-\s+tried array of\s+<WorkflowStep> but
+\s+tried `Workflow`\s+but
+.+test7\.cwl:7:1:     the `steps`\s+field\s+is\s+not valid\s+because
+\s+tried array\s+of\s+<WorkflowStep>\s+but
 .+test7\.cwl:8:3:         item is\s+invalid because
 \s+\* missing\s+required\s+field `run`
 .+test7\.cwl:9:5:           \* invalid\s+field\s+`scatter_method`,\s+expected one of:\s+'id', 'in', 'out',\s+'requirements',\s+'hints', 'label',\s+'doc',\s+'run',\s+'scatter',\s+'scatterMethod'$'''[1:], str(e.exception)), str(e.exception) + ' is not matched.')

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -203,12 +203,12 @@ class TestErrors(unittest.TestCase):
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
 ^.+test15\.cwl:3:1:\s+Object\s+`.+test15\.cwl`\s+is not valid because
-\s+tried `CommandLineTool`\s+but
-.+test15\.cwl:6:1:\s+the `inputs` field\s+is not valid because
+\s+tried\s+`CommandLineTool`\s+but
+.+test15\.cwl:6:1:\s+the `inputs`\s+field\s+is not valid\s+because
 .+test15\.cwl:7:3:\s+item is\s+invalid\s+because
 .+test15\.cwl:9:5:\s+the\s+`inputBinding`\s+field is not\s+valid\s+because
 .+tried\s+CommandLineBinding but
-.+test15\.cwl:11:7:             \*\s+invalid field\s+`invalid_field`, expected one\s+of:\s+'loadContents',\s+'position',\s+'prefix',\s+'separate',\s+'itemSeparator',\s+'valueFrom',\s+'shellQuote'
+.+test15\.cwl:11:7:             \*\s+invalid field\s+`invalid_field`,\s+expected one\s+of:\s+'loadContents',\s+'position',\s+'prefix',\s+'separate',\s+'itemSeparator',\s+'valueFrom',\s+'shellQuote'
 .+test15\.cwl:12:7:             \*\s+invalid field\s+`another_invalid_field`,\s+expected one\s+of:\s+'loadContents',\s+'position',\s+'prefix',\s+'separate',\s+'itemSeparator',\s+'valueFrom',\s+'shellQuote'$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')
 

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -97,6 +97,24 @@ class TestErrors(unittest.TestCase):
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')
 
+    def test_error_message5(self):
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        t = "test_schema/test5.cwl"
+        with self.assertRaises(ValidationException) as e:
+            load_and_validate(document_loader, avsc_names,
+                              six.text_type(get_data("tests/"+t)), True)
+        self.assertTrue(re.match(r'''
+^.+test5\.cwl:2:1: Object `.+test5\.cwl` is\s+not valid because
+\s+tried `Workflow` but
+.+test5\.cwl:7:1:     the `steps` field is not valid because
+\s+tried array of <WorkflowStep> but
+.+test5\.cwl:7:9:         item is invalid because
+\s+is not a dict$'''[1:],
+                                 str(e.exception)),
+                        str(e.exception) + ' is not matched.')
+
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -169,13 +169,13 @@ class TestErrors(unittest.TestCase):
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
 ^.+test10\.cwl:2:1: Object\s+`.+test10\.cwl`\s+is not valid because
-\s+tried `Workflow` but
+\s+tried `Workflow`\s+but
 .+test10\.cwl:7:1:     the `steps`\s+field is\s+not valid\s+because
-\s+tried array of\s+<WorkflowStep> but
+\s+tried array\s+of\s+<WorkflowStep>\s+but
 .+test10\.cwl:8:3:         item is\s+invalid because
 \s+\* missing\s+required\s+field `run`
 .+test10\.cwl:9:5:           \* the\s+`scatterMethod`\s+field is\s+not valid\s+because
-\s+value is a\s+CommentedSeq, expected\s+null\s+or ScatterMethod$'''[1:],
+\s+value\s+is a\s+CommentedSeq,\s+expected\s+null\s+or\s+ScatterMethod$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')
 
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -62,7 +62,7 @@ class TestErrors(unittest.TestCase):
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
 ^.+test2\.cwl:2:1: Field `class` contains\s+undefined reference to
-\s+`file://.+/schema-salad/schema_salad/tests/test_schema/xWorkflow`$'''[1:],
+\s+`file://.+/schema_salad/tests/test_schema/xWorkflow`$'''[1:],
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')
 

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -145,6 +145,20 @@ class TestErrors(unittest.TestCase):
 \s+`file:///.+/tests/test_schema/abc`$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')
 
+    def test_error_message9(self):
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        t = "test_schema/test9.cwl"
+        with self.assertRaises(ValidationException) as e:
+            load_and_validate(document_loader, avsc_names,
+                              six.text_type(get_data("tests/"+t)), True)
+        self.assertTrue(re.match(r'''
+^.+test9\.cwl:7:1: checking field `steps`
+.+test9\.cwl:8:3:   checking object\s+`.+test9\.cwl#step1`
+.+test9\.cwl:9:5:     `scatterMethod` field is int, expected\s+string, list, or a dict.$'''[1:],
+                                 str(e.exception)), str(e.exception) + ' is not matched.')
+
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -82,6 +82,21 @@ class TestErrors(unittest.TestCase):
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')
 
+    def test_error_message4(self):
+        document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
+            get_data(u"tests/test_schema/CommonWorkflowLanguage.yml"))
+
+        t = "test_schema/test4.cwl"
+        with self.assertRaises(ValidationException) as e:
+            load_and_validate(document_loader, avsc_names,
+                              six.text_type(get_data("tests/"+t)), True)
+        self.assertTrue(re.match(r'''
+^.+test4\.cwl:5:1: checking field `outputs`
+.+test4\.cwl:6:3:   checking object `.+test4\.cwl#bar`
+\s+`type` field is int, expected string, list, or a dict.$'''[1:],
+                                 str(e.exception)),
+                        str(e.exception) + ' is not matched.')
+
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")
     def test_errors_previously_defined_dict_key(self):
         document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -154,7 +154,7 @@ class TestErrors(unittest.TestCase):
             load_and_validate(document_loader, avsc_names,
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
-^.+test9\.cwl:7:1: checking field `steps`
+^.+test9\.cwl:7:1: checking field\s+`steps`
 .+test9\.cwl:8:3:   checking object\s+`.+test9\.cwl#step1`
 .+test9\.cwl:9:5:     `scatterMethod`\s+field\s+is int,\s+expected\s+string,\s+list, or a dict.$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -78,7 +78,7 @@ class TestErrors(unittest.TestCase):
 ^.+test3\.cwl:5:1: checking field\s+`outputs`
 .+test3\.cwl:6:3:   checking object\s+`.+test3\.cwl#bar`
 \s+Field `type`\s+references\s+unknown\s+identifier\s+`xstring`,\s+tried
-\s+file://.+/test_schema/test3\.cwl#xstring$'''[1:],
+\s+file://.+/schema_salad/tests/test_schema/test3\.cwl#xstring$'''[1:],
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')
 

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -91,9 +91,9 @@ class TestErrors(unittest.TestCase):
             load_and_validate(document_loader, avsc_names,
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
-^.+test4\.cwl:5:1: checking field `outputs`
+^.+test4\.cwl:5:1: checking field\s+`outputs`
 .+test4\.cwl:6:3:   checking object\s+`.+test4\.cwl#bar`
-\s+`type` field is int,\s+expected string, list, or\s+a\s+dict.$'''[1:],
+\s+`type` field is\s+int,\s+expected\s+string, list, or\s+a\s+dict.$'''[1:],
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')
 

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -207,7 +207,7 @@ class TestErrors(unittest.TestCase):
 .+test15\.cwl:6:1:\s+the `inputs`\s+field\s+is not valid\s+because
 .+test15\.cwl:7:3:\s+item is\s+invalid\s+because
 .+test15\.cwl:9:5:\s+the\s+`inputBinding`\s+field is not\s+valid\s+because
-.+tried\s+CommandLineBinding but
+.+tried\s+CommandLineBinding\s+but
 .+test15\.cwl:11:7:             \*\s+invalid field\s+`invalid_field`,\s+expected one\s+of:\s+'loadContents',\s+'position',\s+'prefix',\s+'separate',\s+'itemSeparator',\s+'valueFrom',\s+'shellQuote'
 .+test15\.cwl:12:7:             \*\s+invalid field\s+`another_invalid_field`,\s+expected one\s+of:\s+'loadContents',\s+'position',\s+'prefix',\s+'separate',\s+'itemSeparator',\s+'valueFrom',\s+'shellQuote'$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -202,16 +202,14 @@ class TestErrors(unittest.TestCase):
             load_and_validate(document_loader, avsc_names,
                               six.text_type(get_data("tests/"+t)), True)
         self.assertTrue(re.match(r'''
-^.+test15\.cwl:3:1:  Object `.+test15\.cwl`\s+is not valid because
+^.+test15\.cwl:3:1:\s+Object `.+test15\.cwl`\s+is not valid because
 \s+tried `CommandLineTool` but
-.+test15\.cwl:6:1:      the `inputs` field is not valid because
-.+test15\.cwl:7:3:        item is invalid because
-.+test15\.cwl:9:5:          the `inputBinding` field is not\s+valid because
+.+test15\.cwl:6:1:\s+the `inputs` field is not valid because
+.+test15\.cwl:7:3:\s+item is invalid because
+.+test15\.cwl:9:5:\s+the `inputBinding` field is not\s+valid because
 .+tried CommandLineBinding but
-.+test15\.cwl:11:7:             \* invalid field\s+`invalid_field`, expected one\s+of:
-\s+'loadContents', 'position', 'prefix',\s+'separate',\s+'itemSeparator',\s+'valueFrom', 'shellQuote'
-.+test15\.cwl:12:7:             \* invalid field\s+`another_invalid_field`,\s+expected one
-\s+of: 'loadContents', 'position',\s+'prefix',\s+'separate', 'itemSeparator',\s+'valueFrom', 'shellQuote'$'''[1:],
+.+test15\.cwl:11:7:             \* invalid field\s+`invalid_field`, expected one\s+of:\s+'loadContents', 'position', 'prefix',\s+'separate',\s+'itemSeparator',\s+'valueFrom', 'shellQuote'
+.+test15\.cwl:12:7:             \* invalid field\s+`another_invalid_field`,\s+expected one\s+of: 'loadContents', 'position',\s+'prefix',\s+'separate', 'itemSeparator',\s+'valueFrom', 'shellQuote'$'''[1:],
                                  str(e.exception)), str(e.exception) + ' is not matched.')
 
     @unittest.skip("See https://github.com/common-workflow-language/common-workflow-language/issues/734")

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -93,7 +93,7 @@ class TestErrors(unittest.TestCase):
         self.assertTrue(re.match(r'''
 ^.+test4\.cwl:5:1: checking field\s+`outputs`
 .+test4\.cwl:6:3:   checking object\s+`.+test4\.cwl#bar`
-\s+`type` field is\s+int,\s+expected\s+string, list, or\s+a\s+dict.$'''[1:],
+\s+`type` field is\s+int,\s+expected\s+string,\s+list, or\s+a\s+dict.$'''[1:],
                                  str(e.exception)),
                         str(e.exception) + ' is not matched.')
 


### PR DESCRIPTION
This request is to add tests for `ValidationException` for `test2.cwl` to `test15.cwl` (a test for `test1.cwl` was done by #232).

This request is currently work in progress and not to merge.
The reason why I sent this unfinished pull request is to know the exact error messages for each CI testers.
As mentioned in the [comment in #232](https://github.com/common-workflow-language/schema_salad/pull/232#issuecomment-460544860), we have to execute the test for all CI testers to make a test for current `ValidationException`.

Here is a list of tests to be done by this request. Once all the tests are written and passed by all the CI testers, I remove the [WIP] tag and will be ready to merge.

I will add a test for each CWL file to mach the generated error message and a simple regular expression that absorbs the number of spaces and newlines.

- [x] test2.cwl
- [x] test3.cwl
- [x] test4.cwl
- [x] test5.cwl
- ~~[ ] test6.cwl~~
  - It generates completely different message for each platform and needs more complicated regex for it.
- [x] test7.cwl
- [x] test8.cwl
- [x] test9.cwl
- [x] test10.cwl
- [x] test11.cwl
- [x] test15.cwl