### PR TITLE
Tree structured exception

### DIFF
--- a/schema_salad/exceptions.py
+++ b/schema_salad/exceptions.py
@@ -1,3 +1,5 @@
+from .sourceline import strip_dup_lineno
+
 class SchemaSaladException(Exception):
     """Base class for all schema-salad exceptions."""
 
@@ -54,7 +56,11 @@ class SchemaSaladException(Exception):
         else:
             next_level = level
 
-        return "\n".join((e for e in [ret, *[c.pretty_str(next_level, self.bullet) for c in self.children]] if len(e)))
+        ret = "\n".join((e for e in [ret, *[c.pretty_str(next_level, self.bullet) for c in self.children]] if len(e)))
+        if level == 0:
+            return strip_dup_lineno(ret)
+        else:
+            return ret
 
 
 class SchemaException(SchemaSaladException):

--- a/schema_salad/exceptions.py
+++ b/schema_salad/exceptions.py
@@ -33,7 +33,7 @@ class SchemaSaladException(Exception):
     def with_sourceline(
         self, sl
     ):  # type: (Optional[SourceLine]) -> SchemaSaladException
-        if sl:
+        if sl and sl.file():
             self.file = sl.file()  # type: Optional[Text]
             self.start = (sl.line(), sl.column())  # type: Optional[Tuple[int, int]]
             self.end = (sl.line(), sl.column() + 1)  # type: Optional[Tuple[int, int]]

--- a/schema_salad/exceptions.py
+++ b/schema_salad/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Sequence, Optional, Tuple
+from typing import Any, Sequence, Optional, Tuple
 from typing_extensions import Text
 from .sourceline import reflow_all, strip_duplicated_lineno, SourceLine
 
@@ -7,11 +7,15 @@ class SchemaSaladException(Exception):
     """Base class for all schema-salad exceptions."""
 
     def __init__(
-        self, msg, sl=None, children=[], bullet=""
-    ):  # type: (Text, Optional[SourceLine], Sequence[SchemaSaladException], Text) -> None
+        self,
+        msg,  # type: Text
+        sl=None,  # type: Optional[SourceLine]
+        children=None,  # type: Optional[Sequence[SchemaSaladException]]
+        bullet="",  # type: Text
+    ):  # type: (...) -> None
         super(SchemaSaladException, self).__init__(msg)
-        self.children = children
-        self.bullet = bullet if len(children) > 1 else ""
+        self.children = children if children else []
+        self.bullet = bullet if len(self.children) > 1 else ""
         self.with_sourceline(sl)
         self.message = self.args[0]
         self.propagate_sourceline()

--- a/schema_salad/exceptions.py
+++ b/schema_salad/exceptions.py
@@ -1,4 +1,4 @@
-from .sourceline import strip_dup_lineno
+from .sourceline import reflow_all, strip_duplicated_lineno
 
 class SchemaSaladException(Exception):
     """Base class for all schema-salad exceptions."""
@@ -56,8 +56,8 @@ class SchemaSaladException(Exception):
             next_level = level
 
         ret = "\n".join((e for e in [ret, *[c.pretty_str(next_level, self.bullet) for c in self.children]] if len(e)))
-        if level == 0:
-            return strip_dup_lineno(ret)
+        if level == 0 and len(self.message):
+            return strip_duplicated_lineno(reflow_all(ret))
         else:
             return ret
 

--- a/schema_salad/exceptions.py
+++ b/schema_salad/exceptions.py
@@ -46,13 +46,12 @@ class SchemaSaladException(Exception):
         ret = ""
         next_level = level+1
         spaces = (level*indent_per_level)*" "
-        print("MSG: `{}`, level: {}, #spaces: {}".format(self.message, level, (level*indent_per_level)))
         if len(self.message):
             if self.file:
-                ret = "{}:{}:{}:{}{} {}".format(self.file, self.start[0], self.start[1],
-                                                spaces, bullet, self.message)
+                ret = "{}:{}:{}: {}{}{}".format(self.file, self.start[0], self.start[1],
+                                                spaces, bullet+" " if len(bullet) else "", self.message)
             else:
-                ret = "{}{} {}".format(spaces, bullet, self.message)
+                ret = "{}{}{}".format(spaces, bullet+" " if len(bullet) else "", self.message)
         else:
             next_level = level
 

--- a/schema_salad/exceptions.py
+++ b/schema_salad/exceptions.py
@@ -2,10 +2,13 @@ from typing import Any, List, Sequence, Optional, Tuple
 from typing_extensions import Text
 from .sourceline import reflow_all, strip_duplicated_lineno, SourceLine
 
+
 class SchemaSaladException(Exception):
     """Base class for all schema-salad exceptions."""
 
-    def __init__(self, msg, sl = None, children = [], bullet = ""):  # type: (Text, Optional[SourceLine], Sequence[SchemaSaladException], Text) -> None
+    def __init__(
+        self, msg, sl=None, children=[], bullet=""
+    ):  # type: (Text, Optional[SourceLine], Sequence[SchemaSaladException], Text) -> None
         super(SchemaSaladException, self).__init__(msg)
         self.children = children
         self.bullet = bullet if len(children) > 1 else ""
@@ -23,11 +26,13 @@ class SchemaSaladException(Exception):
                 c.end = self.end
                 c.propagate_sourceline()
 
-    def with_sourceline(self, sl):  # type: (Optional[SourceLine]) -> SchemaSaladException
+    def with_sourceline(
+        self, sl
+    ):  # type: (Optional[SourceLine]) -> SchemaSaladException
         if sl:
             self.file = sl.file()  # type: Optional[Text]
             self.start = (sl.line(), sl.column())  # type: Optional[Tuple[int, int]]
-            self.end = (sl.line(), sl.column()+1)  # type: Optional[Tuple[int, int]]
+            self.end = (sl.line(), sl.column() + 1)  # type: Optional[Tuple[int, int]]
         else:
             self.file = None
             self.start = None
@@ -44,20 +49,34 @@ class SchemaSaladException(Exception):
     def __str__(self):  # type: () -> str
         return str(self.pretty_str())
 
-    def pretty_str(self, level=0, bullet = ""):  # type: (int, Text) -> Text
+    def pretty_str(self, level=0, bullet=""):  # type: (int, Text) -> Text
         indent_per_level = 2
         ret = u""
-        next_level = level+1
-        spaces = (level*indent_per_level)*" "
+        next_level = level + 1
+        spaces = (level * indent_per_level) * " "
         if len(self.message):
             if self.file:
-                ret = "{}{}{}{}".format(self.prefix(), spaces, bullet+" " if len(bullet) else "", self.message)
+                ret = "{}{}{}{}".format(
+                    self.prefix(),
+                    spaces,
+                    bullet + " " if len(bullet) else "",
+                    self.message,
+                )
             else:
-                ret = "{}{}{}".format(spaces, bullet+" " if len(bullet) else "", self.message)
+                ret = "{}{}{}".format(
+                    spaces, bullet + " " if len(bullet) else "", self.message
+                )
         else:
             next_level = level
 
-        ret = "\n".join((e for e in [ret]+[c.pretty_str(next_level, self.bullet) for c in self.children] if len(e)))
+        ret = "\n".join(
+            (
+                e
+                for e in [ret]
+                + [c.pretty_str(next_level, self.bullet) for c in self.children]
+                if len(e)
+            )
+        )
         if level == 0 and len(self.message):
             return strip_duplicated_lineno(reflow_all(ret))
         else:

--- a/schema_salad/exceptions.py
+++ b/schema_salad/exceptions.py
@@ -1,7 +1,60 @@
 class SchemaSaladException(Exception):
     """Base class for all schema-salad exceptions."""
 
-    pass
+    def __init__(self, msg, sl = None, children = [], bullet = ""):
+        super(SchemaSaladException, self).__init__(msg)
+        self.children = children
+        self.bullet = bullet if len(children) > 1 else ""
+        self.with_sourceline(sl)
+        self.message = self.args[0]
+        self.propagate_sourceline()
+
+    def propagate_sourceline(self):
+        if self.file is None:
+            return
+        for c in self.children:
+            if c.file is None:
+                c.file = self.file
+                c.start = self.start
+                c.end = self.end
+                c.propagate_sourceline()
+
+    def with_sourceline(self, sl):
+        if sl:
+            self.file = sl.file()
+            self.start = (sl.line(), sl.column())
+            self.end = (sl.line(), sl.column()+1)
+        else:
+            self.file = None
+            self.start = None
+            self.end = None
+        return self
+
+    def prefix(self):
+        if self.file:
+            return "{}:{}:{}:".format(self.file, self.start[0], self.start[1])
+        else:
+            return ""
+
+    def __str__(self):
+        return self.pretty_str()
+
+    def pretty_str(self, level=0, bullet = ""):
+        indent_per_level = 2
+        ret = ""
+        next_level = level+1
+        spaces = (level*indent_per_level)*" "
+        print("MSG: `{}`, level: {}, #spaces: {}".format(self.message, level, (level*indent_per_level)))
+        if len(self.message):
+            if self.file:
+                ret = "{}:{}:{}:{}{} {}".format(self.file, self.start[0], self.start[1],
+                                                spaces, bullet, self.message)
+            else:
+                ret = "{}{} {}".format(spaces, bullet, self.message)
+        else:
+            next_level = level
+
+        return "\n".join((e for e in [ret, *[c.pretty_str(next_level, self.bullet) for c in self.children]] if len(e)))
 
 
 class SchemaException(SchemaSaladException):

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -331,9 +331,8 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
             uri, strict_foreign_properties=args.strict_foreign_properties
         )
     except ValidationException as e:
-        # msg = strip_dup_lineno(six.text_type(e))
-        msg = e.pretty_str()
-        msg = to_one_line_messages(str(msg)) if args.print_oneline else msg
+        msg = six.text_type(e)
+        msg = to_one_line_messages(str(msg)) if args.print_oneline else str(e)
         _logger.error(
             "Document `%s` failed validation:\n%s",
             args.document,
@@ -372,8 +371,7 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
             strict_foreign_properties=args.strict_foreign_properties,
         )
     except ValidationException as e:
-        msg = e.pretty_str()
-        msg = to_one_line_messages(str(msg)) if args.print_oneline else msg
+        msg = to_one_line_messages(str(e)) if args.print_oneline else str(e)
         _logger.error("While validating document `%s`:\n%s" % (args.document, msg))
         return 1
 

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -373,7 +373,7 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
         )
     except ValidationException as e:
         msg = e.pretty_str()
-        msg = to_one_line_messages(msg) if args.print_oneline else msg
+        msg = to_one_line_messages(str(msg)) if args.print_oneline else msg
         _logger.error("While validating document `%s`:\n%s" % (args.document, msg))
         return 1
 

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -331,7 +331,8 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
             uri, strict_foreign_properties=args.strict_foreign_properties
         )
     except ValidationException as e:
-        msg = strip_dup_lineno(six.text_type(e))
+        # msg = strip_dup_lineno(six.text_type(e))
+        msg = e.pretty_str()
         msg = to_one_line_messages(str(msg)) if args.print_oneline else msg
         _logger.error(
             "Document `%s` failed validation:\n%s",
@@ -371,7 +372,8 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
             strict_foreign_properties=args.strict_foreign_properties,
         )
     except ValidationException as e:
