### PR TITLE
Fix primitive type loading for java and python codegen

### DIFF
--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -54,103 +54,72 @@ def _safe_makedirs(path):
         os.makedirs(path)
 
 
+_string_type_def = TypeDef(
+    instance_type="String",
+    init="new PrimitiveLoader<String>(String.class)",
+    name="StringInstance",
+    loader_type="Loader<String>",
+)
+
+_int_type_def = TypeDef(
+    instance_type="Integer",
+    init="new PrimitiveLoader<Integer>(Integer.class)",
+    name="IntegerInstance",
+    loader_type="Loader<Integer>",
+)
+
+_long_type_def = TypeDef(
+    instance_type="Long",
+    name="LongInstance",
+    loader_type="Loader<Long>",
+    init="new PrimitiveLoader<Long>(Long.class)",
+)
+
+_float_type_def = TypeDef(
+    instance_type="Double",
+    name="DoubleInstance",
+    loader_type="Loader<Double>",
+    init="new PrimitiveLoader<Double>(Double.class)",
+)
+
+_bool_type_def = TypeDef(
+    instance_type="Boolean",
+    name="BooleanInstance",
+    loader_type="Loader<Boolean>",
+    init="new PrimitiveLoader<Boolean>(Boolean.class)",
+)
+
+_null_type_def = TypeDef(
+    instance_type="Object",
+    name="NullInstance",
+    loader_type="Loader<Object>",
+    init="new NullLoader()",
+)
+
+_any_type_def = TypeDef(
+    instance_type="Object",
+    name="AnyInstance",
+    init="new AnyLoader()",
+    loader_type="Loader<Object>",
+)
+
 prims = {
-    "http://www.w3.org/2001/XMLSchema#string": TypeDef(
-        instance_type="String",
-        init="new PrimitiveLoader<String>(String.class)",
-        name="StringInstance",
-        loader_type="Loader<String>",
-    ),
-    "http://www.w3.org/2001/XMLSchema#int": TypeDef(
-        instance_type="Integer",
-        init="new PrimitiveLoader<Integer>(Integer.class)",
-        name="IntegerInstance",
-        loader_type="Loader<Integer>",
-    ),
-    "http://www.w3.org/2001/XMLSchema#long": TypeDef(
-        instance_type="Long",
-        name="LongInstance",
-        loader_type="Loader<Long>",
-        init="new PrimitiveLoader<Long>(Long.class)",
-    ),
-    "http://www.w3.org/2001/XMLSchema#float": TypeDef(
-        instance_type="Double",
-        name="DoubleInstance",
-        loader_type="Loader<Double>",
-        init="new PrimitiveLoader<Double>(Double.class)",
-    ),
-    "http://www.w3.org/2001/XMLSchema#double": TypeDef(
-        instance_type="Double",
-        name="DoubleInstance",
-        loader_type="Loader<Double>",
-        init="new PrimitiveLoader<Double>(Double.class)",
-    ),
-    "http://www.w3.org/2001/XMLSchema#boolean": TypeDef(
-        instance_type="Boolean",
-        name="BooleanInstance",
-        loader_type="Loader<Boolean>",
-        init="new PrimitiveLoader<Boolean>(Boolean.class)",
-    ),
-    "https://w3id.org/cwl/salad#null": TypeDef(
-        instance_type="Object",
-        name="NullInstance",
-        loader_type="Loader<Object>",
-        init="new NullLoader()",
-    ),
-    "https://w3id.org/cwl/salad#Any": TypeDef(
-        instance_type="Object",
-        name="AnyInstance",
-        init="new AnyLoader()",
-        loader_type="Loader<Object>",
-    ),
-    "string": TypeDef(
-        instance_type="String",
-        init="new PrimitiveLoader<String>(String.class)",
-        name="StringInstance",
-        loader_type="Loader<String>",
-    ),
-    "int": TypeDef(
-        instance_type="Integer",
-        init="new PrimitiveLoader<Integer>(Integer.class)",
-        name="IntegerInstance",
-        loader_type="Loader<Integer>",
-    ),
-    "long": TypeDef(
-        instance_type="Long",
-        name="LongInstance",
-        loader_type="Loader<Long>",
-        init="new PrimitiveLoader<Long>(Long.class)",
-    ),
-    "float": TypeDef(
-        instance_type="Double",
-        name="DoubleInstance",
-        loader_type="Loader<Double>",
-        init="new PrimitiveLoader<Double>(Double.class)",
-    ),
-    "double": TypeDef(
-        instance_type="Double",
-        name="DoubleInstance",
-        loader_type="Loader<Double>",
-        init="new PrimitiveLoader<Double>(Double.class)",
-    ),
-    "boolean": TypeDef(
-        instance_type="Boolean",
-        name="BooleanInstance",
-        loader_type="Loader<Boolean>",
-        init="new PrimitiveLoader<Boolean>(Boolean.class)",
-    ),
-    "null": TypeDef(
-        instance_type="Object",
-        name="NullInstance",
-        loader_type="Loader<Object>",
-        init="new NullLoader()",
-    ),
-    "Any": TypeDef(
-        instance_type="Object",
-        name="AnyInstance",
-        init="new AnyLoader()",
-        loader_type="Loader<Object>",
-    ),
+    "http://www.w3.org/2001/XMLSchema#string": _string_type_def,
+    "http://www.w3.org/2001/XMLSchema#int": _int_type_def,
+    "http://www.w3.org/2001/XMLSchema#long": _long_type_def,
+    "http://www.w3.org/2001/XMLSchema#float": _float_type_def,
+    "http://www.w3.org/2001/XMLSchema#double": _float_type_def,
+    "http://www.w3.org/2001/XMLSchema#boolean": _bool_type_def,
+    "https://w3id.org/cwl/salad#null": _null_type_def,
+    "https://w3id.org/cwl/salad#Any": _any_type_def,
+    "string": _string_type_def,
+    "int": _int_type_def,
+    "long": _long_type_def,
+    "float": _float_type_def,
+    "double": _float_type_def,
+    "boolean": _bool_type_def,
+    "null": _null_type_def,
+    "Any": _any_type_def,
 }
 
 

