### PR TITLE
Refactor SchemaSaladException and to_one_line_messages

### DIFF
--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -18,10 +18,9 @@ from ruamel.yaml.comments import CommentedSeq
 
 from . import codegen, jsonld_context, schema
 from .avro.schema import SchemaParseException
-from .exceptions import ValidationException
+from .exceptions import ValidationException, to_one_line_messages
 from .makedoc import makedoc
 from .ref_resolver import Loader, file_uri
-from .sourceline import to_one_line_messages
 from .utils import json_dumps
 
 # move to a regular typing import when Python 3.3-3.6 is no longer supported
@@ -327,8 +326,7 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
             uri, strict_foreign_properties=args.strict_foreign_properties
         )
     except ValidationException as e:
-        msg = six.text_type(e)
-        msg = to_one_line_messages(str(msg)) if args.print_oneline else msg
+        msg = to_one_line_messages(e) if args.print_oneline else six.text_type(e)
         _logger.error(
             "Document `%s` failed validation:\n%s",
             args.document,
@@ -356,7 +354,7 @@ def main(argsl=None):  # type: (Optional[List[str]]) -> int
             strict_foreign_properties=args.strict_foreign_properties,
         )
     except ValidationException as e:
-        msg = to_one_line_messages(str(e)) if args.print_oneline else str(e)
+        msg = to_one_line_messages(e) if args.print_oneline else six.text_type(e)
         _logger.error("While validating document `%s`:\n%s" % (args.document, msg))
         return 1
 

--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -1346,7 +1346,7 @@ class Loader(object):
                         document[d] = self.validate_link(
                             d, document[d], docid, all_doc_ids
                         )
-                except ValidationException as v:
+                except SchemaSaladException as v:
                     v = v.with_sourceline(sl)
                     if d == "$schemas" or (
                         d in self.foreign_properties and not strict_foreign_properties

--- a/schema_salad/sourceline.py
+++ b/schema_salad/sourceline.py
@@ -66,19 +66,6 @@ def chunk_messages(message):  # type: (str) -> List[Tuple[int, str]]
     return arr
 
 
-def to_one_line_messages(message):  # type: (str) -> str
-    ret = []
-    max_elem = (0, "")
-    for (indent, msg) in chunk_messages(message):
-        if indent > max_elem[0]:
-            max_elem = (indent, msg)
-        else:
-            ret.append(max_elem[1])
-            max_elem = (indent, msg)
-    ret.append(max_elem[1])
-    return "\n".join(ret)
-
-
 def reformat_yaml_exception_message(message):  # type: (str) -> str
     line_regex = re.compile(r'^\s+in "(.+)", line (\d+), column (\d+)$')
     fname_regex = re.compile(r"^file://" + re.escape(os.getcwd()) + "/")

--- a/schema_salad/tests/test_print_oneline.py
+++ b/schema_salad/tests/test_print_oneline.py
@@ -4,10 +4,8 @@ import pytest
 import re
 import six
 
-from schema_salad.main import to_one_line_messages
 from schema_salad.schema import load_and_validate, load_schema
-from schema_salad.sourceline import strip_dup_lineno
-from schema_salad.validate import ValidationException
+from schema_salad.exceptions import ValidationException, to_one_line_messages
 
 from .util import get_data
 
@@ -28,7 +26,7 @@ def test_print_oneline():
                 True,
             )
         except ValidationException as e:
-            msgs = to_one_line_messages(str(e)).splitlines()
+            msgs = to_one_line_messages(e).splitlines()
             assert len(msgs) == 2
             assert msgs[0].endswith(
                 src + ":11:7: invalid field `invalid_field`, expected one of: "
@@ -60,8 +58,7 @@ def test_print_oneline_for_invalid_yaml():
                 True,
             )
         except ValidationException as e:
-            msg = str(e)
-            msg = to_one_line_messages(msg)
+            msg = to_one_line_messages(e)
             assert msg.endswith(src + ":11:1: could not find expected ':'")
             print ("\n", e)
             raise
@@ -83,7 +80,7 @@ def test_print_oneline_for_errors_in_the_same_line():
                 True,
             )
         except ValidationException as e:
-            msgs = to_one_line_messages(str(e)).splitlines()
+            msgs = to_one_line_messages(e).splitlines()
             assert len(msgs) == 2, msgs
             assert msgs[0].endswith(src + ":14:5: missing required field `id`")
             assert msgs[1].endswith(
@@ -109,16 +106,12 @@ def test_print_oneline_for_errors_in_resolve_ref():
                 document_loader, avsc_names, six.text_type(fullpath), True
             )
         except ValidationException as e:
-            msgs = to_one_line_messages(
-                str(strip_dup_lineno(six.text_type(e)))
-            ).splitlines()
+            msg = to_one_line_messages(e)
             # convert Windows path to Posix path
             if "\\" in fullpath:
                 fullpath = "/" + fullpath.lower().replace("\\", "/")
-            assert len(msgs) == 2
             print ("\n", e)
-            assert msgs[0].endswith(src + ":9:1: checking field `outputs`")
-            assert msgs[1].endswith(
+            assert msg.endswith(
                 src + ":14:5: Field `type` references unknown identifier "
                 "`Filea`, tried file://%s#Filea" % (fullpath)
             )


### PR DESCRIPTION
This request simplifies `to_one_line_messages` by using tree structured exception instead of string manipulations.

Here is a list of main changes:

- Change the interface of `to_one_line_messages` from `(str) -> str` to `(SchemaSaladException) -> Text`
- Move the definition of `to_one_line_messages` from `sourceline.py` to `exceptions.py` to prevent a circular reference.
- *Change the intension of `SchemaSaladException#bullet`*
  - Before: `bullet` is a bullet string to be added to `children`
  - After: `bullet` is a bullet string to be added to `self`. It will be set by its parent
- Add `SchemaSaladException#summary` and `SchemaSaladException#leaves`
  - `SchemaSaladException#summary(level: int, with_bullet: bool) -> Text` returns a one line summary of the exception using its `line`, `colum`, `file` and `message` with the given indent `level`. If `with_bullet` is `True` and `self.bullet` is not empty, `self.bullet` is added before `self.message`
  - `SchemaSaladException#leaves` returns a list of `SchemaSaladException`s that show the exact places of the errors
    - It is useful to implement `to_one_line_messages` as well as to implement language servers for CWL

Note that I changed one test for `to_one_line_messages` (a test for `test18.cwl`) because now n
ew `to_one_line_message` returns a better summary!
- Original message without `to_one_line_messages`:
  ```
  schema_salad/tests/test_schema/test18.cwl:9:1:   checking field `outputs`
  schema_salad/tests/test_schema/test18.cwl:13:5:   checking object
                                                    `schema_salad/tests/test_schema/test18.cwl#output1`
  schema_salad/tests/test_schema/test18.cwl:14:5:     Field `type` references unknown identifier
                                                      `Filea`, tried
                                                      file:///Users/tom-tan/schema_salad/schema_salad/tests/test_schema/test18.cwl#Filea
  ```
- Before merging this request:
  ```
  schema_salad/tests/test_schema/test18.cwl:9:1: checking field `outputs`
  schema_salad/tests/test_schema/test18.cwl:14:5: Field `type` references unknown identifier `Filea`, tried file:///Users/tom-tan/schema_salad/schema_salad/tests/test_schema/test18.cwl#Filea
  ```

- After merging this request:
  ```
  schema_salad/tests/test_schema/test18.cwl:14:5: Field `type` references unknown identifier `Filea`, tried file:///Users/tom-tan/schema_salad/schema_salad/tests/test_schema/test18.cwl#Filea
  ```