-        msg = to_one_line_messages(str(e)) if args.print_oneline else str(e)
+        msg = e.pretty_str()
+        msg = to_one_line_messages(msg) if args.print_oneline else msg
         _logger.error("While validating document `%s`:\n%s" % (args.document, msg))
         return 1
 

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -332,7 +332,7 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
         )
     except ValidationException as e:
         msg = six.text_type(e)
-        msg = to_one_line_messages(str(msg)) if args.print_oneline else str(e)
+        msg = to_one_line_messages(str(msg)) if args.print_oneline else msg
         _logger.error(
             "Document `%s` failed validation:\n%s",
             args.document,

--- a/schema_salad/metaschema.py
+++ b/schema_salad/metaschema.py
@@ -503,7 +503,7 @@ def _document_load(loader, doc, baseuri, loadingOptions):
     if isinstance(doc, MutableSequence):
         return loader.load(doc, baseuri, loadingOptions)
 
-    raise ValidationException()
+    raise ValidationException("Oops, we shouldn't be here!")
 
 
 def _document_load_by_url(loader, url, loadingOptions):

--- a/schema_salad/metaschema.py
+++ b/schema_salad/metaschema.py
@@ -280,7 +280,7 @@ class _ArrayLoader(_Loader):
         if not isinstance(doc, MutableSequence):
             raise ValidationException("Expected a list")
         r = []  # type: List[Any]
-        errors = []
+        errors = []  # type: List[SchemaSaladException]
         for i in range(0, len(doc)):
             try:
                 lf = load_field(
@@ -343,7 +343,8 @@ class _UnionLoader(_Loader):
                 errors.append(
                     ValidationException(
                         u"tried {} but".format(t.__class__.__name__),
-                        None, [e]
+                        None,
+                        [e]
                     )
                 )
         raise ValidationException("", None, errors, u"-")
@@ -633,13 +634,8 @@ A field of a record.
                 name = load_field(_doc.get(
                     'name'), uri_strtype_True_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `name` field is not valid because:",
-                        SourceLine(_doc, 'name', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'name', str).makeError(
+                    "the `name` field is not valid because:\n" + str(e)))
         else:
             name = None
 
@@ -654,26 +650,16 @@ A field of a record.
                 doc = load_field(_doc.get(
                     'doc'), union_of_None_type_or_strtype_or_array_of_strtype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `doc` field is not valid because:",
-                        SourceLine(_doc, 'doc', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'doc', str).makeError(
+                    "the `doc` field is not valid because:\n" + str(e)))
         else:
             doc = None
         try:
             type = load_field(_doc.get(
                 'type'), typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_strtype_2, baseuri, loadingOptions)
         except ValidationException as e:
-            errors.append(
-                ValidationException(
-                    "the `type` field is not valid because:",
-                    SourceLine(_doc, 'type', str),
-                    [e]
-                )
-            )
+            errors.append(SourceLine(_doc, 'type', str).makeError(
+                "the `type` field is not valid because:\n" + str(e)))
 
         extension_fields = yaml.comments.CommentedMap()
         for k in _doc.keys():
@@ -686,16 +672,12 @@ A field of a record.
                                     vocab_term=False)
                     extension_fields[ex] = _doc[k]
                 else:
-                    errors.append(
-                        ValidationException(
-                            "invalid field `%s`, expected one of: `doc`, `name`, `type`" % (k),
-                            SourceLine(_doc, k, str),
-                        )
-                    )
+                    errors.append(SourceLine(_doc, k, str).makeError(
+                        "invalid field `%s`, expected one of: `doc`, `name`, `type`" % (k)))
                     break
 
         if errors:
-            raise ValidationException("Trying 'RecordField'", None, errors)
+            raise ValidationException("Trying 'RecordField'\n" + "\n".join(errors))
         loadingOptions = copy.deepcopy(loadingOptions)
         loadingOptions.original_doc = _doc
         return cls(doc, name, type, extension_fields=extension_fields, loadingOptions=loadingOptions)
@@ -772,26 +754,16 @@ class RecordSchema(Savable):
                 fields = load_field(_doc.get(
                     'fields'), idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `fields` field is not valid because:",
-                        SourceLine(_doc, 'fields', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'fields', str).makeError(
+                    "the `fields` field is not valid because:\n" + str(e)))
         else:
             fields = None
         try:
             type = load_field(_doc.get(
                 'type'), typedsl_enum_d9cba076fca539106791a4f46d198c7fcfbdb779Loader_2, baseuri, loadingOptions)
         except ValidationException as e:
-            errors.append(
-                ValidationException(
-                    "the `type` field is not valid because:",
-                    SourceLine(_doc, 'type', str),
-                    [e]
-                )
-            )
+            errors.append(SourceLine(_doc, 'type', str).makeError(
+                "the `type` field is not valid because:\n" + str(e)))
 
         extension_fields = yaml.comments.CommentedMap()
         for k in _doc.keys():
@@ -804,16 +776,12 @@ class RecordSchema(Savable):
                                     vocab_term=False)
                     extension_fields[ex] = _doc[k]
                 else:
-                    errors.append(
-                        ValidationException(
-                            "invalid field `%s`, expected one of: `fields`, `type`" % (k),
-                            SourceLine(_doc, k, str)
-                        )
-                    )
+                    errors.append(SourceLine(_doc, k, str).makeError(
+                        "invalid field `%s`, expected one of: `fields`, `type`" % (k)))
                     break
 
         if errors:
-            raise ValidationException("Trying 'RecordSchema'", None, errors)
+            raise ValidationException("Trying 'RecordSchema'\n" + "\n".join(errors))
         loadingOptions = copy.deepcopy(loadingOptions)
         loadingOptions.original_doc = _doc
         return cls(fields, type, extension_fields=extension_fields, loadingOptions=loadingOptions)
@@ -883,24 +851,14 @@ Define an enumerated type.
             symbols = load_field(_doc.get(
                 'symbols'), uri_array_of_strtype_True_False_None, baseuri, loadingOptions)
         except ValidationException as e:
-            errors.append(
-                ValidationException(
-                    "the `symbols` field is not valid because:",
-                    SourceLine(_doc, 'symbols', str),
-                    [e]
-                )
-            )
+            errors.append(SourceLine(_doc, 'symbols', str).makeError(
+                "the `symbols` field is not valid because:\n" + str(e)))
         try:
             type = load_field(_doc.get(
                 'type'), typedsl_enum_d961d79c225752b9fadb617367615ab176b47d77Loader_2, baseuri, loadingOptions)
         except ValidationException as e:
-            errors.append(
-                ValidationException(
-                    "the `type` field is not valid because:",
-                    SourceLine(_doc, 'type', str),
-                    [e]
-                )
-            )
+            errors.append(SourceLine(_doc, 'type', str).makeError(
+                "the `type` field is not valid because:\n" + str(e)))
 
         extension_fields = yaml.comments.CommentedMap()
         for k in _doc.keys():
@@ -913,16 +871,12 @@ Define an enumerated type.
                                     vocab_term=False)
                     extension_fields[ex] = _doc[k]
                 else:
-                    errors.append(
-                        ValidationException(
-                            "invalid field `%s`, expected one of: `symbols`, `type`" % (k),
-                            SourceLine(_doc, k, str)
-                        )
-                    )
+                    errors.append(SourceLine(_doc, k, str).makeError(
+                        "invalid field `%s`, expected one of: `symbols`, `type`" % (k)))
                     break
 
         if errors:
-            raise ValidationException("Trying 'EnumSchema'", None, errors)
+            raise ValidationException("Trying 'EnumSchema'\n" + "\n".join(errors))
         loadingOptions = copy.deepcopy(loadingOptions)
         loadingOptions.original_doc = _doc
         return cls(symbols, type, extension_fields=extension_fields, loadingOptions=loadingOptions)
@@ -991,24 +945,14 @@ class ArraySchema(Savable):
             items = load_field(_doc.get(
                 'items'), uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_strtype_False_True_2, baseuri, loadingOptions)
         except ValidationException as e:
-            errors.append(
-                ValidationException(
-                    "the `items` field is not valid because:",
-                    SourceLine(_doc, 'items', str),
-                    [e]
-                )
-            )
+            errors.append(SourceLine(_doc, 'items', str).makeError(
+                "the `items` field is not valid because:\n" + str(e)))
         try:
             type = load_field(_doc.get(
                 'type'), typedsl_enum_d062602be0b4b8fd33e69e29a841317b6ab665bcLoader_2, baseuri, loadingOptions)
         except ValidationException as e:
-            errors.append(
-                ValidationException(
-                    "the `type` field is not valid because:",
-                    SourceLine(_doc, 'type', str),
-                    [e]
-                )
-            )
+            errors.append(SourceLine(_doc, 'type', str).makeError(
+                "the `type` field is not valid because:\n" + str(e)))
 
         extension_fields = yaml.comments.CommentedMap()
         for k in _doc.keys():
@@ -1021,17 +965,12 @@ class ArraySchema(Savable):
                                     vocab_term=False)
                     extension_fields[ex] = _doc[k]
                 else:
-                    errors.append(
-                        ValidationException(
-                            "invalid field `%s`, expected one of: `items`, `type`" % (k),
-                            SourceLine(_doc, k, str)
-                        )
-                    )
+                    errors.append(SourceLine(_doc, k, str).makeError(
+                        "invalid field `%s`, expected one of: `items`, `type`" % (k)))
                     break
 
         if errors:
-            raise ValidationException("Trying 'ArraySchema'",
-                                      None, errors)
+            raise ValidationException("Trying 'ArraySchema'\n" + "\n".join(errors))
         loadingOptions = copy.deepcopy(loadingOptions)
         loadingOptions.original_doc = _doc
         return cls(items, type, extension_fields=extension_fields, loadingOptions=loadingOptions)
@@ -1124,13 +1063,8 @@ URI resolution and JSON-LD context generation.
                 _id = load_field(_doc.get(
                     '_id'), uri_union_of_None_type_or_strtype_True_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `_id` field is not valid because:",
-                        SourceLine(_doc, '_id', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, '_id', str).makeError(
+                    "the `_id` field is not valid because:\n" + str(e)))
         else:
             _id = None
         if '_type' in _doc:
@@ -1138,13 +1072,8 @@ URI resolution and JSON-LD context generation.
                 _type = load_field(_doc.get(
                     '_type'), union_of_None_type_or_strtype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `_type` field is not valid because:",
-                        SourceLine(_doc, '_type', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, '_type', str).makeError(
+                    "the `_type` field is not valid because:\n" + str(e)))
         else:
             _type = None
         if '_container' in _doc:
@@ -1152,13 +1081,8 @@ URI resolution and JSON-LD context generation.
                 _container = load_field(_doc.get(
                     '_container'), union_of_None_type_or_strtype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `_container` field is not valid because:",
-                        SourceLine(_doc, '_container', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, '_container', str).makeError(
+                    "the `_container` field is not valid because:\n" + str(e)))
         else:
             _container = None
         if 'identity' in _doc:
