### PR TITLE
Revert "setuptools 58 is not currently compatible"

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upgrade setuptools and install tox
         run: |
-          pip install -U pip setuptools==57.5.0 wheel
+          pip install -U pip setuptools wheel
           pip install tox tox-gh-actions
 
       - name: MyPy cache
@@ -85,7 +85,7 @@ jobs:
             ${{ env.img }} \
             bash -exc '${{ env.py }} -m pip install virtualenv && ${{ env.py }} -m venv .env && \
             source .env/bin/activate && \
-            python -m pip install --upgrade pip wheel setuptools==57.5.0 && \
+            python -m pip install --upgrade pip wheel setuptools && \
             python -m pip install -r mypy_requirements.txt -r requirements.txt && \
             MYPYPATH=typeshed SCHEMA_SALAD_USE_MYPYC=1 pip install -e . && \
             deactivate'
@@ -95,7 +95,7 @@ jobs:
             ${{ env.img }} \
             bash -exc '\
             source .env/bin/activate && \
-            pip install setuptools==57.5.0 wheel -r test-requirements.txt && \
+            pip install setuptools wheel -r test-requirements.txt && \
             make mypyc
             deactivate'
 
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upgrade setuptools and install tox
         run: |
-          pip install -U pip setuptools==57.5.0 wheel
+          pip install -U pip setuptools wheel
           pip install tox tox-gh-actions
 
       - if: ${{ matrix.step == 'pydocstyle' && github.event_name == 'pull_request'}}
@@ -161,7 +161,7 @@ jobs:
 
       - name: Install packages
         run: |
-          pip install -U pip setuptools==57.5.0 wheel
+          pip install -U pip setuptools wheel
           pip install virtualenv
 
       - name: Release test


### PR DESCRIPTION
The issue has been fixe by a new release of rdflib-jsonld

This reverts commit 9454285a15ce465ee6749ae3edb47dc473e4326b.