--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -103,6 +103,54 @@ prims = {
         init="new AnyLoader()",
         loader_type="Loader<Object>",
     ),
+    "string": TypeDef(
+        instance_type="String",
+        init="new PrimitiveLoader<String>(String.class)",
+        name="StringInstance",
+        loader_type="Loader<String>",
+    ),
+    "int": TypeDef(
+        instance_type="Integer",
+        init="new PrimitiveLoader<Integer>(Integer.class)",
+        name="IntegerInstance",
+        loader_type="Loader<Integer>",
+    ),
+    "long": TypeDef(
+        instance_type="Long",
+        name="LongInstance",
+        loader_type="Loader<Long>",
+        init="new PrimitiveLoader<Long>(Long.class)",
+    ),
+    "float": TypeDef(
+        instance_type="Double",
+        name="DoubleInstance",
+        loader_type="Loader<Double>",
+        init="new PrimitiveLoader<Double>(Double.class)",
+    ),
+    "double": TypeDef(
+        instance_type="Double",
+        name="DoubleInstance",
+        loader_type="Loader<Double>",
+        init="new PrimitiveLoader<Double>(Double.class)",
+    ),
+    "boolean": TypeDef(
+        instance_type="Boolean",
+        name="BooleanInstance",
+        loader_type="Loader<Boolean>",
+        init="new PrimitiveLoader<Boolean>(Boolean.class)",
+    ),
+    "null": TypeDef(
+        instance_type="Object",
+        name="NullInstance",
+        loader_type="Loader<Object>",
+        init="new NullLoader()",
+    ),
+    "Any": TypeDef(
+        instance_type="Object",
+        name="AnyInstance",
+        init="new AnyLoader()",
+        loader_type="Loader<Object>",
+    ),
 }
 
 

--- a/schema_salad/metaschema.py
+++ b/schema_salad/metaschema.py
@@ -3054,7 +3054,7 @@ _rvocab = {
     "http://www.w3.org/2001/XMLSchema#string": "string",
 }
 