@@ -1166,13 +1090,8 @@ URI resolution and JSON-LD context generation.
                 identity = load_field(_doc.get(
                     'identity'), union_of_None_type_or_booltype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `identity` field is not valid because:",
-                        SourceLine(_doc, 'identity', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'identity', str).makeError(
+                    "the `identity` field is not valid because:\n" + str(e)))
         else:
             identity = None
         if 'noLinkCheck' in _doc:
@@ -1180,13 +1099,8 @@ URI resolution and JSON-LD context generation.
                 noLinkCheck = load_field(_doc.get(
                     'noLinkCheck'), union_of_None_type_or_booltype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `noLinkCheck` field is not valid because:",
-                        SourceLine(_doc, 'noLinkCheck', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'noLinkCheck', str).makeError(
+                    "the `noLinkCheck` field is not valid because:\n" + str(e)))
         else:
             noLinkCheck = None
         if 'mapSubject' in _doc:
@@ -1194,13 +1108,8 @@ URI resolution and JSON-LD context generation.
                 mapSubject = load_field(_doc.get(
                     'mapSubject'), union_of_None_type_or_strtype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `mapSubject` field is not valid because:",
-                        SourceLine(_doc, 'mapSubject', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'mapSubject', str).makeError(
+                    "the `mapSubject` field is not valid because:\n" + str(e)))
         else:
             mapSubject = None
         if 'mapPredicate' in _doc:
@@ -1208,13 +1117,8 @@ URI resolution and JSON-LD context generation.
                 mapPredicate = load_field(_doc.get(
                     'mapPredicate'), union_of_None_type_or_strtype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `mapPredicate` field is not valid because:",
-                        SourceLine(_doc, 'mapPredicate', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'mapPredicate', str).makeError(
+                    "the `mapPredicate` field is not valid because:\n" + str(e)))
         else:
             mapPredicate = None
         if 'refScope' in _doc:
@@ -1222,13 +1126,8 @@ URI resolution and JSON-LD context generation.
                 refScope = load_field(_doc.get(
                     'refScope'), union_of_None_type_or_inttype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `refScope` field is not valid because:",
-                        SourceLine(_doc, 'refScope', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'refScope', str).makeError(
+                    "the `refScope` field is not valid because:\n" + str(e)))
         else:
             refScope = None
         if 'typeDSL' in _doc:
@@ -1236,13 +1135,8 @@ URI resolution and JSON-LD context generation.
                 typeDSL = load_field(_doc.get(
                     'typeDSL'), union_of_None_type_or_booltype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `typeDSL` field is not valid because:",
-                        SourceLine(_doc, 'typeDSL', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'typeDSL', str).makeError(
+                    "the `typeDSL` field is not valid because:\n" + str(e)))
         else:
             typeDSL = None
         if 'secondaryFilesDSL' in _doc:
@@ -1250,13 +1144,8 @@ URI resolution and JSON-LD context generation.
                 secondaryFilesDSL = load_field(_doc.get(
                     'secondaryFilesDSL'), union_of_None_type_or_booltype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `secondaryFilesDSL` field is not valid because:",
-                        SourceLine(_doc, 'secondaryFilesDSL', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'secondaryFilesDSL', str).makeError(
+                    "the `secondaryFilesDSL` field is not valid because:\n" + str(e)))
         else:
             secondaryFilesDSL = None
         if 'subscope' in _doc:
@@ -1264,13 +1153,8 @@ URI resolution and JSON-LD context generation.
                 subscope = load_field(_doc.get(
                     'subscope'), union_of_None_type_or_strtype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `subscope` field is not valid because:",
-                        SourceLine(_doc, 'subscope', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'subscope', str).makeError(
+                    "the `subscope` field is not valid because:\n" + str(e)))
         else:
             subscope = None
 
@@ -1285,17 +1169,12 @@ URI resolution and JSON-LD context generation.
                                     vocab_term=False)
                     extension_fields[ex] = _doc[k]
                 else:
-                    errors.append(
-                        ValidationException(
-                            "invalid field `%s`, expected one of: `_id`, `_type`, `_container`, `identity`, `noLinkCheck`, `mapSubject`, `mapPredicate`, `refScope`, `typeDSL`, `secondaryFilesDSL`, `subscope`" % (k),
-                            SourceLine(_doc, k, str)
-                        )
-                    )
+                    errors.append(SourceLine(_doc, k, str).makeError(
+                        "invalid field `%s`, expected one of: `_id`, `_type`, `_container`, `identity`, `noLinkCheck`, `mapSubject`, `mapPredicate`, `refScope`, `typeDSL`, `secondaryFilesDSL`, `subscope`" % (k)))
                     break
 
         if errors:
-            raise ValidationException("Trying 'JsonldPredicate'",
-                                      None, errors)
+            raise ValidationException("Trying 'JsonldPredicate'\n" + "\n".join(errors))
         loadingOptions = copy.deepcopy(loadingOptions)
         loadingOptions.original_doc = _doc
         return cls(_id, _type, _container, identity, noLinkCheck, mapSubject, mapPredicate, refScope, typeDSL, secondaryFilesDSL, subscope, extension_fields=extension_fields, loadingOptions=loadingOptions)
@@ -1427,24 +1306,14 @@ class SpecializeDef(Savable):
             specializeFrom = load_field(_doc.get(
                 'specializeFrom'), uri_strtype_False_False_1, baseuri, loadingOptions)
         except ValidationException as e:
-            errors.append(
-                ValidationException(
-                    "the `specializeFrom` field is not valid because:",
-                    SourceLine(_doc, 'specializeFrom', str),
-                    [e]
-                )
-            )
+            errors.append(SourceLine(_doc, 'specializeFrom', str).makeError(
+                "the `specializeFrom` field is not valid because:\n" + str(e)))
         try:
             specializeTo = load_field(_doc.get(
                 'specializeTo'), uri_strtype_False_False_1, baseuri, loadingOptions)
         except ValidationException as e:
-            errors.append(
-                ValidationException(
-                    "the `specializeTo` field is not valid because:",
-                    SourceLine(_doc, 'specializeTo', str),
-                    [e]
-                )
-            )
+            errors.append(SourceLine(_doc, 'specializeTo', str).makeError(
+                "the `specializeTo` field is not valid because:\n" + str(e)))
 
         extension_fields = yaml.comments.CommentedMap()
         for k in _doc.keys():
@@ -1457,16 +1326,12 @@ class SpecializeDef(Savable):
                                     vocab_term=False)
                     extension_fields[ex] = _doc[k]
                 else:
-                    errors.append(
-                        ValidationException(
-                            "invalid field `%s`, expected one of: `specializeFrom`, `specializeTo`" % (k),
-                            SourceLine(_doc, k, str),
-                        )
-                    )
+                    errors.append(SourceLine(_doc, k, str).makeError(
+                        "invalid field `%s`, expected one of: `specializeFrom`, `specializeTo`" % (k)))
                     break
 
         if errors:
-            raise ValidationException("Trying 'SpecializeDef'", None, errors)
+            raise ValidationException("Trying 'SpecializeDef'\n" + "\n".join(errors))
         loadingOptions = copy.deepcopy(loadingOptions)
         loadingOptions.original_doc = _doc
         return cls(specializeFrom, specializeTo, extension_fields=extension_fields, loadingOptions=loadingOptions)
@@ -1564,13 +1429,8 @@ A field of a record.
                 name = load_field(_doc.get(
                     'name'), uri_strtype_True_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `name` field is not valid because:",
-                        SourceLine(_doc, 'name', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'name', str).makeError(
+                    "the `name` field is not valid because:\n" + str(e)))
         else:
             name = None
 
@@ -1585,38 +1445,23 @@ A field of a record.
                 doc = load_field(_doc.get(
                     'doc'), union_of_None_type_or_strtype_or_array_of_strtype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `doc` field is not valid because:",
-                        SourceLine(_doc, 'doc', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'doc', str).makeError(
+                    "the `doc` field is not valid because:\n" + str(e)))
         else:
             doc = None
         try:
             type = load_field(_doc.get(
                 'type'), typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_strtype_2, baseuri, loadingOptions)
         except ValidationException as e:
-            errors.append(
-                ValidationException(
-                    "the `type` field is not valid because:",
-                    SourceLine(_doc, 'type', str),
-                    [e]
-                )
-            )
+            errors.append(SourceLine(_doc, 'type', str).makeError(
+                "the `type` field is not valid because:\n" + str(e)))
         if 'jsonldPredicate' in _doc:
             try:
                 jsonldPredicate = load_field(_doc.get(
                     'jsonldPredicate'), union_of_None_type_or_strtype_or_JsonldPredicateLoader, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `jsonldPredicate` field is not valid because:",
-                        SourceLine(_doc, 'jsonldPredicate', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'jsonldPredicate', str).makeError(
+                    "the `jsonldPredicate` field is not valid because:\n" + str(e)))
         else:
             jsonldPredicate = None
         if 'default' in _doc:
@@ -1624,13 +1469,8 @@ A field of a record.
                 default = load_field(_doc.get(
                     'default'), union_of_None_type_or_Any_type, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `default` field is not valid because:",
-                        SourceLine(_doc, 'default', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'default', str).makeError(
+                    "the `default` field is not valid because:\n" + str(e)))
         else:
             default = None
 
@@ -1645,16 +1485,12 @@ A field of a record.
                                     vocab_term=False)
                     extension_fields[ex] = _doc[k]
                 else:
-                    errors.append(
-                        ValidationException(
-                            "invalid field `%s`, expected one of: `doc`, `name`, `type`, `jsonldPredicate`, `default`" % (k),
-                            SourceLine(_doc, k, str)
-                        )
-                    )
+                    errors.append(SourceLine(_doc, k, str).makeError(
+                        "invalid field `%s`, expected one of: `doc`, `name`, `type`, `jsonldPredicate`, `default`" % (k)))
                     break
 
         if errors:
-            raise ValidationException("Trying 'SaladRecordField'", None, errors)
+            raise ValidationException("Trying 'SaladRecordField'\n" + "\n".join(errors))
         loadingOptions = copy.deepcopy(loadingOptions)
         loadingOptions.original_doc = _doc
         return cls(doc, name, type, jsonldPredicate, default, extension_fields=extension_fields, loadingOptions=loadingOptions)
@@ -1767,13 +1603,8 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                 name = load_field(_doc.get(
                     'name'), uri_strtype_True_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `name` field is not valid because:",
-                        SourceLine(_doc, 'name', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'name', str).makeError(
+                    "the `name` field is not valid because:\n" + str(e)))
         else:
             name = None
 
@@ -1788,13 +1619,8 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                 inVocab = load_field(_doc.get(
                     'inVocab'), union_of_None_type_or_booltype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `inVocab` field is not valid because:",
-                        SourceLine(_doc, 'inVocab', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'inVocab', str).makeError(
+                    "the `inVocab` field is not valid because:\n" + str(e)))
         else:
             inVocab = None
         if 'fields' in _doc:
