### PR TITLE
Use ValidationException instead of RuntimeError and ValueError

### DIFF
--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -21,11 +21,7 @@ from .avro.schema import SchemaParseException
 from .exceptions import ValidationException
 from .makedoc import makedoc
 from .ref_resolver import Loader, file_uri
-from .sourceline import (
-    reformat_yaml_exception_message,
-    strip_dup_lineno,
-    to_one_line_messages,
-)
+from .sourceline import to_one_line_messages
 from .utils import json_dumps
 
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
@@ -333,17 +329,6 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
     except ValidationException as e:
         msg = six.text_type(e)
         msg = to_one_line_messages(str(msg)) if args.print_oneline else msg
-        _logger.error(
-            "Document `%s` failed validation:\n%s",
-            args.document,
-            msg,
-            exc_info=args.debug,
-        )
-        return 1
-    except RuntimeError as e:
-        msg = strip_dup_lineno(six.text_type(e))
-        msg = reformat_yaml_exception_message(str(msg))
-        msg = to_one_line_messages(msg) if args.print_oneline else msg
         _logger.error(
             "Document `%s` failed validation:\n%s",
             args.document,

--- a/schema_salad/makedoc.py
+++ b/schema_salad/makedoc.py
@@ -30,7 +30,7 @@ from six.moves import range, urllib
 from typing_extensions import Text  # pylint: disable=unused-import
 
 from . import schema
-from .exceptions import SchemaSaladException
+from .exceptions import SchemaSaladException, ValidationException
 from .utils import add_dictlist, aslist
 
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
@@ -710,7 +710,7 @@ def makedoc(args):  # type: (argparse.Namespace) -> None
             elif isinstance(j, MutableMapping):
                 s.append(j)
             else:
-                raise ValueError("Schema must resolve to a list or a dict")
+                raise ValidationException("Schema must resolve to a list or a dict")
     redirect = {}
     for r in args.redirect or []:
         redirect[r.split("=")[0]] = r.split("=")[1]

--- a/schema_salad/schema.py
+++ b/schema_salad/schema.py
@@ -43,7 +43,7 @@ from .exceptions import (
 )
 from .avro.schema import Names, SchemaParseException, make_avsc_object
 from .ref_resolver import Loader
-from .sourceline import SourceLine, add_lc_filename, relname, strip_dup_lineno
+from .sourceline import SourceLine, add_lc_filename, relname
 
 SALAD_FILES = (
     "metaschema.yml",
@@ -242,7 +242,7 @@ def load_schema(
     schema_doc, schema_metadata = metaschema_loader.resolve_ref(schema_ref, "")
 
     if not isinstance(schema_doc, MutableSequence):
-        raise ValueError("Schema reference must resolve to a list.")
+        raise ValidationException("Schema reference must resolve to a list.")
 
     validate_doc(metaschema_names, schema_doc, metaschema_loader, True)
     metactx = schema_metadata.get("@context", {})
@@ -294,7 +294,7 @@ def load_and_validate(
             strict_foreign_properties=strict_foreign_properties,
         )
     except ValidationException as exc:
-        raise_from(ValidationException(strip_dup_lineno(str(exc))), exc)
+        raise_from(ValidationException("", None, [exc]), exc)
     return data, metadata
 
 

--- a/schema_salad/tests/test_print_oneline.py
+++ b/schema_salad/tests/test_print_oneline.py
@@ -1,6 +1,7 @@
 from os.path import normpath
 
 import pytest
+import re
 import six
 
 from schema_salad.main import to_one_line_messages
@@ -169,7 +170,9 @@ def test_for_invalid_yaml2():
             assert (
                 msg.endswith("expected <block end>, but found ':'")
                 or msg.endswith("expected <block end>, but found u':'")
-                or msg.endswith("mapping with implicit null key")
+                or re.sub(r"\s+", " ", msg, re.M).endswith(
+                    "mapping with implicit null key"
+                )
             )
             print ("\n", e)
             raise

--- a/schema_salad/tests/test_print_oneline.py
+++ b/schema_salad/tests/test_print_oneline.py
@@ -144,7 +144,7 @@ def test_for_invalid_yaml1():
             msg = str(e)
             assert re.search(src + r":10:7: while scanning a\s+simple key", msg, re.M)
             assert re.search(
-                src + r":11:1:   could not\s+find\s+expected ':'$", msg, re.M
+                src + r":11:1:   could not\s+find\s+expected ':'", msg, re.M
             )
             print ("\n", e)
             raise

--- a/schema_salad/tests/test_print_oneline.py
+++ b/schema_salad/tests/test_print_oneline.py
@@ -144,7 +144,7 @@ def test_for_invalid_yaml1():
             msg = str(e)
             assert re.search(src + r":10:7: while scanning a\s+simple key", msg, re.M)
             assert re.search(
-                src + r":11:1:   could not find\s+expected ':'$", msg, re.M
+                src + r":11:1:   could not\s+find\s+expected ':'$", msg, re.M
             )
             print ("\n", e)
             raise
@@ -170,7 +170,7 @@ def test_for_invalid_yaml2():
             assert (
                 msg.endswith("expected <block end>, but found ':'")
                 or msg.endswith("expected <block end>, but found u':'")
-                or re.search(r"mapping with implicit\s+null key$", msg, re.M)
+                or re.search(r"mapping with\s+implicit\s+null key$", msg, re.M)
             )
             print ("\n", e)
             raise

--- a/schema_salad/tests/test_print_oneline.py
+++ b/schema_salad/tests/test_print_oneline.py
@@ -142,10 +142,10 @@ def test_for_invalid_yaml1():
             )
         except ValidationException as e:
             msg = str(e)
-            msgs = msg.splitlines()
-            assert len(msgs) == 2
-            assert msgs[0].endswith(src + ":10:7: while scanning a simple key")
-            assert msgs[1].endswith(src + ":11:1:   could not find expected ':'")
+            assert re.search(src + r":10:7: while scanning a\s+simple key", msg, re.M)
+            assert re.search(
+                src + r":11:1:   could not find\s+expected ':'$", msg, re.M
+            )
             print ("\n", e)
             raise
 
@@ -170,9 +170,7 @@ def test_for_invalid_yaml2():
             assert (
                 msg.endswith("expected <block end>, but found ':'")
                 or msg.endswith("expected <block end>, but found u':'")
-                or re.sub(r"\s+", " ", msg, re.M).endswith(
-                    "mapping with implicit null key"
-                )
+                or re.search(r"mapping with implicit\s+null key$", msg, re.M)
             )
             print ("\n", e)
             raise

--- a/schema_salad/tests/test_print_oneline.py
+++ b/schema_salad/tests/test_print_oneline.py
@@ -142,9 +142,9 @@ def test_for_invalid_yaml1():
             )
         except ValidationException as e:
             msg = str(e)
-            assert re.search(src + r":10:7: while scanning a\s+simple key", msg, re.M)
+            assert re.search(src + r":10:7: while scanning a\s+simple\s+key", msg, re.M)
             assert re.search(
-                src + r":11:1:   could not\s+find\s+expected ':'", msg, re.M
+                src + r":11:1:   could not\s+find\s+expected ':'$", msg, re.M
             )
             print ("\n", e)
             raise


### PR DESCRIPTION
It continues #288.

By merging this request, all the exceptions thrown by schema salad (including exceptions from `ruamel.yaml` parser) can be caught as `SchemaSaladException`.

Here is a list of the next step:
- Make tests robust by using `SchemaSaladException#message` and `SchemaSaladException#start`
- Simplify `to_one_line_messages` using tree structured exception
- Cleanup code
  - Now some functions can be safely removed (e.g. `reformat_yaml_exception_message` and `SourceLine#__enter__`)