### PR TITLE
Use `T` rather than `<class 'T'> ` in errors from codegen-ed parser

### DIFF
--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -170,7 +170,7 @@ class _PrimitiveLoader(_Loader):
 
     def load(self, doc, baseuri, loadingOptions, docRoot=None):
         if not isinstance(doc, self.tp):
-            raise ValidationException("Expected a %s but got %s" % (self.tp, type(doc)))
+            raise ValidationException("Expected a %s but got %s" % (self.tp.__class__.__name__, doc.__class__.__name__))
         return doc
 
     def __repr__(self):
@@ -239,7 +239,7 @@ class _UnionLoader(_Loader):
             try:
                 return t.load(doc, baseuri, loadingOptions, docRoot=docRoot)
             except ValidationException as e:
-                errors.append("tried %s but\n%s" % (t, indent(str(e))))
+                errors.append("tried %s but\n%s" % (t.__class__.__name__, indent(str(e))))
         raise ValidationException(bullets(errors, "- "))
 
     def __repr__(self):


### PR DESCRIPTION
This request partially solves the error message from the code generated parser.

# How to reproduce
```console
$ schema-salad-tool --codegen python /path/to/common-workflow-language/v1.0/CommonWorkflowLanguage.yml > v1_0.py
$ cat <<EOS > validate.py
from v1_0 import load_document
import sys

if __name__ == '__main__':
    try:
        load_document(sys.argv[1])
    except Exception as e:
        print(e)
EOS
$ sed 's/cwlVersion: v1.0/cwlVersion: v1.0a/' /path/to/common-workflow-language/v1.0/v1.0/bwa-mem-tool.cwl > error.cwl
$ python validate.py error.cwl
```

# Current result

```console
- tried <class 'v1_0.CommandLineTool'> but
    Trying 'CommandLineTool'
error.cwl:3:1:     the `cwlVersion` field is not valid because:
error.cwl:3:1:     - tried <class 'NoneType'> but
error.cwl:3:1:         Expected a <class 'NoneType'> but got <class 'str'>
error.cwl:3:1:     - tried <v1_0._EnumLoader object at 0x10f3c7e48> but
error.cwl:3:1:         Expected one of ('draft-2', 'draft-3.dev1', 'draft-3.dev2', 'draft-3.dev3', 'draft-3.dev4', 'draft-3.dev5', 'draft-3', 'draft-4.dev1', 'draft-4.dev2', 'draft-4.dev3', 'v1.0.dev4', 'v1.0')
- tried <class 'v1_0.ExpressionTool'> but
    Not a ExpressionTool
- tried <class 'v1_0.Workflow'> but
    Not a Workflow
- tried array<<class 'v1_0.CommandLineTool'> | <class 'v1_0.ExpressionTool'> | <class 'v1_0.Workflow'>> but
    Expected a list
```
- It is better to use `CommandLineTool` rather than `<class 'v1_0.CommandLineTool'>`.
  - This request is to solve it.
- There are other issues in this example but they should be done in other PRs.
  - Several messages do not follow to the file name, line number and column number.
  - Its message is quite different from that is generated by the original `schema-salad-tool`. Such difference makes harder to make tests for code generated parsers or we have to re-implement tests for the error messages for a code generated parser.
    ```console
    $ schema-salad-tool /path/to/common-workflow-language/v1.0/CommonWorkflowLanguage.yml error.cwl
    ...
    error.cwl:40:7:   Field `location` contains undefined reference to `file:///Users/tanjo/repos/cwl-language-server/cwl_language_server/args.py`
    Document `error.cwl` failed validation:
    error.cwl:3:1: Field `cwlVersion` contains undefined reference to
                   `file:///Users/tom-tan/repos/cwl-language-server/cwl_language_server/v1.0a`
    ```

# Result after merging this request

```console
- tried _RecordLoader but
    Trying 'CommandLineTool'
error.cwl:3:1:     the `cwlVersion` field is not valid because:
error.cwl:3:1:     - tried _PrimitiveLoader but
error.cwl:3:1:         Expected a type but got str
error.cwl:3:1:     - tried _EnumLoader but
error.cwl:3:1:         Expected one of ('draft-2', 'draft-3.dev1', 'draft-3.dev2', 'draft-3.dev3', 'draft-3.dev4', 'draft-3.dev5', 'draft-3', 'draft-4.dev1', 'draft-4.dev2', 'draft-4.dev3', 'v1.0.dev4', 'v1.0')
- tried _RecordLoader but
    Not a ExpressionTool
- tried _RecordLoader but
    Not a Workflow
- tried _ArrayLoader but
    Expected a list
```
