### PR TITLE
Make non-required parameters in Python codegen optional (=None)

### DIFF
--- a/schema_salad/codegen.py
+++ b/schema_salad/codegen.py
@@ -73,7 +73,7 @@ def codegen(
                     and tp[0] == "https://w3id.org/cwl/salad#null"
                 ):
                     optional_fields.add(field_name)
-                    
+
             idfield = ""
             for field in rec.get("fields", []):
                 if field.get("jsonldPredicate") == "@id":
@@ -86,7 +86,7 @@ def codegen(
                 rec.get("abstract", False),
                 field_names,
                 idfield,
-                optional_fields
+                optional_fields,
             )
             gen.add_vocab(shortname(rec["name"]), rec["name"])
 

--- a/schema_salad/codegen_base.py
+++ b/schema_salad/codegen_base.py
@@ -1,6 +1,6 @@
 """Base class for the generation of loaders from schema-salad definitions."""
 import collections
-from typing import Any, Dict, List, MutableSequence, Optional, Union
+from typing import Any, Dict, List, MutableSequence, Optional, Union, Set
 
 from . import schema
 
@@ -76,7 +76,7 @@ class CodeGenBase(object):
         abstract: bool,
         field_names: MutableSequence[str],
         idfield: str,
-        optional_fields: MutableSequence[str],
+        optional_fields: Set[str],
     ) -> None:
         """Produce the header for the given class."""
         raise NotImplementedError()

--- a/schema_salad/codegen_base.py
+++ b/schema_salad/codegen_base.py
@@ -76,6 +76,7 @@ class CodeGenBase(object):
         abstract: bool,
         field_names: MutableSequence[str],
         idfield: str,
+        optional_fields: MutableSequence[str],
     ) -> None:
         """Produce the header for the given class."""
         raise NotImplementedError()

--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -154,6 +154,7 @@ class JavaCodeGen(CodeGenBase):
         abstract: bool,
         field_names: MutableSequence[str],
         idfield: str,
+        optional_fields: MutableSequence[str],
     ) -> None:
         cls = self.interface_name(classname)
         self.current_class = cls

--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -4,7 +4,16 @@ import shutil
 import string
 from io import StringIO
 from io import open as io_open
-from typing import Any, Dict, List, MutableMapping, MutableSequence, Optional, Union, Set
+from typing import (
+    Any,
+    Dict,
+    List,
+    MutableMapping,
+    MutableSequence,
+    Optional,
+    Union,
+    Set,
+)
 from urllib.parse import urlsplit
 
 import pkg_resources

--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -4,7 +4,7 @@ import shutil
 import string
 from io import StringIO
 from io import open as io_open
-from typing import Any, Dict, List, MutableMapping, MutableSequence, Optional, Union
+from typing import Any, Dict, List, MutableMapping, MutableSequence, Optional, Union, Set
 from urllib.parse import urlsplit
 
 import pkg_resources
@@ -154,7 +154,7 @@ class JavaCodeGen(CodeGenBase):
         abstract: bool,
         field_names: MutableSequence[str],
         idfield: str,
-        optional_fields: MutableSequence[str],
+        optional_fields: Set[str],
     ) -> None:
         cls = self.interface_name(classname)
         self.current_class = cls

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -80,6 +80,7 @@ class PythonCodeGen(CodeGenBase):
         abstract,  # type: bool
         field_names,  # type: MutableSequence[str]
         idfield,  # type: str
+        optional_fields, # type: MutableSequence[str]
     ):  # type: (...) -> None
         classname = self.safe_name(classname)
 
@@ -102,11 +103,21 @@ class PythonCodeGen(CodeGenBase):
             self.out.write("    pass\n\n\n")
             return
 