@@ -1802,38 +1628,23 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                 fields = load_field(_doc.get(
                     'fields'), idmap_fields_union_of_None_type_or_array_of_SaladRecordFieldLoader, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `fields` field is not valid because:",
-                        SourceLine(_doc, 'fields', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'fields', str).makeError(
+                    "the `fields` field is not valid because:\n" + str(e)))
         else:
             fields = None
         try:
             type = load_field(_doc.get(
                 'type'), typedsl_enum_d9cba076fca539106791a4f46d198c7fcfbdb779Loader_2, baseuri, loadingOptions)
         except ValidationException as e:
-            errors.append(
-                ValidationException(
-                    "the `type` field is not valid because:",
-                    SourceLine(_doc, 'type', str),
-                    [e]
-                )
-            )
+            errors.append(SourceLine(_doc, 'type', str).makeError(
+                "the `type` field is not valid because:\n" + str(e)))
         if 'doc' in _doc:
             try:
                 doc = load_field(_doc.get(
                     'doc'), union_of_None_type_or_strtype_or_array_of_strtype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `doc` field is not valid because:",
-                        SourceLine(_doc, 'doc', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'doc', str).makeError(
+                    "the `doc` field is not valid because:\n" + str(e)))
         else:
             doc = None
         if 'docParent' in _doc:
@@ -1841,13 +1652,8 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                 docParent = load_field(_doc.get(
                     'docParent'), uri_union_of_None_type_or_strtype_False_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `docParent` field is not valid because:",
-                        SourceLine(_doc, 'docParent', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'docParent', str).makeError(
+                    "the `docParent` field is not valid because:\n" + str(e)))
         else:
             docParent = None
         if 'docChild' in _doc:
@@ -1855,13 +1661,8 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                 docChild = load_field(_doc.get(
                     'docChild'), uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `docChild` field is not valid because:",
-                        SourceLine(_doc, 'docChild', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'docChild', str).makeError(
+                    "the `docChild` field is not valid because:\n" + str(e)))
         else:
             docChild = None
         if 'docAfter' in _doc:
@@ -1869,13 +1670,8 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                 docAfter = load_field(_doc.get(
                     'docAfter'), uri_union_of_None_type_or_strtype_False_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `docAfter` field is not valid because:",
-                        SourceLine(_doc, 'docAfter', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'docAfter', str).makeError(
+                    "the `docAfter` field is not valid because:\n" + str(e)))
         else:
             docAfter = None
         if 'jsonldPredicate' in _doc:
@@ -1883,13 +1679,8 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                 jsonldPredicate = load_field(_doc.get(
                     'jsonldPredicate'), union_of_None_type_or_strtype_or_JsonldPredicateLoader, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `jsonldPredicate` field is not valid because:",
-                        SourceLine(_doc, 'jsonldPredicate', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'jsonldPredicate', str).makeError(
+                    "the `jsonldPredicate` field is not valid because:\n" + str(e)))
         else:
             jsonldPredicate = None
         if 'documentRoot' in _doc:
@@ -1897,13 +1688,8 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                 documentRoot = load_field(_doc.get(
                     'documentRoot'), union_of_None_type_or_booltype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `documentRoot` field is not valid because:",
-                        SourceLine(_doc, 'documentRoot', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'documentRoot', str).makeError(
+                    "the `documentRoot` field is not valid because:\n" + str(e)))
         else:
             documentRoot = None
         if 'abstract' in _doc:
@@ -1911,13 +1697,8 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                 abstract = load_field(_doc.get(
                     'abstract'), union_of_None_type_or_booltype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `abstract` field is not valid because:",
-                        SourceLine(_doc, 'abstract', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'abstract', str).makeError(
+                    "the `abstract` field is not valid because:\n" + str(e)))
         else:
             abstract = None
         if 'extends' in _doc:
@@ -1925,13 +1706,8 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                 extends = load_field(_doc.get(
                     'extends'), uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `extends` field is not valid because:",
-                        SourceLine(_doc, 'extends', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'extends', str).makeError(
+                    "the `extends` field is not valid because:\n" + str(e)))
         else:
             extends = None
         if 'specialize' in _doc:
@@ -1939,13 +1715,8 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                 specialize = load_field(_doc.get(
                     'specialize'), idmap_specialize_union_of_None_type_or_array_of_SpecializeDefLoader, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `specialize` field is not valid because:",
-                        SourceLine(_doc, 'specialize', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'specialize', str).makeError(
+                    "the `specialize` field is not valid because:\n" + str(e)))
         else:
             specialize = None
 
@@ -1960,16 +1731,12 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                                     vocab_term=False)
                     extension_fields[ex] = _doc[k]
                 else:
-                    errors.append(
-                        ValidationException(
-                            "invalid field `%s`, expected one of: `name`, `inVocab`, `fields`, `type`, `doc`, `docParent`, `docChild`, `docAfter`, `jsonldPredicate`, `documentRoot`, `abstract`, `extends`, `specialize`" % (k),
-                            SourceLine(_doc, k, str)
-                        )
-                    )
+                    errors.append(SourceLine(_doc, k, str).makeError(
+                        "invalid field `%s`, expected one of: `name`, `inVocab`, `fields`, `type`, `doc`, `docParent`, `docChild`, `docAfter`, `jsonldPredicate`, `documentRoot`, `abstract`, `extends`, `specialize`" % (k)))
                     break
 
         if errors:
-            raise ValidationException("Trying 'SaladRecordSchema'", None, errors)
+            raise ValidationException("Trying 'SaladRecordSchema'\n" + "\n".join(errors))
         loadingOptions = copy.deepcopy(loadingOptions)
         loadingOptions.original_doc = _doc
         return cls(name, inVocab, fields, type, doc, docParent, docChild, docAfter, jsonldPredicate, documentRoot, abstract, extends, specialize, extension_fields=extension_fields, loadingOptions=loadingOptions)
@@ -2150,13 +1917,8 @@ Define an enumerated type.
                 name = load_field(_doc.get(
                     'name'), uri_strtype_True_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `name` field is not valid because:",
-                        SourceLine(_doc, 'name', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'name', str).makeError(
+                    "the `name` field is not valid because:\n" + str(e)))
         else:
             name = None
 
@@ -2171,49 +1933,29 @@ Define an enumerated type.
                 inVocab = load_field(_doc.get(
                     'inVocab'), union_of_None_type_or_booltype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `inVocab` field is not valid because:",
-                        SourceLine(_doc, 'inVocab', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'inVocab', str).makeError(
+                    "the `inVocab` field is not valid because:\n" + str(e)))
         else:
             inVocab = None
         try:
             symbols = load_field(_doc.get(
                 'symbols'), uri_array_of_strtype_True_False_None, baseuri, loadingOptions)
         except ValidationException as e:
-            errors.append(
-                ValidationException(
-                    "the `symbols` field is not valid because:",
-                    SourceLine(_doc, 'symbols', str),
-                    [e]
-                )
-            )
+            errors.append(SourceLine(_doc, 'symbols', str).makeError(
+                "the `symbols` field is not valid because:\n" + str(e)))
         try:
             type = load_field(_doc.get(
                 'type'), typedsl_enum_d961d79c225752b9fadb617367615ab176b47d77Loader_2, baseuri, loadingOptions)
         except ValidationException as e:
-            errors.append(
-                ValidationException(
-                    "the `type` field is not valid because:",
-                    SourceLine(_doc, 'type', str),
-                    [e]
-                )
-            )
+            errors.append(SourceLine(_doc, 'type', str).makeError(
+                "the `type` field is not valid because:\n" + str(e)))
         if 'doc' in _doc:
             try:
                 doc = load_field(_doc.get(
                     'doc'), union_of_None_type_or_strtype_or_array_of_strtype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `doc` field is not valid because:",
-                        SourceLine(_doc, 'doc', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'doc', str).makeError(
+                    "the `doc` field is not valid because:\n" + str(e)))
         else:
             doc = None
         if 'docParent' in _doc:
@@ -2221,13 +1963,8 @@ Define an enumerated type.
                 docParent = load_field(_doc.get(
                     'docParent'), uri_union_of_None_type_or_strtype_False_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `docParent` field is not valid because:",
-                        SourceLine(_doc, 'docParent', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'docParent', str).makeError(
+                    "the `docParent` field is not valid because:\n" + str(e)))
         else:
             docParent = None
         if 'docChild' in _doc:
@@ -2235,13 +1972,8 @@ Define an enumerated type.
                 docChild = load_field(_doc.get(
                     'docChild'), uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `docChild` field is not valid because:",
-                        SourceLine(_doc, 'docChild', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'docChild', str).makeError(
+                    "the `docChild` field is not valid because:\n" + str(e)))
         else:
             docChild = None
         if 'docAfter' in _doc:
@@ -2249,13 +1981,8 @@ Define an enumerated type.
                 docAfter = load_field(_doc.get(
                     'docAfter'), uri_union_of_None_type_or_strtype_False_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `docAfter` field is not valid because:",
-                        SourceLine(_doc, 'docAfter', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'docAfter', str).makeError(
+                    "the `docAfter` field is not valid because:\n" + str(e)))
         else:
             docAfter = None
         if 'jsonldPredicate' in _doc:
@@ -2263,13 +1990,8 @@ Define an enumerated type.
                 jsonldPredicate = load_field(_doc.get(
                     'jsonldPredicate'), union_of_None_type_or_strtype_or_JsonldPredicateLoader, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `jsonldPredicate` field is not valid because:",
-                        SourceLine(_doc, 'jsonldPredicate', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'jsonldPredicate', str).makeError(
+                    "the `jsonldPredicate` field is not valid because:\n" + str(e)))
         else:
             jsonldPredicate = None
         if 'documentRoot' in _doc:
@@ -2277,13 +1999,8 @@ Define an enumerated type.
                 documentRoot = load_field(_doc.get(
                     'documentRoot'), union_of_None_type_or_booltype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `documentRoot` field is not valid because:",
-                        SourceLine(_doc, 'documentRoot', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'documentRoot', str).makeError(
+                    "the `documentRoot` field is not valid because:\n" + str(e)))
         else:
             documentRoot = None
         if 'extends' in _doc:
@@ -2291,13 +2008,8 @@ Define an enumerated type.
                 extends = load_field(_doc.get(
                     'extends'), uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `extends` field is not valid because:",
-                        SourceLine(_doc, 'extends', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'extends', str).makeError(
+                    "the `extends` field is not valid because:\n" + str(e)))
         else:
             extends = None
 
@@ -2312,16 +2024,12 @@ Define an enumerated type.
                                     vocab_term=False)
                     extension_fields[ex] = _doc[k]
                 else:
-                    errors.append(
-                        ValidationException(
-                            "invalid field `%s`, expected one of: `name`, `inVocab`, `symbols`, `type`, `doc`, `docParent`, `docChild`, `docAfter`, `jsonldPredicate`, `documentRoot`, `extends`" % (k),
-                            SourceLine(_doc, k, str)
-                        )
-                    )
+                    errors.append(SourceLine(_doc, k, str).makeError(
+                        "invalid field `%s`, expected one of: `name`, `inVocab`, `symbols`, `type`, `doc`, `docParent`, `docChild`, `docAfter`, `jsonldPredicate`, `documentRoot`, `extends`" % (k)))
                     break
 
         if errors:
