### PR TITLE
resolver: inject fewer IDs

### DIFF
--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -997,12 +997,15 @@ class Loader:
         except MarkedYAMLError as e:
             raise to_validation_exception(e) from e
         if isinstance(result, CommentedMap) and inject_ids and bool(self.identifiers):
+            missing_identifier = True
             for identifier in self.identifiers:
-                if identifier not in result:
-                    result[identifier] = url
-                self.idx[
-                    self.expand_url(result[identifier], url, scoped_id=True)
-                ] = result
+                if identifier in result:
+                    missing_identifier = False
+                    self.idx[
+                        self.expand_url(result[identifier], url, scoped_id=True)
+                    ] = result
+            if missing_identifier:
+                result[self.identifiers[0]] = url
         self.idx[url] = result
         return result
 


### PR DESCRIPTION
- [ ] bump the minor version due to the behavior change?

Fixes https://github.com/common-workflow-language/cwltool/issues/1505 and partially addresses https://github.com/common-workflow-language/cwl-utils/issues/71

Will still inject an `id` (or other identifier) in some circumstances.

For example with CWL: https://github.com/common-workflow-language/cwl-v1.2/blob/main/tests/schemadef-wf.cwl#L7 will result in `"id": "#schemadef-type.yml"` as part of the first entry in `requirements` as show below

``` cwl
{
    "$graph": [
        {
            "class": "CommandLineTool",
            "requirements": [
                {
                    "class": "SchemaDefRequirement",
                    "types": [
                        {
                            "name": "#schemadef-type.yml/HelloType",
                            "type": "record",
                            "fields": [
                                {
                                    "name": "#schemadef-type.yml/HelloType/a",
                                    "type": "string"
                                },
                                {
                                    "name": "#schemadef-type.yml/HelloType/b",
                                    "type": "string"
                                }
                            ]
                        }
                    ],
                    "id": "#schemadef-type.yml"
                }
            ],
            "inputs": [
                {
                    "id": "#schemadef-tool.cwl/hello",
                    "type": "#schemadef-type.yml/HelloType",
                    "inputBinding": {
                        "valueFrom": "$(self.a)/$(self.b)"
                    }
                }
            ],
            "outputs": [
                {
                    "id": "#schemadef-tool.cwl/output",
                    "type": "File",
                    "outputBinding": {
                        "glob": "output.txt"
                    }
                }
            ],
            "stdout": "output.txt",
            "baseCommand": "echo",
            "id": "#schemadef-tool.cwl"
        },
        {
            "class": "Workflow",
            "requirements": [
                {
                    "$import": "#schemadef-type.yml"
                }
            ],
            "inputs": [
                {
                    "type": "#schemadef-type.yml/HelloType",
                    "id": "#main/hello"
                }
            ],
            "outputs": [
                {
                    "type": "File",
                    "outputSource": "#main/step1/output",
                    "id": "#main/output"
                }
            ],
            "steps": [
                {
                    "in": [
                        {
                            "source": "#main/hello",
                            "id": "#main/step1/hello"
                        }
                    ],
                    "out": [
                        "#main/step1/output"
                    ],
                    "run": "#schemadef-tool.cwl",
                    "id": "#main/step1"
                }
            ],
            "id": "#main"
        }
    ],
    "cwlVersion": "v1.2"
```
