### PR TITLE
Correct attribute for "relation" on link elements

### DIFF
--- a/schema_salad/makedoc.py
+++ b/schema_salad/makedoc.py
@@ -519,7 +519,7 @@ def avrold_doc(
             "sha384-604wwakM23pEysLJAhja8Lm42IIwYrJ0dEAqzFsj9pJ/P5buiujjywArgPCi8eoz"
         )
         brandstyle_template = (
-            '<link ref="stylesheet" href={} integrity={} crossorigin="anonymous">'
+            '<link rel="stylesheet" href={} integrity={} crossorigin="anonymous">'
         )
         brandstyle = brandstyle_template.format(bootstrap_url, bootstrap_integrity)
 


### PR DESCRIPTION
This solves a problem with loading a external css file on:

https://www.commonwl.org/v1.1/
![image](https://user-images.githubusercontent.com/12774464/71525635-e2b55800-28d2-11ea-8086-71c8759469c9.png)

https://www.commonwl.org/v1.0/
![image](https://user-images.githubusercontent.com/12774464/71525639-e77a0c00-28d2-11ea-9aea-99648ef1cb54.png)
