### PR TITLE
JSON float type

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,11 +14,13 @@ jobs:
       with:
         pre-build-command: source .github/workflows/wheel-prep.sh
         build-requirements: mypy -rrequirements.txt
+        python-version: cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39
     - name: Build manylinux2014 Python wheels
       uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2014_x86_64
       with:
         pre-build-command: source .github/workflows/wheel-prep.sh
         build-requirements: mypy -rrequirements.txt
+        python-version: cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39
     - name: Move audited wheels to new directory
       run: mkdir audited_wheels && cp dist/*-manylinux*.whl audited_wheels/
     - name: Publish wheels to PyPI

--- a/schema_salad/avro/schema.py
+++ b/schema_salad/avro/schema.py
@@ -58,13 +58,13 @@ SCHEMA_RESERVED_PROPS = (
 # MappingDataType = Dict[str, Union[PropType, List[PropsType]]]
 # was: Union[str, MappingDataType, List[MappingDataType]]
 JsonDataType = Any
-AtomicPropType = Union[str, int, bool, "Schema", List[str], List["Field"]]
+AtomicPropType = Union[None, str, int, float, bool, "Schema", List[str], List["Field"]]
 PropType = Union[
     AtomicPropType,
-    Dict[str, Optional[AtomicPropType]],
-    List[Dict[str, Optional[AtomicPropType]]],
+    Dict[str, AtomicPropType],
+    List[Dict[str, AtomicPropType]],
 ]
-PropsType = Dict[str, Optional[PropType]]
+PropsType = Dict[str, PropType]
 
 FIELD_RESERVED_PROPS = ("default", "name", "doc", "order", "type")
 

--- a/schema_salad/schema.py
+++ b/schema_salad/schema.py
@@ -434,8 +434,7 @@ def replace_type(
     find_embeds: bool = True,
     deepen: bool = True,
 ) -> Any:
-    """ Go through and replace types in the 'spec' mapping"""
-
+    """Go through and replace types in the 'spec' mapping."""
     if isinstance(items, MutableMapping):
         # recursively check these fields for types to replace
         if items.get("type") in ("record", "enum") and items.get("name"):

--- a/schema_salad/utils.py
+++ b/schema_salad/utils.py
@@ -98,7 +98,7 @@ def json_dump(
     fp,  # type: IO[str]
     **kwargs  # type: Any
 ):  # type: (...) -> None
-    """ Force use of unicode. """
+    """Force use of unicode."""
     json.dump(convert_to_dict(obj), fp, **kwargs)
 
 
@@ -106,5 +106,5 @@ def json_dumps(
     obj,  # type: Any
     **kwargs  # type: Any
 ):  # type: (...) -> str
-    """ Force use of unicode. """
+    """Force use of unicode."""
     return json.dumps(convert_to_dict(obj), **kwargs)


### PR DESCRIPTION
Fixes #385 

Due to recent binary wheel publishing using mypyc. Issue troubleshooting complicated due to lack of published Python 3.9 binary wheel for schema-salad; which this PR works around https://github.com/RalfG/python-wheels-manylinux-build/pull/33 not being released yet

- [ ] add a test

Locally I tested this by using a Python 3.7 virtualenv; ensuring that one of the manylinux binary wheels was installed from https://pypi.org/project/schema-salad/7.1.20210316164414/#files and running 

`cwltool https://github.com/ncbi/pgap/raw/b56520bb683f8b795974f32d19bdcae09b84e590/task_types/tt_kmer_top_n_extract.cwl --gcextract2_sqlite README.rst --ref_assembly_id 0 --ref_assembly_taxid 0 --taxon_db README.rst --top_distances README.rst`

Without this fix I am able to reproduce the error in #385

Locally I did a `make mypyc` in my schema_salad checkout to create the mypyc binaries; then I `pip install -e` that directory. Repeating the above test, the ScalarFloat error is gone (and I get an error about my bogus inputs to that workflow)