+        required_field_names = [f for f in field_names if f not in optional_fields]
+        optional_field_names = [f for f in field_names if f in optional_fields]
+
         safe_inits = ["        self,"]  # type: List[str]
         safe_inits.extend(
             [
                 "        {},  # type: Any".format(self.safe_name(f))
-                for f in field_names
+                for f in required_field_names
+                if f != "class"
+            ]
+        )
+        safe_inits.extend(
+            [
+                "        {}=None,  # type: Any".format(self.safe_name(f))
+                for f in optional_field_names
                 if f != "class"
             ]
         )

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -74,13 +74,13 @@ class PythonCodeGen(CodeGenBase):
 
     def begin_class(
         self,  # pylint: disable=too-many-arguments
-        classname,  # type: str
-        extends,  # type: MutableSequence[str]
-        doc,  # type: str
-        abstract,  # type: bool
-        field_names,  # type: MutableSequence[str]
-        idfield,  # type: str
-        optional_fields, # type: MutableSequence[str]
+        classname: str,
+        extends: MutableSequence[str],
+        doc: str,
+        abstract: bool,
+        field_names: MutableSequence[str],
+        idfield: str,
+        optional_fields: MutableSequence[str],
     ):  # type: (...) -> None
         classname = self.safe_name(classname)
 

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -1,6 +1,6 @@
 """Python code generator for a given schema salad definition."""
 from io import StringIO
-from typing import IO, Any, Dict, List, MutableMapping, MutableSequence, Optional, Union
+from typing import IO, Any, Dict, List, MutableMapping, MutableSequence, Optional, Union, Set
 
 from pkg_resources import resource_stream
 
@@ -80,7 +80,7 @@ class PythonCodeGen(CodeGenBase):
         abstract: bool,
         field_names: MutableSequence[str],
         idfield: str,
-        optional_fields: MutableSequence[str],
+        optional_fields: Set[str],
     ):  # type: (...) -> None
         classname = self.safe_name(classname)
 

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -1,6 +1,16 @@
 """Python code generator for a given schema salad definition."""
 from io import StringIO
-from typing import IO, Any, Dict, List, MutableMapping, MutableSequence, Optional, Union, Set
+from typing import (
+    IO,
+    Any,
+    Dict,
+    List,
+    MutableMapping,
+    MutableSequence,
+    Optional,
+    Union,
+    Set,
+)
 
 from pkg_resources import resource_stream
 


### PR DESCRIPTION
Hi @mr-c, @tetron, per the discussion in:

- Closes: https://github.com/common-workflow-language/schema_salad/issues/262
- https://github.com/common-workflow-language/python-cwlgen/issues/27
- Discussed in [2020-05-12 EMEA-Americas Common Workflow Language meeting notes](https://docs.google.com/document/d/1BsUKJzUiOJw8SjEF0fuiXxFgBY8gMBgRhZHF2x5b53M/edit)

This adds extra annotations to the schema salad python codegen to make parameters that are not required, optional within the class initialiser. 
### Example

Before: 

```python
class Workflow(Process):
  def __init__(self, inputs, outputs , steps, id, label, doc, requirements, hints, cwlVersion, extension_fields, loadingOptions):
    pass # init code here
```

After:

> Note, this isn't the actual generated code due to the codegen injecting type annotations

```python
class Workflow(Process):
  def __init__(self, inputs, outputs, steps, id=None, label=None, doc=None, requirements=None, hints=None, cwlVersion=None, extension_fields=None, loadingOptions=None):
    pass
```

### Summary of changes

- I've added `optional_fields` to `CodeGenBase.begin_class`
- The logic designed to determine if a field is optional comes from https://github.com/common-workflow-language/schema_salad/blob/0ee6ec466bd94ded2919d7b55f3362d4855a4c08/schema_salad/makedoc.py#L433-L440
    - Nb, the `opt` variable name in the referred code is inverted: https://github.com/common-workflow-language/schema_salad/blob/0ee6ec466bd94ded2919d7b55f3362d4855a4c08/schema_salad/makedoc.py#L453
- We modify the argument order in Python to prioritise the required arguments (this is a Python requirement). For the optional arguments, we add `"=None"` the `safe_inits` argument.


### Testing

- Thanks to @TMiguelT for performing some preliminary testing.
- I've written a test migration from cwlgen for Janis: https://github.com/PMCC-BioinformaticsCore/janis-core/pull/21. There are a few minor things to fix up, but it's almost there.


### From here

If possible, I'd love to get this in before Tuesday so I can talk about future of cwlgen too. Happy to attend the regular Tuesday CWL chat.

After this PR has merged, 
- I'll document my migration from cwlgen, 
- Regenerate (or ask someone politely to regenerate) the CWL in cwl-utils with these changes
- Formally propose deprecating cwlgen in favour of cwl-utils. 