### PR TITLE
Clean up Python code generation.

### DIFF
--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -4,7 +4,6 @@ import re
 import uuid  # pylint: disable=unused-import # noqa: F401
 from typing import (
     Any,
-    cast,
     Dict,
     List,
     MutableMapping,
@@ -416,7 +415,7 @@ class _TypeDSLLoader(_Loader):
             r = []  # type: List[Any]
             for d in doc:
                 if isinstance(d, string_types):
-                    resolved = self.resolve(cast(Text, d), baseuri, loadingOptions)
+                    resolved = self.resolve(d, baseuri, loadingOptions)
                     if isinstance(resolved, MutableSequence):
                         for i in resolved:
                             if i not in r:
@@ -428,7 +427,7 @@ class _TypeDSLLoader(_Loader):
                     r.append(d)
             doc = r
         elif isinstance(doc, string_types):
-            doc = self.resolve(cast(Text, doc), baseuri, loadingOptions)
+            doc = self.resolve(doc, baseuri, loadingOptions)
 
         return self.inner.load(doc, baseuri, loadingOptions)
 

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -49,13 +49,11 @@ class LoadingOptions(object):
         namespaces=None,  # type: Optional[Dict[Text, Text]]
         fileuri=None,  # type: Optional[Text]
         copyfrom=None,  # type: Optional[LoadingOptions]
-        schemas=None,  # type: Optional[List[Text]]
         original_doc=None,  # type: Optional[Any]
     ):  # type: (...) -> None
         self.idx = {}  # type: Dict[Text, Dict[Text, Any]]
         self.fileuri = fileuri  # type: Optional[Text]
         self.namespaces = namespaces
-        self.schemas = schemas
         self.original_doc = original_doc
         if copyfrom is not None:
             self.idx = copyfrom.idx
@@ -65,8 +63,6 @@ class LoadingOptions(object):
                 self.fileuri = copyfrom.fileuri
             if namespaces is None:
                 self.namespaces = copyfrom.namespaces
-            if namespaces is None:
-                schemas = copyfrom.schemas
 
         if fetcher is None:
             import requests
@@ -482,12 +478,6 @@ def _document_load(loader, doc, baseuri, loadingOptions):
                 copyfrom=loadingOptions, namespaces=doc["$namespaces"]
             )
             doc = {k: v for k, v in doc.items() if k != "$namespaces"}
-
-        if "$schemas" in doc:
-            loadingOptions = LoadingOptions(
-                copyfrom=loadingOptions, schemas=doc["$schemas"]
-            )
-            doc = {k: v for k, v in doc.items() if k != "$schemas"}
 
         if "$base" in doc:
             baseuri = doc["$base"]

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -380,8 +380,13 @@ class _TypeDSLLoader(_Loader):
         self.inner = inner
         self.refScope = refScope
 
-    def resolve(self, doc, baseuri, loadingOptions):
-        # type: (Text, Text, LoadingOptions) -> Any
+    def resolve(
+        self,
+        doc,  # type: Text
+        baseuri,  # type: Text
+        loadingOptions,  # type: LoadingOptions
+    ):
+        # type: (...) -> Union[List[Union[Dict[Text, Text], Text]], Dict[Text, Text], Text]
         m = self.typeDSLregex.match(doc)
         if m:
             first = expand_url(
@@ -389,7 +394,7 @@ class _TypeDSLLoader(_Loader):
             )
             second = third = None
             if bool(m.group(2)):
-                second = {"type": "array", "items": first}
+                second = {u"type": u"array", u"items": first}
                 # second = CommentedMap((("type", "array"),
                 #                       ("items", first)))
                 # second.lc.add_kv_line_col("type", lc)
@@ -401,7 +406,7 @@ class _TypeDSLLoader(_Loader):
                 # third.lc.add_kv_line_col(0, lc)
                 # third.lc.add_kv_line_col(1, lc)
                 # third.lc.filename = filename
-            doc = third or second or first
+            return third or second or first
         return doc
 
     def load(self, doc, baseuri, loadingOptions, docRoot=None):

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -385,7 +385,7 @@ class _TypeDSLLoader(_Loader):
         self.refScope = refScope
 
     def resolve(self, doc, baseuri, loadingOptions):
-        # type: (Any, Text, LoadingOptions) -> Any
+        # type: (Text, Text, LoadingOptions) -> Any
         m = self.typeDSLregex.match(doc)
         if m:
             first = expand_url(

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -161,10 +161,6 @@ def expand_url(
     scoped_ref=None,  # type: Optional[int]
 ):
     # type: (...) -> Text
-
-    if not isinstance(url, string_types):
-        return url
-
     url = Text(url)
 
     if url in (u"@id", u"@type"):


### PR DESCRIPTION
Three commits, three cleanups to bring inline with Java codegen I did:
- The schema parsing stuff looks to be wrong and isn't used anywhere as far as I can tell.
- Type annotation for resolving typedsl strings can be tightened up based on how the function is called and what it is assuming about its inputs otherwise.
- Eliminate a defensive code block in expand_url - the type annotation already says it is a string-ish type - don't need to re-check I assume.