-            raise ValidationException("Trying 'SaladEnumSchema'", None, errors)
+            raise ValidationException("Trying 'SaladEnumSchema'\n" + "\n".join(errors))
         loadingOptions = copy.deepcopy(loadingOptions)
         loadingOptions.original_doc = _doc
         return cls(name, inVocab, symbols, type, doc, docParent, docChild, docAfter, jsonldPredicate, documentRoot, extends, extension_fields=extension_fields, loadingOptions=loadingOptions)
@@ -2484,13 +2192,8 @@ schemas but has no role in formal validation.
                 name = load_field(_doc.get(
                     'name'), uri_strtype_True_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `name` field is not valid because:",
-                        SourceLine(_doc, 'name', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'name', str).makeError(
+                    "the `name` field is not valid because:\n" + str(e)))
         else:
             name = None
 
@@ -2505,13 +2208,8 @@ schemas but has no role in formal validation.
                 inVocab = load_field(_doc.get(
                     'inVocab'), union_of_None_type_or_booltype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `inVocab` field is not valid because:",
-                        SourceLine(_doc, 'inVocab', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'inVocab', str).makeError(
+                    "the `inVocab` field is not valid because:\n" + str(e)))
         else:
             inVocab = None
         if 'doc' in _doc:
@@ -2519,13 +2217,8 @@ schemas but has no role in formal validation.
                 doc = load_field(_doc.get(
                     'doc'), union_of_None_type_or_strtype_or_array_of_strtype, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `doc` field is not valid because:",
-                        SourceLine(_doc, 'doc', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'doc', str).makeError(
+                    "the `doc` field is not valid because:\n" + str(e)))
         else:
             doc = None
         if 'docParent' in _doc:
@@ -2533,13 +2226,8 @@ schemas but has no role in formal validation.
                 docParent = load_field(_doc.get(
                     'docParent'), uri_union_of_None_type_or_strtype_False_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `docParent` field is not valid because:",
-                        SourceLine(_doc, 'docParent', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'docParent', str).makeError(
+                    "the `docParent` field is not valid because:\n" + str(e)))
         else:
             docParent = None
         if 'docChild' in _doc:
@@ -2547,13 +2235,8 @@ schemas but has no role in formal validation.
                 docChild = load_field(_doc.get(
                     'docChild'), uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `docChild` field is not valid because:",
-                        SourceLine(_doc, 'docChild', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'docChild', str).makeError(
+                    "the `docChild` field is not valid because:\n" + str(e)))
         else:
             docChild = None
         if 'docAfter' in _doc:
@@ -2561,26 +2244,16 @@ schemas but has no role in formal validation.
                 docAfter = load_field(_doc.get(
                     'docAfter'), uri_union_of_None_type_or_strtype_False_False_None, baseuri, loadingOptions)
             except ValidationException as e:
-                errors.append(
-                    ValidationException(
-                        "the `docAfter` field is not valid because:",
-                        SourceLine(_doc, 'docAfter', str),
-                        [e]
-                    )
-                )
+                errors.append(SourceLine(_doc, 'docAfter', str).makeError(
+                    "the `docAfter` field is not valid because:\n" + str(e)))
         else:
             docAfter = None
         try:
             type = load_field(_doc.get(
                 'type'), typedsl_enum_056429f0e9355680bd9b2411dc96a69c7ff2e76bLoader_2, baseuri, loadingOptions)
         except ValidationException as e:
-            errors.append(
-                ValidationException(
-                    "the `type` field is not valid because:",
-                    SourceLine(_doc, 'type', str),
-                    [e]
-                )
-            )
+            errors.append(SourceLine(_doc, 'type', str).makeError(
+                "the `type` field is not valid because:\n" + str(e)))
 
         extension_fields = yaml.comments.CommentedMap()
         for k in _doc.keys():
@@ -2593,16 +2266,12 @@ schemas but has no role in formal validation.
                                     vocab_term=False)
                     extension_fields[ex] = _doc[k]
                 else:
-                    errors.append(
-                        ValidationException(
-                            "invalid field `%s`, expected one of: `name`, `inVocab`, `doc`, `docParent`, `docChild`, `docAfter`, `type`" % (k),
-                            SourceLine(_doc, k, str)
-                        )
-                    )
+                    errors.append(SourceLine(_doc, k, str).makeError(
+                        "invalid field `%s`, expected one of: `name`, `inVocab`, `doc`, `docParent`, `docChild`, `docAfter`, `type`" % (k)))
                     break
 
         if errors:
-            raise ValidationException("Trying 'Documentation'", None, errors)
+            raise ValidationException("Trying 'Documentation'\n" + "\n".join(errors))
         loadingOptions = copy.deepcopy(loadingOptions)
         loadingOptions.original_doc = _doc
         return cls(name, inVocab, doc, docParent, docChild, docAfter, type, extension_fields=extension_fields, loadingOptions=loadingOptions)

--- a/schema_salad/metaschema.py
+++ b/schema_salad/metaschema.py
@@ -27,7 +27,7 @@ from typing_extensions import Text  # pylint: disable=unused-import
 from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap
 from schema_salad.ref_resolver import Fetcher
-from schema_salad.sourceline import SourceLine, add_lc_filename, bullets, indent
+from schema_salad.sourceline import SourceLine, add_lc_filename
 from schema_salad.exceptions import SchemaSaladException, ValidationException
 
 # move to a regular typing import when Python 3.3-3.6 is no longer supported

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -337,9 +337,7 @@ class _UnionLoader(_Loader):
             except ValidationException as e:
                 errors.append(
                     ValidationException(
-                        u"tried {} but".format(t.__class__.__name__),
-                        None,
-                        [e]
+                        u"tried {} but".format(t.__class__.__name__), None, [e]
                     )
                 )
         raise ValidationException("", None, errors, u"-")

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -275,7 +275,7 @@ class _ArrayLoader(_Loader):
         if not isinstance(doc, MutableSequence):
             raise ValidationException("Expected a list")
         r = []  # type: List[Any]
-        errors = []
+        errors = []  # type: List[SchemaSaladException]
         for i in range(0, len(doc)):
             try:
                 lf = load_field(
@@ -286,7 +286,7 @@ class _ArrayLoader(_Loader):
                 else:
                     r.append(lf)
             except ValidationException as e:
-                errors.apppend(e.with_sourceline(SourceLine(doc, i, str)))
+                errors.append(e.with_sourceline(SourceLine(doc, i, str)))
         if errors:
             raise ValidationException("", None, errors)
         return r

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -22,7 +22,7 @@ from typing_extensions import Text  # pylint: disable=unused-import
 from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap
 from schema_salad.ref_resolver import Fetcher
-from schema_salad.sourceline import SourceLine, add_lc_filename, bullets, indent
+from schema_salad.sourceline import SourceLine, add_lc_filename
 from schema_salad.exceptions import SchemaSaladException, ValidationException
 
 # move to a regular typing import when Python 3.3-3.6 is no longer supported

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -286,9 +286,9 @@ class _ArrayLoader(_Loader):
                 else:
                     r.append(lf)
             except ValidationException as e:
-                errors.append(SourceLine(doc, i, str).makeError(text_type(e)))
+                errors.apppend(e.with_sourceline(SourceLine(doc, i, str)))
         if errors:
-            raise ValidationException("\n".join(errors))
+            raise ValidationException("", None, errors)
         return r
 
     def __repr__(self):  # type: () -> str
@@ -336,9 +336,13 @@ class _UnionLoader(_Loader):
                 return t.load(doc, baseuri, loadingOptions, docRoot=docRoot)
             except ValidationException as e:
                 errors.append(
-                    u"tried {} but\n{}".format(t.__class__.__name__, indent(str(e)))
+                    ValidationException(
+                        u"tried {} but".format(t.__class__.__name__),
+                        None,
+                        [e]
+                    )
                 )
-        raise ValidationException(bullets(errors, u"- "))
+        raise ValidationException("", None, errors, u"-")
 
     def __repr__(self):  # type: () -> str
         return " | ".join(str(a) for a in self.alternates)

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -498,7 +498,7 @@ def _document_load(loader, doc, baseuri, loadingOptions):
     if isinstance(doc, MutableSequence):
         return loader.load(doc, baseuri, loadingOptions)
 
-    raise ValidationException()
+    raise ValidationException("Oops, we shouldn't be here!")
 
 
 def _document_load_by_url(loader, url, loadingOptions):

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -1318,12 +1318,16 @@ class Loader(object):
                             d, document[d], docid, all_doc_ids
                         )
                 except (ValidationException, ValueError) as v:
+                    if isinstance(v, ValueError):
+                        v = ValidationException(str(v), sl)
+                    else:
+                        v = v.with_sourceline(sl)
                     if d == "$schemas" or (
                         d in self.foreign_properties and not strict_foreign_properties
                     ):
-                        _logger.warning(v.with_sourceline(sl).pretty_str())
+                        _logger.warning(v.pretty_str())
                     else:
-                        errors.append(v.with_sourceline(sl))
+                        errors.append(v)
             # TODO: Validator should local scope only in which
             # duplicated keys are prohibited.
             # See also https://github.com/common-workflow-language/common-workflow-language/issues/734  # noqa: B950

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -37,7 +37,7 @@ from typing_extensions import Text  # pylint: disable=unused-import
 from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, LineCol
 
-from .exceptions import ValidationException
+from .exceptions import ValidationException, SchemaSaladException
 from .sourceline import SourceLine, add_lc_filename, indent, relname, strip_dup_lineno
 from .utils import aslist, onWindows
 
@@ -1305,7 +1305,7 @@ class Loader(object):
         if not docid:
             docid = base_url
 
-        errors = []  # type: List[Text]
+        errors = []  # type: List[SchemaSaladException]
         iterator = None  # type: Any
         if isinstance(document, MutableSequence):
             iterator = enumerate(document)
@@ -1317,11 +1317,8 @@ class Loader(object):
                         document[d] = self.validate_link(
                             d, document[d], docid, all_doc_ids
                         )
-                except (ValidationException, ValueError) as v:
-                    if isinstance(v, ValueError):
-                        v = ValidationException(str(v), sl)
-                    else:
-                        v = v.with_sourceline(sl)
+                except (ValidationException, ValueError) as v_:
+                    v = ValidationException(str(v_), sl) if isinstance(v_, ValueError) else v_.with_sourceline(sl)
                     if d == "$schemas" or (
                         d in self.foreign_properties and not strict_foreign_properties
                     ):

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -38,7 +38,7 @@ from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, LineCol
 
 from .exceptions import ValidationException, SchemaSaladException
-from .sourceline import SourceLine, add_lc_filename, indent, relname, strip_dup_lineno
+from .sourceline import SourceLine, add_lc_filename, relname
 from .utils import aslist, onWindows
 
 # move to a regular typing import when Python 3.3-3.6 is no longer supported

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -1330,7 +1330,7 @@ class Loader(object):
                     if d == "$schemas" or (
                         d in self.foreign_properties and not strict_foreign_properties
                     ):
-                        _logger.warning(v.pretty_str())
+                        _logger.warning(v)
                     else:
                         errors.append(v)
             # TODO: Validator should local scope only in which
