### PR TITLE
Pin ruamel.yaml below 0.17, exclude 0.16.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ruamel.yaml>=0.12.4, <= 0.16.5
+ruamel.yaml>=0.12.4, != 0.16.6, <0.17
 rdflib>=4.2.2, <= 5.0.0
 rdflib-jsonld>=0.4.0, <0.6.0
 mistune>=0.8.1,<0.9

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ else:
 install_requires = [
     "setuptools",
     "requests >= 1.0",
-    "ruamel.yaml >= 0.12.4, <= 0.16.5",
+    "ruamel.yaml >= 0.12.4, !=0.16.6, < 0.17",
     # once the minimum version for ruamel.yaml >= 0.15.99
     # then please update the mypy targets in the Makefile
     "rdflib >= 4.2.2, <= 5.0.0",


### PR DESCRIPTION
The original type annotation bug had been fixed in 0.16.6 (https://sourceforge.net/p/ruamel-yaml/code/ci/default/tree/CHANGES). 0.17 contains some breaking changes, hence the pin <0.17. 