### PR TITLE
Revert "Make non-required parameters in Python codegen optional 

### DIFF
--- a/schema_salad/codegen.py
+++ b/schema_salad/codegen.py
@@ -1,7 +1,7 @@
 """Generate langauge specific loaders for a particular SALAD schema."""
 import sys
 from io import open
-from typing import Any, Dict, List, MutableMapping, MutableSequence, Optional
+from typing import Any, Dict, List, MutableMapping, Optional
 
 from . import schema
 from .codegen_base import CodeGenBase
@@ -63,16 +63,8 @@ def codegen(
                 document_roots.append(rec["name"])
 
             field_names = []
-            optional_fields = set()
             for field in rec.get("fields", []):
-                field_name = shortname(field["name"])
-                field_names.append(field_name)
-                tp = field["type"]
-                if (
-                    isinstance(tp, MutableSequence)
-                    and tp[0] == "https://w3id.org/cwl/salad#null"
-                ):
-                    optional_fields.add(field_name)
+                field_names.append(shortname(field["name"]))
 
             idfield = ""
             for field in rec.get("fields", []):
@@ -86,7 +78,6 @@ def codegen(
                 rec.get("abstract", False),
                 field_names,
                 idfield,
-                optional_fields,
             )
             gen.add_vocab(shortname(rec["name"]), rec["name"])
 

--- a/schema_salad/codegen_base.py
+++ b/schema_salad/codegen_base.py
@@ -1,6 +1,6 @@
 """Base class for the generation of loaders from schema-salad definitions."""
 import collections
-from typing import Any, Dict, List, MutableSequence, Optional, Union, Set
+from typing import Any, Dict, List, MutableSequence, Optional, Union
 
 from . import schema
 
@@ -76,7 +76,6 @@ class CodeGenBase(object):
         abstract: bool,
         field_names: MutableSequence[str],
         idfield: str,
-        optional_fields: Set[str],
     ) -> None:
         """Produce the header for the given class."""
         raise NotImplementedError()

--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -4,16 +4,7 @@ import shutil
 import string
 from io import StringIO
 from io import open as io_open
-from typing import (
-    Any,
-    Dict,
-    List,
-    MutableMapping,
-    MutableSequence,
-    Optional,
-    Union,
-    Set,
-)
+from typing import Any, Dict, List, MutableMapping, MutableSequence, Optional, Union
 from urllib.parse import urlsplit
 
 import pkg_resources
@@ -163,7 +154,6 @@ class JavaCodeGen(CodeGenBase):
         abstract: bool,
         field_names: MutableSequence[str],
         idfield: str,
-        optional_fields: Set[str],
     ) -> None:
         cls = self.interface_name(classname)
         self.current_class = cls

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -1,16 +1,6 @@
 """Python code generator for a given schema salad definition."""
 from io import StringIO
-from typing import (
-    IO,
-    Any,
-    Dict,
-    List,
-    MutableMapping,
-    MutableSequence,
-    Optional,
-    Union,
-    Set,
-)
+from typing import IO, Any, Dict, List, MutableMapping, MutableSequence, Optional, Union
 
 from pkg_resources import resource_stream
 
@@ -84,13 +74,12 @@ class PythonCodeGen(CodeGenBase):
 
     def begin_class(
         self,  # pylint: disable=too-many-arguments
-        classname: str,
-        extends: MutableSequence[str],
-        doc: str,
-        abstract: bool,
-        field_names: MutableSequence[str],
-        idfield: str,
-        optional_fields: Set[str],
+        classname,  # type: str
+        extends,  # type: MutableSequence[str]
+        doc,  # type: str
+        abstract,  # type: bool
+        field_names,  # type: MutableSequence[str]
+        idfield,  # type: str
     ):  # type: (...) -> None
         classname = self.safe_name(classname)
 
@@ -113,21 +102,11 @@ class PythonCodeGen(CodeGenBase):
             self.out.write("    pass\n\n\n")
             return
 
-        required_field_names = [f for f in field_names if f not in optional_fields]
-        optional_field_names = [f for f in field_names if f in optional_fields]
-
         safe_inits = ["        self,"]  # type: List[str]
         safe_inits.extend(
             [
                 "        {},  # type: Any".format(self.safe_name(f))
-                for f in required_field_names
-                if f != "class"
-            ]
-        )
-        safe_inits.extend(
-            [
-                "        {}=None,  # type: Any".format(self.safe_name(f))
-                for f in optional_field_names
+                for f in field_names
                 if f != "class"
             ]
         )


### PR DESCRIPTION
Alas, we can try again once the parsing / order bug shown at https://github.com/common-workflow-language/cwl-utils/pull/14 is fixed

This reverts commit 5b494860842eac06a428bb891aef0bab3b0460a7.