### PR TITLE
python codegen - allow fields named uuid.

### DIFF
--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -324,7 +324,7 @@ class PythonCodeGen(CodeGenBase):
         self.declare_field(name, fieldtype, doc, True)
 
         if optional:
-            opt = """{safename} = "_:" + str(uuid.uuid4())""".format(
+            opt = """{safename} = "_:" + str(_uuid__.uuid4())""".format(
                 safename=self.safe_name(name)
             )
         else:

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -1,7 +1,7 @@
 import copy
 import os
 import re
-import uuid  # pylint: disable=unused-import # noqa: F401
+import uuid as _uuid__  # pylint: disable=unused-import # noqa: F401
 from typing import (
     Any,
     Dict,


### PR DESCRIPTION
Turns Galaxy workflows have a field name somewhere for each Python variable we're using during codegen.

A smarter approach might be like a local scope block - I was thinking abou that for Java. But it seems it isn't even a valid concept in Python (https://stackoverflow.com/questions/6167923/block-scope-in-python).

Similar approach used in https://github.com/common-workflow-language/schema_salad/pull/308.