### PR TITLE
Refactoring of accessors for SourceLine

### DIFF
--- a/schema_salad/exceptions.py
+++ b/schema_salad/exceptions.py
@@ -35,8 +35,8 @@ class SchemaSaladException(Exception):
     ):  # type: (Optional[SourceLine]) -> SchemaSaladException
         if sl and sl.file():
             self.file = sl.file()  # type: Optional[Text]
-            self.start = (sl.line(), sl.column())  # type: Optional[Tuple[int, int]]
-            self.end = (sl.line(), sl.column() + 1)  # type: Optional[Tuple[int, int]]
+            self.start = sl.start()  # type: Optional[Tuple[int, int]]
+            self.end = sl.end()  # type: Optional[Tuple[int, int]]
         else:
             self.file = None
             self.start = None

--- a/schema_salad/sourceline.py
+++ b/schema_salad/sourceline.py
@@ -342,28 +342,29 @@ class SourceLine(object):
         else:
             return None
 
-    def line(self):  # type: () -> int
-        if (
+    def start(self):  # type: () -> Optional[Tuple[int, int]]
+        if self.file() is None:
+            return None
+        elif (
             self.key is None
             or self.item.lc.data is None
             or self.key not in self.item.lc.data
         ):
-            return (self.item.lc.line or 0) + 1
+            return ((self.item.lc.line or 0) + 1, (self.item.lc.col or 0) + 1)
         else:
-            return (self.item.lc.data[self.key][0] or 0) + 1
+            return ((self.item.lc.data[self.key][0] or 0) + 1,
+                    (self.item.lc.data[self.key][1] or 0) + 1)
 
-    def column(self):  # type: () -> int
-        if (
-            self.key is None
-            or self.item.lc.data is None
-            or self.key not in self.item.lc.data
-        ):
-            return (self.item.lc.col or 0) + 1
-        else:
-            return (self.item.lc.data[self.key][1] or 0) + 1
+    def end(self):  # type: () -> Optional[Tuple[int, int]]
+        return None
 
     def makeLead(self):  # type: () -> Text
-        return "{}:{}:{}:".format(self.file(), self.line(), self.column())
+        if self.file():
+            lcol = self.start()
+            line, col = lcol if lcol else ("", "")
+            return "{}:{}:{}:".format(self.file(), line, col)
+        else:
+            return ""
 
     def makeError(self, msg):  # type: (Text) -> Any
         if not isinstance(self.item, ruamel.yaml.comments.CommentedBase):

--- a/schema_salad/sourceline.py
+++ b/schema_salad/sourceline.py
@@ -352,8 +352,10 @@ class SourceLine(object):
         ):
             return ((self.item.lc.line or 0) + 1, (self.item.lc.col or 0) + 1)
         else:
-            return ((self.item.lc.data[self.key][0] or 0) + 1,
-                    (self.item.lc.data[self.key][1] or 0) + 1)
+            return (
+                (self.item.lc.data[self.key][0] or 0) + 1,
+                (self.item.lc.data[self.key][1] or 0) + 1,
+            )
 
     def end(self):  # type: () -> Optional[Tuple[int, int]]
         return None


### PR DESCRIPTION
This request is for refactoring of `SourceLine`.

- Introduce `start` and `end` method instead of `line` and `column`
  - `start` returns a tuple of `line` and `column` if `file` is present. Otherwise returns `None`
  - `end` is for future extensions. Currently it always returns `None`