### PR TITLE
Raise validation exception if element in list of URIs is not a string.

### DIFF
--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -403,17 +403,22 @@ class _URILoader(_Loader):
     def load(self, doc, baseuri, loadingOptions, docRoot=None):
         # type: (Any, str, LoadingOptions, Optional[str]) -> Any
         if isinstance(doc, MutableSequence):
-            doc = [
-                expand_url(
-                    i,
-                    baseuri,
-                    loadingOptions,
-                    self.scoped_id,
-                    self.vocab_term,
-                    self.scoped_ref,
+            doc = []
+            for i in doc:
+                if not isinstance(i, str):
+                    raise ValidationException(
+                        f"Expected a list of strings, but item was {typeof(i)}"
+                    )
+                doc.append(
+                    expand_url(
+                        i,
+                        baseuri,
+                        loadingOptions,
+                        self.scoped_id,
+                        self.vocab_term,
+                        self.scoped_ref,
+                    )
                 )
-                for i in doc
-            ]
         if isinstance(doc, str):
             doc = expand_url(
                 doc,

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -407,7 +407,7 @@ class _URILoader(_Loader):
             for i in doc:
                 if not isinstance(i, str):
                     raise ValidationException(
-                        f"Expected a list of strings, but item was {typeof(i)}"
+                        f"Expected a list of strings, but item was {type(i)}"
                     )
                 doc.append(
                     expand_url(


### PR DESCRIPTION
Fix URILoader when in a union type that includes arrays of objects.  refs #359 