@@ -1380,7 +1380,7 @@ class Loader(object):
                 if key in self.nolinkcheck or (
                     isinstance(key, string_types) and ":" in key
                 ):
-                    _logger.warning(v.pretty_str())
+                    _logger.warning(v)
                 else:
                     docid2 = self.getid(val)
                     if docid2 is not None:

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -1113,8 +1113,10 @@ class Loader(object):
                 raise_from(
                     ValidationException(
                         "({}) ({}) Validation error in field {}:".format(
-                            id(loader), file_base, key),
-                        None, [v]
+                            id(loader), file_base, key
+                        ),
+                        None,
+                        [v],
                     ),
                     v,
                 )
@@ -1160,7 +1162,9 @@ class Loader(object):
                     ValidationException(
                         "({}) ({}) Validation error in position {}:".format(
                             id(loader), file_base, i
-                        ), None, [v]
+                        ),
+                        None,
+                        [v],
                     ),
                     v,
                 )
@@ -1318,7 +1322,11 @@ class Loader(object):
                             d, document[d], docid, all_doc_ids
                         )
                 except (ValidationException, ValueError) as v_:
-                    v = ValidationException(str(v_), sl) if isinstance(v_, ValueError) else v_.with_sourceline(sl)
+                    v = (
+                        ValidationException(str(v_), sl)
+                        if isinstance(v_, ValueError)
+                        else v_.with_sourceline(sl)
+                    )
                     if d == "$schemas" or (
                         d in self.foreign_properties and not strict_foreign_properties
                     ):
@@ -1376,12 +1384,18 @@ class Loader(object):
                 else:
                     docid2 = self.getid(val)
                     if docid2 is not None:
-                        errors.append(ValidationException("checking object `{}`".format(relname(docid2)),
-                                                          sl, [v]))
+                        errors.append(
+                            ValidationException(
+                                "checking object `{}`".format(relname(docid2)), sl, [v]
+                            )
+                        )
                     else:
                         if isinstance(key, string_types):
-                            errors.append(ValidationException("checking field `{}`".format(key),
-                                                              sl, [v]))
+                            errors.append(
+                                ValidationException(
+                                    "checking field `{}`".format(key), sl, [v]
+                                )
+                            )
                         else:
                             errors.append(ValidationException("checking item", sl, [v]))
         if bool(errors):

--- a/schema_salad/schema.py
+++ b/schema_salad/schema.py
@@ -376,11 +376,6 @@ def validate_doc(
                         ClassValidationException(
                             "tried `{}` but".format(name), sourceline, [exc]
                         )
-                        # sourceline.makeError(
-                        #     u"tried `{}` but\n{}".format(
-                        #         name, indent(str(exc), nolead=False)
-                        #     )
-                        # )
                     ]
                     break
                 except ValidationException as exc:
@@ -388,29 +383,18 @@ def validate_doc(
                         ValidationException(
                             "tried `{}` but".format(name), sourceline, [exc]
                         )
-                        # sourceline.makeError(
-                        #     u"tried `{}` but\n{}".format(
-                        #         name, indent(str(exc), nolead=False)
-                        #     )
-                        # )
                     )
 
-            # objerr = sourceline.makeError(u"Invalid")
             objerr = u"Invalid"
             for ident in loader.identifiers:
                 if ident in item:
                     objerr = u"Object `{}` is not valid because".format(
                         relname(item[ident])
                     )
-                    # objerr = sourceline.makeError(
-                    #     u"Object `{}` is not valid because".format(relname(item[ident]))
-                    # )
                     break
             anyerrors.append(ValidationException(objerr, sourceline, errors, "-"))
-            # anyerrors.append(u"{}\n{}".format(objerr, indent(bullets(errors, "- "))))
     if anyerrors:
         raise ValidationException("", None, anyerrors, "*")
-        # raise ValidationException(strip_dup_lineno(bullets(anyerrors, "* ")))
 
 
 def get_anon_name(rec):

--- a/schema_salad/schema.py
+++ b/schema_salad/schema.py
@@ -376,32 +376,38 @@ def validate_doc(
                     )
                 except ClassValidationException as exc:
                     errors = [
-                        sourceline.makeError(
-                            u"tried `{}` but\n{}".format(
-                                name, indent(str(exc), nolead=False)
-                            )
-                        )
+                        ClassValidationException("tried `{}` but".format(name), sourceline, [exc])
+                        # sourceline.makeError(
+                        #     u"tried `{}` but\n{}".format(
+                        #         name, indent(str(exc), nolead=False)
+                        #     )
+                        # )
                     ]
                     break
                 except ValidationException as exc:
                     errors.append(
-                        sourceline.makeError(
-                            u"tried `{}` but\n{}".format(
-                                name, indent(str(exc), nolead=False)
-                            )
-                        )
+                        ValidationException("tried `{}` but".format(name), sourceline, [exc])
+                        # sourceline.makeError(
+                        #     u"tried `{}` but\n{}".format(
+                        #         name, indent(str(exc), nolead=False)
+                        #     )
+                        # )
                     )
 
-            objerr = sourceline.makeError(u"Invalid")
+            # objerr = sourceline.makeError(u"Invalid")
+            objerr = u"Invalid"
             for ident in loader.identifiers:
                 if ident in item:
-                    objerr = sourceline.makeError(
-                        u"Object `{}` is not valid because".format(relname(item[ident]))
-                    )
+                    objerr = u"Object `{}` is not valid because".format(relname(item[ident]))
+                    # objerr = sourceline.makeError(
+                    #     u"Object `{}` is not valid because".format(relname(item[ident]))
+                    # )
                     break
-            anyerrors.append(u"{}\n{}".format(objerr, indent(bullets(errors, "- "))))
+            anyerrors.append(ValidationException(objerr, sourceline, errors, "-"))
+            # anyerrors.append(u"{}\n{}".format(objerr, indent(bullets(errors, "- "))))
     if anyerrors:
-        raise ValidationException(strip_dup_lineno(bullets(anyerrors, "* ")))
+        raise ValidationException("", None, anyerrors, "*")
+        # raise ValidationException(strip_dup_lineno(bullets(anyerrors, "* ")))
 
 
 def get_anon_name(rec):

--- a/schema_salad/schema.py
+++ b/schema_salad/schema.py
@@ -43,14 +43,7 @@ from .exceptions import (
 )
 from .avro.schema import Names, SchemaParseException, make_avsc_object
 from .ref_resolver import Loader