-strtype = _PrimitiveLoader((str, str))
+strtype = _PrimitiveLoader(str)
 inttype = _PrimitiveLoader(int)
 floattype = _PrimitiveLoader(float)
 booltype = _PrimitiveLoader(bool)

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -21,7 +21,7 @@ from .codegen_base import CodeGenBase, TypeDef
 from .exceptions import SchemaException
 from .schema import shortname
 
-_string_type_def = TypeDef("strtype", "_PrimitiveLoader((str, str))")
+_string_type_def = TypeDef("strtype", "_PrimitiveLoader(str)")
 _int_type_def = TypeDef("inttype", "_PrimitiveLoader(int)")
 _float_type_def = TypeDef("floattype", "_PrimitiveLoader(float)")
 _bool_type_def = TypeDef("booltype", "_PrimitiveLoader(bool)")

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -21,32 +21,30 @@ from .codegen_base import CodeGenBase, TypeDef
 from .exceptions import SchemaException
 from .schema import shortname
 
+_string_type_def = TypeDef("strtype", "_PrimitiveLoader((str, str))")
 _int_type_def = TypeDef("inttype", "_PrimitiveLoader(int)")
 _float_type_def = TypeDef("floattype", "_PrimitiveLoader(float)")
+_bool_type_def = TypeDef("booltype", "_PrimitiveLoader(bool)")
+_null_type_def = TypeDef("None_type", "_PrimitiveLoader(type(None))")
+_any_type_def = TypeDef("Any_type", "_AnyLoader()")
 
 prims = {
-    "http://www.w3.org/2001/XMLSchema#string": TypeDef(
-        "strtype", "_PrimitiveLoader((str, str))"
-    ),
+    "http://www.w3.org/2001/XMLSchema#string": _string_type_def,
     "http://www.w3.org/2001/XMLSchema#int": _int_type_def,
     "http://www.w3.org/2001/XMLSchema#long": _int_type_def,
     "http://www.w3.org/2001/XMLSchema#float": _float_type_def,
     "http://www.w3.org/2001/XMLSchema#double": _float_type_def,
-    "http://www.w3.org/2001/XMLSchema#boolean": TypeDef(
-        "booltype", "_PrimitiveLoader(bool)"
-    ),
-    "https://w3id.org/cwl/salad#null": TypeDef(
-        "None_type", "_PrimitiveLoader(type(None))"
-    ),
-    "https://w3id.org/cwl/salad#Any": TypeDef("Any_type", "_AnyLoader()"),
-    "string": TypeDef("strtype", "_PrimitiveLoader((str, str))"),
+    "http://www.w3.org/2001/XMLSchema#boolean": _bool_type_def,
+    "https://w3id.org/cwl/salad#null": _null_type_def,
+    "https://w3id.org/cwl/salad#Any": _any_type_def,
+    "string": _string_type_def,
     "int": _int_type_def,
     "long": _int_type_def,
     "float": _float_type_def,
     "double": _float_type_def,
-    "boolean": TypeDef("booltype", "_PrimitiveLoader(bool)"),
-    "null": TypeDef("None_type", "_PrimitiveLoader(type(None))"),
-    "Any": TypeDef("Any_type", "_AnyLoader()"),
+    "boolean": _bool_type_def,
+    "null": _null_type_def,
+    "Any": _any_type_def,
 }
 
 

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -39,6 +39,14 @@ prims = {
         "None_type", "_PrimitiveLoader(type(None))"
     ),
     "https://w3id.org/cwl/salad#Any": TypeDef("Any_type", "_AnyLoader()"),
+    "string": TypeDef("strtype", "_PrimitiveLoader((str, str))"),
+    "int": _int_type_def,
+    "long": _int_type_def,
+    "float": _float_type_def,
+    "double": _float_type_def,
+    "boolean": TypeDef("booltype", "_PrimitiveLoader(bool)"),
+    "null": TypeDef("None_type", "_PrimitiveLoader(type(None))"),
+    "Any": TypeDef("Any_type", "_AnyLoader()"),
 }
 
 


### PR DESCRIPTION
I'm proposing this as a fix for https://github.com/common-workflow-language/schema_salad/issues/320.
The java codegen had the same problems, which this PR also addresses.