### PR TITLE
root the exception hierarchy in ValidationException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ jobs:
     - stage: test
       python: "3.7"
       dist: xenial
-    - stage: test
-      python: "3.8-dev"
-      dist: xenial
+      # - stage: test
+      # - python: "3.8-dev"
+      # - dist: xenial
     - stage: release-test
       python: "2.7"
       script: RELEASE_SKIP=head PYVER= ${TRAVIS_BUILD_DIR}/release-test.sh

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ diff_pydocstyle_report: pydocstyle_report.txt
 
 ## format      : check/fix all code indentation and formatting (runs black)
 format:
-	black --target-version py27 schema_salad
+	black --target-version py27 --exclude metaschema.py schema_salad
 
 ## pylint      : run static code analysis on Python code
 pylint: $(PYSOURCES)

--- a/schema_salad/avro/schema.py
+++ b/schema_salad/avro/schema.py
@@ -32,6 +32,8 @@ A schema may be one of:
 """
 from typing import Any, Dict, List, Optional, Text, Tuple, Union, cast
 
+from schema_salad.exceptions import ValidationException
+
 import six
 
 #
@@ -63,7 +65,7 @@ VALID_FIELD_SORT_ORDERS = ("ascending", "descending", "ignore")
 #
 
 
-class AvroException(Exception):
+class AvroException(ValidationException):
     pass
 
 

--- a/schema_salad/avro/schema.py
+++ b/schema_salad/avro/schema.py
@@ -32,7 +32,7 @@ A schema may be one of:
 """
 from typing import Any, Dict, List, Optional, Text, Tuple, Union, cast
 
-from schema_salad.exceptions import ValidationException
+from schema_salad.exceptions import SchemaException
 
 import six
 
@@ -65,7 +65,7 @@ VALID_FIELD_SORT_ORDERS = ("ascending", "descending", "ignore")
 #
 
 
-class AvroException(ValidationException):
+class AvroException(SchemaException):
     pass
 
 

