### PR TITLE
Add `load_document_by_string` for codegen

### DIFF
--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -327,5 +327,15 @@ def load_document(doc, baseuri=None, loadingOptions=None):
         baseuri = file_uri(os.getcwd()) + "/"
     if loadingOptions is None:
         loadingOptions = LoadingOptions()
-    return _document_load(%s, doc, baseuri, loadingOptions)
-""" % root_loader.name)
+    return _document_load(%(name)s, doc, baseuri, loadingOptions)
+
+def load_document_by_string(string, uri, loadingOptions=None):
+    result = yaml.round_trip_load(string, preserve_quotes=True)
+    add_lc_filename(result, uri)
+
+    if loadingOptions is None:
+        loadingOptions = LoadingOptions(fileuri=uri)
+    loadingOptions.idx[uri] = result
+
+    return _document_load(%(name)s, result, uri, loadingOptions)
+""" % dict(name=root_loader.name))


### PR DESCRIPTION
This request adds `load_document_by_string` that takes a content of a CWL document rather than URI or relative path of the document to be loaded.

We are working on a [cwl-language-server](https://github.com/common-workflow-language/cwl-language-server) and currently we are start adding `publishDiagnostics` (It is to add syntax checking feature) by using a python module that is generated by `schema-salad-tool --codegen python`.

According to the [spec of language server protocol](https://microsoft.github.io/language-server-protocol/specification#textDocument_didOpen), language servers have to manage the content of the document by using notifications from a client (i.e., editors and IDEs etc) and they should not read the document directly.

However, the code-generated module does not provide an interface for that.
It currently provides `load_document` that takes a URI or relative path for the document but does not provide a function to load an argument string directly.
This request is to solve this problem.