-from .sourceline import (
-    SourceLine,
-    add_lc_filename,
-    bullets,
-    indent,
-    relname,
-    strip_dup_lineno,
-)
+from .sourceline import SourceLine, add_lc_filename, relname, strip_dup_lineno
 
 SALAD_FILES = (
     "metaschema.yml",

--- a/schema_salad/schema.py
+++ b/schema_salad/schema.py
@@ -36,7 +36,11 @@ from schema_salad.utils import (
 )
 
 from . import _logger, jsonld_context, ref_resolver, validate
-from .exceptions import ClassValidationException, ValidationException, SchemaSaladException
+from .exceptions import (
+    ClassValidationException,
+    ValidationException,
+    SchemaSaladException,
+)
 from .avro.schema import Names, SchemaParseException, make_avsc_object
 from .ref_resolver import Loader
 from .sourceline import (
@@ -376,7 +380,9 @@ def validate_doc(
                     )
                 except ClassValidationException as exc:
                     errors = [
-                        ClassValidationException("tried `{}` but".format(name), sourceline, [exc])
+                        ClassValidationException(
+                            "tried `{}` but".format(name), sourceline, [exc]
+                        )
                         # sourceline.makeError(
                         #     u"tried `{}` but\n{}".format(
                         #         name, indent(str(exc), nolead=False)
@@ -386,7 +392,9 @@ def validate_doc(
                     break
                 except ValidationException as exc:
                     errors.append(
-                        ValidationException("tried `{}` but".format(name), sourceline, [exc])
+                        ValidationException(
+                            "tried `{}` but".format(name), sourceline, [exc]
+                        )
                         # sourceline.makeError(
                         #     u"tried `{}` but\n{}".format(
                         #         name, indent(str(exc), nolead=False)
@@ -398,7 +406,9 @@ def validate_doc(
             objerr = u"Invalid"
             for ident in loader.identifiers:
                 if ident in item:
-                    objerr = u"Object `{}` is not valid because".format(relname(item[ident]))
+                    objerr = u"Object `{}` is not valid because".format(
+                        relname(item[ident])
+                    )
                     # objerr = sourceline.makeError(
                     #     u"Object `{}` is not valid because".format(relname(item[ident]))
                     # )

--- a/schema_salad/schema.py
+++ b/schema_salad/schema.py
@@ -36,7 +36,7 @@ from schema_salad.utils import (
 )
 
 from . import _logger, jsonld_context, ref_resolver, validate
-from .exceptions import ClassValidationException, ValidationException
+from .exceptions import ClassValidationException, ValidationException, SchemaSaladException
 from .avro.schema import Names, SchemaParseException, make_avsc_object
 from .ref_resolver import Loader
 from .sourceline import (
@@ -356,7 +356,7 @@ def validate_doc(
                 break
 
         if not success:
-            errors = []  # type: List[Text]
+            errors = []  # type: List[SchemaSaladException]
             for root in roots:
                 if hasattr(root, "get_prop"):
                     name = root.get_prop(u"name")

--- a/schema_salad/sourceline.py
+++ b/schema_salad/sourceline.py
@@ -336,7 +336,7 @@ class SourceLine(object):
         else:
             raise_from(self.makeError(six.text_type(exc_value)), exc_value)
 
-    def file(self):  # type: () -> Text
+    def file(self):  # type: () -> Optional[Text]
         if hasattr(self.item, "lc") and hasattr(self.item.lc, "filename"):
             return Text(self.item.lc.filename)
         else:

--- a/schema_salad/sourceline.py
+++ b/schema_salad/sourceline.py
@@ -337,7 +337,10 @@ class SourceLine(object):
             raise_from(self.makeError(six.text_type(exc_value)), exc_value)
 
     def file(self):  # type: () -> Text
-        return Text(self.item.lc.filename) if hasattr(self.item.lc, "filename") else ""
+        if hasattr(self.item, "lc") and hasattr(self.item.lc, "filename"):
+            return Text(self.item.lc.filename)
+        else:
+            return None
 
     def line(self):  # type: () -> int
         if (

--- a/schema_salad/sourceline.py
+++ b/schema_salad/sourceline.py
@@ -136,7 +136,7 @@ def add_lc_filename(
     _add_lc_filename(r, relname(source))
 
 
-def reflow_all(text, maxline = None):
+def reflow_all(text, maxline = None):  # type: (Text, Optional[int]) -> Text
     if maxline is None:
         maxline = int(os.environ.get("COLUMNS", "100"))
     maxno = 0
@@ -198,7 +198,7 @@ def bullets(textlist, bul):  # type: (List[Text], Text) -> Text
         return "\n".join(indent(t, bullet=bul) for t in textlist)
 
 
-def strip_duplicated_lineno(text):
+def strip_duplicated_lineno(text):  # type: (Text) -> Text
     """Same as `strip_dup_lineno` but without reflow"""
     pre = None
     msg = []

--- a/schema_salad/sourceline.py
+++ b/schema_salad/sourceline.py
@@ -136,7 +136,7 @@ def add_lc_filename(
     _add_lc_filename(r, relname(source))
 
 
-def reflow_all(text, maxline = None):  # type: (Text, Optional[int]) -> Text
+def reflow_all(text, maxline=None):  # type: (Text, Optional[int]) -> Text
     if maxline is None:
         maxline = int(os.environ.get("COLUMNS", "100"))
     maxno = 0
@@ -145,7 +145,7 @@ def reflow_all(text, maxline = None):  # type: (Text, Optional[int]) -> Text
         if not g:
             continue
         maxno = max(maxno, len(g.group(1)))
-    maxno_text = maxline-maxno
+    maxno_text = maxline - maxno
     msg = []
     for l in text.splitlines():
         g = lineno_re.match(l)
@@ -154,7 +154,7 @@ def reflow_all(text, maxline = None):  # type: (Text, Optional[int]) -> Text
             continue
         pre = g.group(1)
         reflowed = reflow(g.group(2), maxno_text, g.group(3)).splitlines()
-        msg.extend([pre.ljust(maxno, ' ')+r for r in reflowed])
+        msg.extend([pre.ljust(maxno, " ") + r for r in reflowed])
     return "\n".join(msg)
 
 
@@ -211,7 +211,7 @@ def strip_duplicated_lineno(text):  # type: (Text) -> Text
             msg.append(l)
             pre = g.group(1)
         else:
-            msg.append(' '*len(g.group(1))+g.group(2))
+            msg.append(" " * len(g.group(1)) + g.group(2))
     return "\n".join(msg)
 
 

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -126,7 +126,7 @@ def test_error_message5():
 \s+tried `Workflow`\s+but
 .+test5\.cwl:7:1:     the `steps`\s+field\s+is\s+not valid\s+because
 \s+tried array\s+of\s+<WorkflowStep>\s+but
-.+test5\.cwl:7:9:         item is\s+invalid because
+.+test5\.cwl:7:9:         item is\s+invalid\s+because
 \s+is not a\s+dict$"""[
         1:
     ]
@@ -147,10 +147,10 @@ def test_error_message7():
 \s+tried `Workflow`\s+but
 .+test7\.cwl:7:1:     the `steps`\s+field\s+is\s+not valid\s+because
 \s+tried array\s+of\s+<WorkflowStep>\s+but
-.+test7\.cwl:8:3:         item is\s+invalid because
-\s+\* missing\s+required\s+field `run`
+.+test7\.cwl:8:3:         item is\s+invalid\s+because
+\s+\* missing\s+required\s+field\s+`run`
 .+test7\.cwl:9:5:           \* invalid\s+field\s+`scatter_method`,\s+expected\s+one """
-        + r"""of:\s+'id', 'in', 'out',\s+'requirements',\s+'hints',\s+"""
+        + r"""of:\s+'id',\s+'in', 'out',\s+'requirements',\s+'hints',\s+"""
         + r"""'label',\s+'doc',\s+'run',\s+'scatter',\s+'scatterMethod'$"""
     )
     with pytest.raises(ValidationException, match=match):
@@ -207,8 +207,8 @@ def test_error_message10():
 \s+tried `Workflow`\s+but
 .+test10\.cwl:7:1:     the `steps`\s+field is\s+not valid\s+because
 \s+tried array\s+of\s+<WorkflowStep>\s+but
-.+test10\.cwl:8:3:         item is\s+invalid because
-\s+\* missing\s+required\s+field `run`
+.+test10\.cwl:8:3:         item is\s+invalid\s+because
+\s+\* missing\s+required\s+field\s+`run`
 .+test10\.cwl:9:5:           \* the\s+`scatterMethod`\s+field is\s+not valid\s+because
 \s+value\s+is a\s+CommentedSeq,\s+expected\s+null\s+or\s+ScatterMethod$"""[
         1:
@@ -249,12 +249,12 @@ def test_error_message15():
 \s+tried\s+`CommandLineTool`\s+but
 .+test15\.cwl:6:1:\s+the `inputs`\s+field\s+is not valid\s+because
 .+test15\.cwl:7:3:\s+item is\s+invalid\s+because
-.+test15\.cwl:9:5:\s+the\s+`inputBinding`\s+field is not\s+valid\s+because
+.+test15\.cwl:9:5:\s+the\s+`inputBinding`\s+field is\s+not\s+valid\s+because
 .+tried\s+CommandLineBinding\s+but
-.+test15\.cwl:11:7:             \*\s+invalid field\s+`invalid_field`,\s+expected """
+.+test15\.cwl:11:7:             \*\s+invalid\s+field\s+`invalid_field`,\s+expected """
         + r"""one\s+of:\s+'loadContents',\s+'position',\s+'prefix',\s+'separate',"""
         + r"""\s+'itemSeparator',\s+'valueFrom',\s+'shellQuote'
-.+test15\.cwl:12:7:             \*\s+invalid field\s+`another_invalid_field`,"""
+.+test15\.cwl:12:7:             \*\s+invalid\s+field\s+`another_invalid_field`,"""
         + r"""\s+expected one\s+of:\s+'loadContents',\s+'position',\s+'prefix',"""
         + r"""\s+'separate',\s+'itemSeparator',\s+'valueFrom',\s+'shellQuote'$"""
     )

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -188,7 +188,7 @@ def test_error_message9():
         r"""^.+test9\.cwl:7:1: checking field\s+`steps`
 .+test9\.cwl:8:3:   checking object\s+`.+test9\.cwl#step1`
 .+test9\.cwl:9:5:     `scatterMethod`\s+field\s+is\s+"""
-        + r"""int,\s+expected\s+string,\s+list,\s+or a dict.$"""
+        + r"""int,\s+expected\s+string,\s+list,\s+or a\s+dict.$"""
     )
     with pytest.raises(ValidationException, match=match):
         load_and_validate(
@@ -205,12 +205,12 @@ def test_error_message10():
     match = r"""
 ^.+test10\.cwl:2:1: Object\s+`.+test10\.cwl`\s+is not valid because
 \s+tried `Workflow`\s+but
-.+test10\.cwl:7:1:     the `steps`\s+field is\s+not\s+valid\s+because
+.+test10\.cwl:7:1:     the `steps`\s+field\s+is\s+not\s+valid\s+because
 \s+tried array\s+of\s+<WorkflowStep>\s+but
 .+test10\.cwl:8:3:         item is\s+invalid\s+because
 \s+\* missing\s+required\s+field\s+`run`
-.+test10\.cwl:9:5:           \* the\s+`scatterMethod`\s+field is\s+not\s+valid\s+because
-\s+value\s+is a\s+CommentedSeq,\s+expected\s+null\s+or\s+ScatterMethod$"""[
+.+test10\.cwl:9:5:           \* the\s+`scatterMethod`\s+field\s+is\s+not\s+valid\s+because
+\s+value\s+is\s+a\s+CommentedSeq,\s+expected\s+null\s+or\s+ScatterMethod$"""[
         1:
     ]
     with pytest.raises(ValidationException, match=match):
@@ -249,7 +249,7 @@ def test_error_message15():
 \s+tried\s+`CommandLineTool`\s+but
 .+test15\.cwl:6:1:\s+the `inputs`\s+field\s+is\s+not valid\s+because
 .+test15\.cwl:7:3:\s+item is\s+invalid\s+because
-.+test15\.cwl:9:5:\s+the\s+`inputBinding`\s+field is\s+not\s+valid\s+because
+.+test15\.cwl:9:5:\s+the\s+`inputBinding`\s+field\s+is\s+not\s+valid\s+because
 .+tried\s+CommandLineBinding\s+but
 .+test15\.cwl:11:7:             \*\s+invalid\s+field\s+`invalid_field`,\s+expected\s+"""
         + r"""one\s+of:\s+'loadContents',\s+'position',\s+'prefix',\s+'separate',"""

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -124,7 +124,7 @@ def test_error_message5():
     match = r"""
 ^.+test5\.cwl:2:1: Object\s+`.+test5\.cwl`\s+is\s+not valid because
 \s+tried `Workflow`\s+but
-.+test5\.cwl:7:1:     the `steps`\s+field\s+is\s+not valid\s+because
+.+test5\.cwl:7:1:     the `steps`\s+field\s+is\s+not\s+valid\s+because
 \s+tried array\s+of\s+<WorkflowStep>\s+but
 .+test5\.cwl:7:9:         item is\s+invalid\s+because
 \s+is not a\s+dict$"""[
@@ -145,7 +145,7 @@ def test_error_message7():
     match = (
         r"""^.+test7\.cwl:2:1: Object\s+`.+test7\.cwl`\s+is\s+not valid because
 \s+tried `Workflow`\s+but
-.+test7\.cwl:7:1:     the `steps`\s+field\s+is\s+not valid\s+because
+.+test7\.cwl:7:1:     the `steps`\s+field\s+is\s+not\s+valid\s+because
 \s+tried array\s+of\s+<WorkflowStep>\s+but
 .+test7\.cwl:8:3:         item is\s+invalid\s+because
 \s+\* missing\s+required\s+field\s+`run`
@@ -168,7 +168,7 @@ def test_error_message8():
     match = r"""
 ^.+test8\.cwl:7:1: checking field\s+`steps`
 .+test8\.cwl:8:3:   checking object\s+`.+test8\.cwl#step1`
-.+test8\.cwl:9:5:     Field\s+`scatterMethod`\s+contains\s+undefined\s+reference to
+.+test8\.cwl:9:5:     Field\s+`scatterMethod`\s+contains\s+undefined\s+reference\s+to
 \s+`file:///.+/tests/test_schema/abc`$"""[
         1:
     ]
@@ -188,7 +188,7 @@ def test_error_message9():
         r"""^.+test9\.cwl:7:1: checking field\s+`steps`
 .+test9\.cwl:8:3:   checking object\s+`.+test9\.cwl#step1`
 .+test9\.cwl:9:5:     `scatterMethod`\s+field\s+is\s+"""
-        + r"""int,\s+expected\s+string,\s+list, or a dict.$"""
+        + r"""int,\s+expected\s+string,\s+list,\s+or a dict.$"""
     )
     with pytest.raises(ValidationException, match=match):
         load_and_validate(
@@ -205,11 +205,11 @@ def test_error_message10():
     match = r"""
 ^.+test10\.cwl:2:1: Object\s+`.+test10\.cwl`\s+is not valid because
 \s+tried `Workflow`\s+but
-.+test10\.cwl:7:1:     the `steps`\s+field is\s+not valid\s+because
+.+test10\.cwl:7:1:     the `steps`\s+field is\s+not\s+valid\s+because
 \s+tried array\s+of\s+<WorkflowStep>\s+but
 .+test10\.cwl:8:3:         item is\s+invalid\s+because
 \s+\* missing\s+required\s+field\s+`run`
-.+test10\.cwl:9:5:           \* the\s+`scatterMethod`\s+field is\s+not valid\s+because
+.+test10\.cwl:9:5:           \* the\s+`scatterMethod`\s+field is\s+not\s+valid\s+because
 \s+value\s+is a\s+CommentedSeq,\s+expected\s+null\s+or\s+ScatterMethod$"""[
         1:
     ]
@@ -247,11 +247,11 @@ def test_error_message15():
     match = (
         r"""^.+test15\.cwl:3:1:\s+Object\s+`.+test15\.cwl`\s+is not valid because
 \s+tried\s+`CommandLineTool`\s+but
-.+test15\.cwl:6:1:\s+the `inputs`\s+field\s+is not valid\s+because
+.+test15\.cwl:6:1:\s+the `inputs`\s+field\s+is\s+not valid\s+because
 .+test15\.cwl:7:3:\s+item is\s+invalid\s+because
 .+test15\.cwl:9:5:\s+the\s+`inputBinding`\s+field is\s+not\s+valid\s+because
 .+tried\s+CommandLineBinding\s+but
-.+test15\.cwl:11:7:             \*\s+invalid\s+field\s+`invalid_field`,\s+expected """
+.+test15\.cwl:11:7:             \*\s+invalid\s+field\s+`invalid_field`,\s+expected\s+"""
         + r"""one\s+of:\s+'loadContents',\s+'position',\s+'prefix',\s+'separate',"""
         + r"""\s+'itemSeparator',\s+'valueFrom',\s+'shellQuote'
 .+test15\.cwl:12:7:             \*\s+invalid\s+field\s+`another_invalid_field`,"""

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -149,8 +149,8 @@ def test_error_message7():
 \s+tried array\s+of\s+<WorkflowStep>\s+but
 .+test7\.cwl:8:3:         item is\s+invalid because
 \s+\* missing\s+required\s+field `run`
-.+test7\.cwl:9:5:           \* invalid\s+field\s+`scatter_method`,\s+expected one """
-        + r"""of:\s+'id', 'in', 'out',\s+'requirements',\s+'hints', """
+.+test7\.cwl:9:5:           \* invalid\s+field\s+`scatter_method`,\s+expected\s+one """
+        + r"""of:\s+'id', 'in', 'out',\s+'requirements',\s+'hints',\s+"""
         + r"""'label',\s+'doc',\s+'run',\s+'scatter',\s+'scatterMethod'$"""
     )
     with pytest.raises(ValidationException, match=match):

--- a/schema_salad/validate.py
+++ b/schema_salad/validate.py
@@ -13,7 +13,7 @@ from typing import (  # noqa: F401
 )
 
 import six
-from six.moves import range, urllib
+from six.moves import urllib
 from typing_extensions import Text  # pylint: disable=unused-import
 
 from . import avro
@@ -26,7 +26,7 @@ from .avro import schema  # noqa: F401
 from .avro.schema import (  # pylint: disable=unused-import, no-name-in-module, import-error
     Schema,
 )
-from .sourceline import SourceLine, bullets, indent, strip_dup_lineno
+from .sourceline import SourceLine
 
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
 

--- a/schema_salad/validate.py
+++ b/schema_salad/validate.py
@@ -226,11 +226,6 @@ def validate_ex(
                 except ValidationException as v:
                     if raise_ex:
                         raise ValidationException("item is invalid because", sl, [v])
-                        # raise sl.makeError(
-                        #     six.text_type(
-                        #         "item is invalid because\n{}".format(indent(str(v)))
-                        #     )
-                        # )
                     else:
                         return False
             return True
@@ -295,7 +290,6 @@ def validate_ex(
                 raise
             except ValidationException as e:
                 errors.append(e)
-                # errors.append(six.text_type(e))
         if bool(errors):
             raise ValidationException(
                 "",
@@ -308,16 +302,6 @@ def validate_ex(
                 ],
                 "-",
             )
-            #     bullets(
-            #         [
-            #             "tried {} but\n{}".format(
-            #                 friendly(checked[i]), indent(errors[i])
-            #             )
-            #             for i in range(0, len(errors))
-            #         ],
-            #         "- ",
-            #     )
-            # )
         else:
             raise ValidationException(
                 "value is a {}, expected {}".format(
@@ -394,11 +378,6 @@ def validate_ex(
                             sl,
                             [v],
                         )
-                        # sl.makeError(
-                        #     u"the `{}` field is not valid because\n{}".format(
-                        #         f.name, indent(str(v))
-                        #     )
-                        # )
                     )
 
         for d in datum:
@@ -409,12 +388,11 @@ def validate_ex(
             if not found:
                 sl = SourceLine(datum, d, six.text_type)
                 if d is None:
-                    # err = sl.makeError(u"mapping with implicit null key")
                     err = ValidationException(u"mapping with implicit null key", sl)
                     if strict:
                         errors.append(err)
                     else:
-                        logger.warning(err.pretty_str())
+                        logger.warning(err)
                     continue
                 if (
                     d not in identifiers
@@ -448,23 +426,10 @@ def validate_ex(
                                 ),
                                 sl,
                             )
-                            # err = sl.makeError(
-                            #     u"unrecognized extension field `{}`{}.{}".format(
-                            #         d,
-                            #         " and strict_foreign_properties checking is enabled"
-                            #         if strict_foreign_properties
-                            #         else "",
-                            #         "\nForeign properties from $schemas:\n  {}".format(
-                            #             "\n  ".join(sorted(foreign_properties))
-                            #         )
-                            #         if len(foreign_properties) > 0
-                            #         else "",
-                            #     )
-                            # )
                             if strict_foreign_properties:
                                 errors.append(err)
                             elif len(foreign_properties) > 0:
-                                logger.warning(err.pretty_str())
+                                logger.warning(err)
                     else:
                         err = ValidationException(
                             u"invalid field `{}`, expected one of: {}".format(
@@ -476,19 +441,10 @@ def validate_ex(
                             ),
                             sl,
                         )
-                        # err = sl.makeError(
-                        #     u"invalid field `{}`, expected one of: {}".format(
-                        #         d,
-                        #         ", ".join(
-                        #             "'{}'".format(fn.name)
-                        #             for fn in expected_schema.fields
-                        #         ),
-                        #     )
-                        # )
                         if strict:
                             errors.append(err)
                         else:
-                            logger.warning(err.pretty_str())
+                            logger.warning(err)
 
         if bool(errors):
             if raise_ex:

--- a/schema_salad/validate.py
+++ b/schema_salad/validate.py
@@ -17,7 +17,11 @@ from six.moves import range, urllib
 from typing_extensions import Text  # pylint: disable=unused-import
 
 from . import avro
-from .exceptions import ClassValidationException, ValidationException, SchemaSaladException
+from .exceptions import (
+    ClassValidationException,
+    ValidationException,
+    SchemaSaladException,
+)
 from .avro import schema  # noqa: F401
 from .avro.schema import (  # pylint: disable=unused-import, no-name-in-module, import-error
     Schema,
@@ -293,10 +297,15 @@ def validate_ex(
                 errors.append(e)
                 # errors.append(six.text_type(e))
         if bool(errors):
-            raise ValidationException("", None,
-                                      [ValidationException("tried {} but".format(friendly(c)),
-                                                           None, [e]) for (c, e) in zip(checked, errors)],
-                                      "-")
+            raise ValidationException(
+                "",
+                None,
+                [
+                    ValidationException("tried {} but".format(friendly(c)), None, [e])
+                    for (c, e) in zip(checked, errors)
+                ],
+                "-",
+            )
             #     bullets(
             #         [
             #             "tried {} but\n{}".format(
@@ -371,10 +380,18 @@ def validate_ex(
                     return False
             except ValidationException as v:
                 if f.name not in datum:
-                    errors.append(ValidationException(u"missing required field `{}`".format(f.name)))
+                    errors.append(
+                        ValidationException(
+                            u"missing required field `{}`".format(f.name)
+                        )
+                    )
                 else:
-                    errors.append(ValidationException(u"the `{}` field is not valid because".format(f.name),
-                                                      sl, [v])
+                    errors.append(
+                        ValidationException(
+                            u"the `{}` field is not valid because".format(f.name),
+                            sl,
+                            [v],
+                        )
                         # sl.makeError(
                         #     u"the `{}` field is not valid because\n{}".format(
                         #         f.name, indent(str(v))
@@ -426,7 +443,9 @@ def validate_ex(
                                     )
                                     if len(foreign_properties) > 0
                                     else "",
-                                ), sl)
+                                ),
+                                sl,
+                            )
                             # err = sl.makeError(
                             #     u"unrecognized extension field `{}`{}.{}".format(
                             #         d,
@@ -452,7 +471,9 @@ def validate_ex(
                                     "'{}'".format(fn.name)
                                     for fn in expected_schema.fields
                                 ),
-                            ), sl)
+                            ),
+                            sl,
+                        )
                         # err = sl.makeError(
                         #     u"invalid field `{}`, expected one of: {}".format(
                         #         d,

--- a/schema_salad/validate.py
+++ b/schema_salad/validate.py
@@ -301,8 +301,10 @@ def validate_ex(
                 "",
                 None,
                 [
-                    ValidationException("tried {} but".format(friendly(c)), None, [e])
-                    for (c, e) in zip(checked, errors)
+                    ValidationException(
+                        "tried {} but".format(friendly(check)), None, [err]
+                    )
+                    for (check, err) in zip(checked, errors)
                 ],
                 "-",
             )

--- a/schema_salad/validate.py
+++ b/schema_salad/validate.py
@@ -17,7 +17,7 @@ from six.moves import range, urllib
 from typing_extensions import Text  # pylint: disable=unused-import
 
 from . import avro
-from .exceptions import ClassValidationException, ValidationException
+from .exceptions import ClassValidationException, ValidationException, SchemaSaladException
 from .avro import schema  # noqa: F401
 from .avro.schema import (  # pylint: disable=unused-import, no-name-in-module, import-error
     Schema,
@@ -256,7 +256,7 @@ def validate_ex(
         if not raise_ex:
             return False
 
-        errors = []  # type: List[Text]
+        errors = []  # type: List[SchemaSaladException]
         checked = []
         for s in expected_schema.schemas:
             if isinstance(datum, MutableSequence) and not isinstance(


### PR DESCRIPTION
It is to solve #244 by introducing tree structured exception instead of manipulating strings.
I introduce the following API to `SchemaSaladException`:

```python
class SchemaSaladException(Exception):
  self.file # type: Text: file name where an error occurs
  self.start # type: Optional[Tuple[int, int]]: it consists of (line, column) where an error token starts
  self.end # type: Optional[Tuple[int, int]]: where an error token ends (for future extensions)
  self.children # type: Sequence[SchemaSaladException]
  def str(self):
    """Returns a nice string as same as before. It internally uses `pretty_str()` method."""
    pass
```

I also introduce two functions in `sourceline.py`: `reflow_all` and `strip_duplicated_lineno`.
`reflow_all` is to apply `reflow` for all lines. `strip_duplicated_lineno` is almost same as `strip_dup_lineno` but without calling `reflow` to make it easier to test.

- [x] Implement Tree structure for exception
- [x] More description
- [x] More compatibility of the message with current implementation
- [x] Cleanup code
- [x] Use tree structure to code-generated code