--- a/schema_salad/codegen.py
+++ b/schema_salad/codegen.py
@@ -31,7 +31,9 @@ def codegen(
     elif lang == "java":
         gen = JavaCodeGen(schema_metadata.get("$base", schema_metadata.get("id")))
     else:
-        raise Exception("Unsupported code generation language '{}'".format(lang))
+        raise SchemaSaladException(
+            "Unsupported code generation language '{}'".format(lang)
+        )
     assert gen is not None
 
     gen.prologue()

--- a/schema_salad/codegen.py
+++ b/schema_salad/codegen.py
@@ -6,6 +6,7 @@ from typing_extensions import Text  # pylint: disable=unused-import
 
 from . import schema
 from .codegen_base import CodeGenBase
+from .exceptions import SchemaSaladException
 from .java_codegen import JavaCodeGen
 from .python_codegen import PythonCodeGen
 from .ref_resolver import Loader  # pylint: disable=unused-import

--- a/schema_salad/exceptions.py
+++ b/schema_salad/exceptions.py
@@ -1,0 +1,20 @@
+class SchemaSaladException(Exception):
+    """Base class for all schema-salad exceptions."""
+
+    pass
+
+
+class SchemaException(SchemaSaladException):
+    """Indicates error with the provided schema definition."""
+
+    pass
+
+
+class ValidationException(SchemaSaladException):
+    """Indicates error with document against the provided schema."""
+
+    pass
+
+
+class ClassValidationException(ValidationException):
+    pass

--- a/schema_salad/jsonld_context.py
+++ b/schema_salad/jsonld_context.py
@@ -22,6 +22,7 @@ from rdflib.namespace import RDF, RDFS
 from six.moves import urllib
 from typing_extensions import Text  # pylint: disable=unused-import
 
+from .exceptions import SchemaException
 from .ref_resolver import ContextType  # pylint: disable=unused-import
 from .utils import aslist, json_dumps
 
@@ -69,11 +70,11 @@ def pred(
                     if d["symbol"] == name:
                         v = d["predicate"]
                 else:
-                    raise Exception(
+                    raise SchemaException(
                         "entries in the jsonldPredicate List must be " "Dictionaries"
                     )
         else:
-            raise Exception("jsonldPredicate must be a List of Dictionaries.")
+            raise SchemaException("jsonldPredicate must be a List of Dictionaries.")
 
     ret = v or vee
 
@@ -82,7 +83,7 @@ def pred(
 
     if name in context:
         if context[name] != ret:
-            raise Exception(
+            raise SchemaException(
                 "Predicate collision on {}, '{}' != '{}'".format(
                     name, context[name], ret
                 )
@@ -124,14 +125,14 @@ def process_type(
                 predicate = "{}:{}".format(defaultPrefix, recordname)
 
         if context.get(recordname, predicate) != predicate:
-            raise Exception(
+            raise SchemaException(
                 "Predicate collision on '{}', '{}' != '{}'".format(
                     recordname, context[recordname], predicate
                 )
             )
 
         if not recordname:
-            raise Exception()
+            raise SchemaException("Unable to find/derive recordname for {}".format(t))
 
         _logger.debug(
             "Adding to context '%s' %s (%s)", recordname, predicate, type(predicate)

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -18,6 +18,7 @@ from ruamel.yaml.comments import CommentedSeq
 
 from . import codegen, jsonld_context, schema, validate
 from .avro.schema import SchemaParseException
+from .exceptions import ValidationException
 from .makedoc import makedoc
 from .ref_resolver import Loader, file_uri
 from .sourceline import (
@@ -206,7 +207,7 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
         schema_doc, schema_metadata = metaschema_loader.resolve_all(
             schema_raw_doc, schema_uri
         )
-    except (validate.ValidationException) as e:
+    except ValidationException as e:
         _logger.error(
             "Schema `%s` failed link checking:\n%s",
             args.schema,
@@ -243,7 +244,7 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
         schema.validate_doc(
             metaschema_names, schema_doc, metaschema_loader, args.strict
         )
-    except validate.ValidationException as e:
+    except ValidationException as e:
         _logger.error("While validating schema `%s`:\n%s", args.schema, Text(e))
         return 1
 
@@ -329,7 +330,7 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
         document, doc_metadata = document_loader.resolve_ref(
             uri, strict_foreign_properties=args.strict_foreign_properties
         )
-    except validate.ValidationException as e:
+    except ValidationException as e:
         msg = strip_dup_lineno(six.text_type(e))
         msg = to_one_line_messages(str(msg)) if args.print_oneline else msg
         _logger.error(
@@ -369,7 +370,7 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
             args.strict,
             strict_foreign_properties=args.strict_foreign_properties,
         )
-    except validate.ValidationException as e:
+    except ValidationException as e:
         msg = to_one_line_messages(str(e)) if args.print_oneline else str(e)
         _logger.error("While validating document `%s`:\n%s" % (args.document, msg))
         return 1

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -255,7 +255,7 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
     if isinstance(schema_doc, CommentedSeq):
         (schema_ctx, rdfs) = jsonld_context.salad_to_jsonld_context(schema_doc, metactx)
     else:
-        raise Exception(
+        raise ValidationException(
             "Expected a CommentedSeq, got {}: {}.".format(type(schema_doc), schema_doc)
         )
 

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -16,7 +16,7 @@ from typing_extensions import Text  # pylint: disable=unused-import
 
 from ruamel.yaml.comments import CommentedSeq
 
-from . import codegen, jsonld_context, schema, validate
+from . import codegen, jsonld_context, schema
 from .avro.schema import SchemaParseException
 from .exceptions import ValidationException
 from .makedoc import makedoc

--- a/schema_salad/makedoc.py
+++ b/schema_salad/makedoc.py
@@ -339,7 +339,7 @@ class RenderType(object):
             if frg != "":
                 tp = frg
             return """<a href="{}">{}</a>""".format(to_id(tp), tp)
-        raise Exception("We should not be here!")
+        raise SchemaSaladException("We should not be here!")
 
     def render_type(self, f, depth):  # type: (Dict[Text, Any], int) -> None
         if f["name"] in self.rendered or f["name"] in self.redirects:

--- a/schema_salad/makedoc.py
+++ b/schema_salad/makedoc.py
@@ -30,6 +30,7 @@ from six.moves import range, urllib
 from typing_extensions import Text  # pylint: disable=unused-import
 
 from . import schema
+from .exceptions import SchemaSaladException
 from .utils import add_dictlist, aslist
 
 # move to a regular typing import when Python 3.3-3.6 is no longer supported

--- a/schema_salad/metaschema.py
+++ b/schema_salad/metaschema.py
@@ -28,15 +28,12 @@ from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap
 from schema_salad.ref_resolver import Fetcher
 from schema_salad.sourceline import SourceLine, add_lc_filename, bullets, indent
+from schema_salad.exceptions import SchemaSaladException, ValidationException
 
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 _vocab = {}  # type: Dict[Text, Text]
 _rvocab = {}  # type: Dict[Text, Text]
-
-
-class ValidationException(Exception):
-    pass
 
 
 class Savable(object):
@@ -120,7 +117,7 @@ def load_field(val, fieldtype, baseuri, loadingOptions):
     if isinstance(val, MutableMapping):
         if "$import" in val:
             if loadingOptions.fileuri is None:
-                raise Exception("Cannot load $import without fileuri")
+                raise SchemaSaladException("Cannot load $import without fileuri")
             return _document_load_by_url(
                 fieldtype,
                 loadingOptions.fetcher.urljoin(loadingOptions.fileuri, val["$import"]),
@@ -128,7 +125,7 @@ def load_field(val, fieldtype, baseuri, loadingOptions):
             )
         elif "$include" in val:
             if loadingOptions.fileuri is None:
-                raise Exception("Cannot load $import without fileuri")
+                raise SchemaSaladException("Cannot load $import without fileuri")
             val = loadingOptions.fetcher.fetch_text(
                 loadingOptions.fetcher.urljoin(loadingOptions.fileuri, val["$include"])
             )
@@ -2410,11 +2407,11 @@ _rvocab = {
 }
 
 strtype = _PrimitiveLoader((str, text_type))
+inttype = _PrimitiveLoader(int)
 floattype = _PrimitiveLoader(float)
 booltype = _PrimitiveLoader(bool)
-Any_type = _AnyLoader()
-inttype = _PrimitiveLoader(int)
 None_type = _PrimitiveLoader(type(None))
+Any_type = _AnyLoader()
 DocumentedLoader = _RecordLoader(Documented)
 PrimitiveTypeLoader = _EnumLoader(("null", "boolean", "int", "long", "float", "double", "string",))
 AnyLoader = _EnumLoader(("Any",))

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -7,6 +7,7 @@ from six.moves import cStringIO
 from typing_extensions import Text  # pylint: disable=unused-import
 
 from . import schema
+from .exceptions import SchemaException
 from .codegen_base import CodeGenBase, TypeDef
 from .schema import shortname
 
@@ -305,7 +306,7 @@ class PythonCodeGen(CodeGenBase):
                         ),
                     )
                 )
-            raise Exception("wft {}".format(type_declaration["type"]))
+            raise SchemaException("wft {}".format(type_declaration["type"]))
         if type_declaration in self.prims:
             return self.prims[type_declaration]
         return self.collected_types[self.safe_name(type_declaration) + "Loader"]

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -23,7 +23,7 @@ from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap
 from schema_salad.ref_resolver import Fetcher
 from schema_salad.sourceline import SourceLine, add_lc_filename, bullets, indent
-from schema_salad.exceptions import ValidationException
+from schema_salad.exceptions import SchemaSaladException, ValidationException
 
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
@@ -112,7 +112,7 @@ def load_field(val, fieldtype, baseuri, loadingOptions):
     if isinstance(val, MutableMapping):
         if "$import" in val:
             if loadingOptions.fileuri is None:
-                raise Exception("Cannot load $import without fileuri")
+                raise SchemaSaladException("Cannot load $import without fileuri")
             return _document_load_by_url(
                 fieldtype,
                 loadingOptions.fetcher.urljoin(loadingOptions.fileuri, val["$import"]),
@@ -120,7 +120,7 @@ def load_field(val, fieldtype, baseuri, loadingOptions):
             )
         elif "$include" in val:
             if loadingOptions.fileuri is None:
-                raise Exception("Cannot load $import without fileuri")
+                raise SchemaSaladException("Cannot load $import without fileuri")
             val = loadingOptions.fetcher.fetch_text(
                 loadingOptions.fetcher.urljoin(loadingOptions.fileuri, val["$include"])
             )

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -23,15 +23,12 @@ from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap
 from schema_salad.ref_resolver import Fetcher
 from schema_salad.sourceline import SourceLine, add_lc_filename, bullets, indent
+from schema_salad.exceptions import ValidationException
 
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 
 _vocab = {}  # type: Dict[Text, Text]
 _rvocab = {}  # type: Dict[Text, Text]
-
-
-class ValidationException(Exception):
-    pass
 
 
 class Savable(object):

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -1048,7 +1048,7 @@ class Loader(object):
         elif isinstance(document, CommentedSeq):
             pass
         elif isinstance(document, (list, dict)):
-            raise Exception(
+            raise ValidationException(
                 "Expected CommentedMap or CommentedSeq, got {}: `{}`".format(
                     type(document), document
                 )

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -37,7 +37,6 @@ from typing_extensions import Text  # pylint: disable=unused-import
 from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, LineCol
 
-from . import validate
 from .exceptions import ValidationException
 from .sourceline import SourceLine, add_lc_filename, indent, relname, strip_dup_lineno
 from .utils import aslist, onWindows

--- a/schema_salad/schema.py
+++ b/schema_salad/schema.py
@@ -36,6 +36,7 @@ from schema_salad.utils import (
 )
 
 from . import _logger, jsonld_context, ref_resolver, validate
+from .exceptions import ClassValidationException, ValidationException
 from .avro.schema import Names, SchemaParseException, make_avsc_object
 from .ref_resolver import Loader
 from .sourceline import (
@@ -206,7 +207,7 @@ def add_namespaces(metadata, namespaces):
         if key not in namespaces:
             namespaces[key] = value
         elif namespaces[key] != value:
-            raise validate.ValidationException(
+            raise ValidationException(
                 "Namespace prefix '{}' has conflicting definitions '{}'"
                 " and '{}'.".format(key, namespaces[key], value)
             )
@@ -295,8 +296,8 @@ def load_and_validate(
             strict,
             strict_foreign_properties=strict_foreign_properties,
         )
-    except validate.ValidationException as exc:
-        raise_from(validate.ValidationException(strip_dup_lineno(str(exc))), exc)
+    except ValidationException as exc:
+        raise_from(ValidationException(strip_dup_lineno(str(exc))), exc)
     return data, metadata
 
 
@@ -318,7 +319,7 @@ def validate_doc(
             break
 
     if not has_root:
-        raise validate.ValidationException("No document roots defined in the schema")
+        raise ValidationException("No document roots defined in the schema")
 
     if isinstance(doc, MutableSequence):
         vdoc = doc
@@ -327,7 +328,7 @@ def validate_doc(
         vdoc.lc.add_kv_line_col(0, [doc.lc.line, doc.lc.col])
         vdoc.lc.filename = doc.lc.filename
     else:
-        raise validate.ValidationException("Document must be dict or list")
+        raise ValidationException("Document must be dict or list")
 
     roots = []
     for root in schema_names.names.values():
@@ -373,7 +374,7 @@ def validate_doc(
                         skip_foreign_properties=loader.skip_schemas,
                         strict_foreign_properties=strict_foreign_properties,
                     )
-                except validate.ClassValidationException as exc:
+                except ClassValidationException as exc:
                     errors = [
                         sourceline.makeError(
                             u"tried `{}` but\n{}".format(
@@ -382,7 +383,7 @@ def validate_doc(
                         )
                     ]
                     break
-                except validate.ValidationException as exc:
+                except ValidationException as exc:
                     errors.append(
                         sourceline.makeError(
                             u"tried `{}` but\n{}".format(
@@ -400,7 +401,7 @@ def validate_doc(
                     break
             anyerrors.append(u"{}\n{}".format(objerr, indent(bullets(errors, "- "))))
     if anyerrors:
-        raise validate.ValidationException(strip_dup_lineno(bullets(anyerrors, "* ")))
+        raise ValidationException(strip_dup_lineno(bullets(anyerrors, "* ")))
 
 
 def get_anon_name(rec):
@@ -410,7 +411,7 @@ def get_anon_name(rec):
         name = rec["name"]
         if isinstance(name, Text):
             return name
-        raise validate.ValidationException(
+        raise ValidationException(
             "Expected name field to be a string, was {}".format(name)
         )
     anon_name = u""
@@ -423,7 +424,7 @@ def get_anon_name(rec):
             if isinstance(field, Mapping):
                 anon_name += field[u"name"]
             else:
-                raise validate.ValidationException(
+                raise ValidationException(
                     "Expected entries in 'fields' to also be maps, was {}.".format(
                         field
                     )
@@ -431,9 +432,7 @@ def get_anon_name(rec):
         return u"record_" + hashlib.sha1(anon_name.encode("UTF-8")).hexdigest()
     if rec["type"] in ("array", saladp + "array"):
         return u""
-    raise validate.ValidationException(
-        "Expected enum or record, was {}".format(rec["type"])
-    )
+    raise ValidationException("Expected enum or record, was {}".format(rec["type"]))
 
 
 def replace_type(items, spec, loader, found, find_embeds=True, deepen=True):
@@ -628,7 +627,7 @@ def extend_and_specialize(items, loader):
                 fieldnames = set()  # type: Set[Text]
                 for field in stype["fields"]:
                     if field["name"] in fieldnames:
-                        raise validate.ValidationException(
+                        raise ValidationException(
                             "Field name {} appears twice in {}".format(
                                 field["name"], stype["name"]
                             )
@@ -658,7 +657,7 @@ def extend_and_specialize(items, loader):
 
     for result in results:
         if result.get("abstract") and result["name"] not in extended_by:
-            raise validate.ValidationException(
+            raise ValidationException(
                 "{} is abstract but missing a concrete subtype".format(result["name"])
             )
 

--- a/schema_salad/schema.py
+++ b/schema_salad/schema.py
@@ -597,7 +597,7 @@ def extend_and_specialize(items, loader):
             exsym = []  # type: List[Text]
             for ex in aslist(stype["extends"]):
                 if ex not in types:
-                    raise Exception(
+                    raise ValidationException(
                         "Extends {} in {} refers to invalid base type.".format(
                             stype["extends"], stype["name"]
                         )

--- a/schema_salad/validate.py
+++ b/schema_salad/validate.py
@@ -17,6 +17,7 @@ from six.moves import range, urllib
 from typing_extensions import Text  # pylint: disable=unused-import
 
 from . import avro
+from .exceptions import ClassValidationException, ValidationException
 from .avro import schema  # noqa: F401
 from .avro.schema import (  # pylint: disable=unused-import, no-name-in-module, import-error
     Schema,
@@ -27,14 +28,6 @@ from .sourceline import SourceLine, bullets, indent, strip_dup_lineno
 
 
 _logger = logging.getLogger("salad")
-
-
-class ValidationException(Exception):
-    pass
-
-
-class ClassValidationException(ValidationException):
-    pass
 
 
 def validate(


### PR DESCRIPTION
TODO:

- [x] Replace all bare `Exception()`s thrown in validation code paths with `ValidationException` or a sublcass
- [x] for non-validation code paths, don't use bare `Exception()`s either, probably one of https://docs.python.org/3/library/exceptions.html#exception-hierarchy