### PR TITLE
Fix type annotation of renderlist

### DIFF
--- a/schema_salad/makedoc.py
+++ b/schema_salad/makedoc.py
@@ -187,7 +187,7 @@ class RenderType:
         self,
         toc: ToC,
         j: List[Dict[str, str]],
-        renderlist: str,
+        renderlist: List[str],
         redirects: Dict[str, str],
         primitiveType: str,
     ) -> None:
@@ -496,7 +496,7 @@ class RenderType:
 def avrold_doc(
     j: List[Dict[str, Any]],
     outdoc: Union[IO[Any], StreamWriter],
-    renderlist: str,
+    renderlist: List[str],
     redirects: Dict[str, str],
     brand: str,
     brandlink: str,


### PR DESCRIPTION
Fix:

```
schema-salad-doc --brandstyle '<link rel="stylesheet" href="https://jamestaylor.org/galaxy-bootstrap/galaxy_bootstrap.css">' --brandinverse --brand '<img src="icon.png" />' --only https://galaxyproject.org/gxformat2/v19_09#WorkflowDoc --only https://galaxyproject.org/gxformat2/v19_09#GalaxyWorkflow workflow.yml
Traceback (most recent call last):
  File "/home/soranzon/software/nsoranzo_gxformat2/.venv/bin/schema-salad-doc", line 8, in <module>
    sys.exit(main())
  File "schema_salad/makedoc.py", line 695, in main
  File "schema_salad/makedoc.py", line 730, in makedoc
TypeError: str object expected; got list
```