### PR TITLE
Optional codegen args

### DIFF
--- a/schema_salad/codegen.py
+++ b/schema_salad/codegen.py
@@ -73,7 +73,7 @@ def codegen(
                     and tp[0] == "https://w3id.org/cwl/salad#null"
                 ):
                     optional_fields.add(field_name)
-                    
+
             idfield = ""
             for field in rec.get("fields", []):
                 if field.get("jsonldPredicate") == "@id":
@@ -86,7 +86,7 @@ def codegen(
                 rec.get("abstract", False),
                 field_names,
                 idfield,
-                optional_fields
+                optional_fields,
             )
             gen.add_vocab(shortname(rec["name"]), rec["name"])
 

--- a/schema_salad/codegen_base.py
+++ b/schema_salad/codegen_base.py
@@ -1,6 +1,6 @@
 """Base class for the generation of loaders from schema-salad definitions."""
 import collections
-from typing import Any, Dict, List, MutableSequence, Optional, Union
+from typing import Any, Dict, List, MutableSequence, Optional, Union, Set
 
 from . import schema
 
@@ -76,7 +76,7 @@ class CodeGenBase(object):
         abstract: bool,
         field_names: MutableSequence[str],
         idfield: str,
-        optional_fields: MutableSequence[str],
+        optional_fields: Set[str],
     ) -> None:
         """Produce the header for the given class."""
         raise NotImplementedError()

--- a/schema_salad/codegen_base.py
+++ b/schema_salad/codegen_base.py
@@ -76,6 +76,7 @@ class CodeGenBase(object):
         abstract: bool,
         field_names: MutableSequence[str],
         idfield: str,
+        optional_fields: MutableSequence[str],
     ) -> None:
         """Produce the header for the given class."""
         raise NotImplementedError()

--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -154,6 +154,7 @@ class JavaCodeGen(CodeGenBase):
         abstract: bool,
         field_names: MutableSequence[str],
         idfield: str,
+        optional_fields: MutableSequence[str],
     ) -> None:
         cls = self.interface_name(classname)
         self.current_class = cls

--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -4,7 +4,16 @@ import shutil
 import string
 from io import StringIO
 from io import open as io_open
-from typing import Any, Dict, List, MutableMapping, MutableSequence, Optional, Union, Set
+from typing import (
+    Any,
+    Dict,
+    List,
+    MutableMapping,
+    MutableSequence,
+    Optional,
+    Union,
+    Set,
+)
 from urllib.parse import urlsplit
 
 import pkg_resources

--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -4,7 +4,7 @@ import shutil
 import string
 from io import StringIO
 from io import open as io_open
-from typing import Any, Dict, List, MutableMapping, MutableSequence, Optional, Union
+from typing import Any, Dict, List, MutableMapping, MutableSequence, Optional, Union, Set
 from urllib.parse import urlsplit
 
 import pkg_resources
@@ -154,7 +154,7 @@ class JavaCodeGen(CodeGenBase):
         abstract: bool,
         field_names: MutableSequence[str],
         idfield: str,
-        optional_fields: MutableSequence[str],
+        optional_fields: Set[str],
     ) -> None:
         cls = self.interface_name(classname)
         self.current_class = cls

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -80,6 +80,7 @@ class PythonCodeGen(CodeGenBase):
         abstract,  # type: bool
         field_names,  # type: MutableSequence[str]
         idfield,  # type: str
+        optional_fields, # type: MutableSequence[str]
     ):  # type: (...) -> None
         classname = self.safe_name(classname)
 
@@ -102,11 +103,21 @@ class PythonCodeGen(CodeGenBase):
             self.out.write("    pass\n\n\n")
             return
 
+        required_field_names = [f for f in field_names if f not in optional_fields]
+        optional_field_names = [f for f in field_names if f in optional_fields]
+
         safe_inits = ["        self,"]  # type: List[str]
         safe_inits.extend(
             [
                 "        {},  # type: Any".format(self.safe_name(f))
-                for f in field_names
+                for f in required_field_names
+                if f != "class"
+            ]
+        )
+        safe_inits.extend(
+            [
+                "        {}=None,  # type: Any".format(self.safe_name(f))
+                for f in optional_field_names
                 if f != "class"
             ]
         )

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -74,13 +74,13 @@ class PythonCodeGen(CodeGenBase):
 
     def begin_class(
         self,  # pylint: disable=too-many-arguments
-        classname,  # type: str
-        extends,  # type: MutableSequence[str]
-        doc,  # type: str
-        abstract,  # type: bool
-        field_names,  # type: MutableSequence[str]
-        idfield,  # type: str
-        optional_fields, # type: MutableSequence[str]
+        classname: str,
+        extends: MutableSequence[str],
+        doc: str,
+        abstract: bool,
+        field_names: MutableSequence[str],
+        idfield: str,
+        optional_fields: MutableSequence[str],
     ):  # type: (...) -> None
         classname = self.safe_name(classname)
 

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -258,9 +258,11 @@ class PythonCodeGen(CodeGenBase):
             "    attrs = frozenset({attrs})\n".format(attrs=field_names)
         )
 
-        safe_inits = [
+        safe_init_fields = [
             self.safe_name(f) for f in field_names if f != "class"
         ]  # type: List[str]
+
+        safe_inits = [f + "=" + f for f in safe_init_fields]
 
         safe_inits.extend(
             ["extension_fields=extension_fields", "loadingOptions=loadingOptions"]

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -1,6 +1,6 @@
 """Python code generator for a given schema salad definition."""
 from io import StringIO
-from typing import IO, Any, Dict, List, MutableMapping, MutableSequence, Optional, Union
+from typing import IO, Any, Dict, List, MutableMapping, MutableSequence, Optional, Union, Set
 
 from pkg_resources import resource_stream
 
@@ -80,7 +80,7 @@ class PythonCodeGen(CodeGenBase):
         abstract: bool,
         field_names: MutableSequence[str],
         idfield: str,
-        optional_fields: MutableSequence[str],
+        optional_fields: Set[str],
     ):  # type: (...) -> None
         classname = self.safe_name(classname)
 

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -1,6 +1,16 @@
 """Python code generator for a given schema salad definition."""
 from io import StringIO
-from typing import IO, Any, Dict, List, MutableMapping, MutableSequence, Optional, Union, Set
+from typing import (
+    IO,
+    Any,
+    Dict,
+    List,
+    MutableMapping,
+    MutableSequence,
+    Optional,
+    Union,
+    Set,
+)
 
 from pkg_resources import resource_stream
 


### PR DESCRIPTION
Reopens  #330

Thanks @mr-c for testing this in CWLUtils. Unfortunately the parameter reordering broke the parsing. I've added https://github.com/common-workflow-language/schema_salad/commit/b9a30fff334dc135845fcfb0b0e092d1a3acfa78 to address this problem by making `doc.load` to use kwargs (named arguments) instead of the original ordered arguments. 

I'll issue a CWL-utils PR with the updated generated code and hopefully travis will pass these to show this fix.

