### PR TITLE
Special case validation for 'Expression'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ COVBASE=coverage run --branch --append --source=${MODULE} \
 
 # Updating the Major & Minor version below?
 # Don't forget to update setup.py as well
-VERSION=4.1.$(shell date +%Y%m%d%H%M%S --utc --date=`git log --first-parent \
+VERSION=4.2.$(shell date +%Y%m%d%H%M%S --utc --date=`git log --first-parent \
 	--max-count=1 --format=format:%cI`)
 
 ## all         : default task

--- a/schema_salad/validate.py
+++ b/schema_salad/validate.py
@@ -159,6 +159,13 @@ def validate_ex(expected_schema,                  # type: Schema
                     u"value is a %s but expected a string" % (type(datum).__name__))
             else:
                 return False
+        if expected_schema.name == "Expression":
+            if "$(" in datum or "${" in datum:
+                return True
+            if raise_ex:
+                raise ValidationException(u"value `%s` does not contain an expression in the form $() or ${}" % datum)
+            else:
+                return False
         if datum in expected_schema.symbols:
             return True
         else:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ extras_require={
 }
 
 setup(name='schema-salad',
-      version='4.1',  # update the VERSION prefix in the Makefile as well 🙂
+      version='4.2',  # update the VERSION prefix in the Makefile as well 🙂
       description='Schema Annotations for Linked Avro Data (SALAD)',
       long_description=open(README).read(),
       author='Common workflow language working group',


### PR DESCRIPTION
Eliminate workaround of requiring both "string" and "Expression" even
when a string value wasn't meaningful.

refs #39