### PR TITLE
Fix #473: Add `--codegen-parser-info`

### DIFF
--- a/release-test.sh
+++ b/release-test.sh
@@ -18,8 +18,8 @@ else
     HEAD=$(git rev-parse HEAD)
 fi
 run_tests="bin/py.test --pyargs ${module}"
-pipver=20.3 # minimum required version of pip for Python 3.10
-setuptoolsver=50.0.0 # required for Python 3.10
+pipver=20.3.3  # minimum required version of pip for Python 3.10
+setuptoolsver=50.0.0  # required for Python 3.10
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 rm -Rf testenv? || /bin/true

--- a/schema_salad/codegen.py
+++ b/schema_salad/codegen.py
@@ -33,6 +33,7 @@ def codegen(
     examples: Optional[str] = None,
     package: Optional[str] = None,
     copyright: Optional[str] = None,
+    parser_info: Optional[str] = None,
 ) -> None:
     """Generate classes with loaders for the given Schema Salad description."""
 
@@ -46,7 +47,7 @@ def codegen(
             )
         else:
             dest = sys.stdout
-        gen = PythonCodeGen(dest, copyright=copyright)
+        gen = PythonCodeGen(dest, copyright=copyright, parser_info=parser_info)
     elif lang == "java":
         gen = JavaCodeGen(
             schema_metadata.get("$base", schema_metadata.get("id")),

--- a/schema_salad/codegen.py
+++ b/schema_salad/codegen.py
@@ -47,7 +47,15 @@ def codegen(
             )
         else:
             dest = sys.stdout
-        gen = PythonCodeGen(dest, copyright=copyright, parser_info=parser_info)
+
+        if parser_info:
+            info: Optional[str] = parser_info
+        elif package:
+            info = package
+        else:
+            info = None
+
+        gen = PythonCodeGen(dest, copyright=copyright, parser_info=info)
     elif lang == "java":
         gen = JavaCodeGen(
             schema_metadata.get("$base", schema_metadata.get("id")),

--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -14,7 +14,6 @@ from typing import (
     Set,
     Union,
 )
-from urllib.parse import urlsplit
 
 import pkg_resources
 
@@ -129,20 +128,13 @@ class JavaCodeGen(CodeGenBase):
         base: str,
         target: Optional[str],
         examples: Optional[str],
-        package: Optional[str],
+        package: str,
         copyright: Optional[str],
     ) -> None:
         super().__init__()
         self.base_uri = base
-        sp = urlsplit(base)
         self.examples = examples
-        self.package = (
-            package
-            if package
-            else ".".join(
-                list(reversed(sp.netloc.split("."))) + sp.path.strip("/").split("/")
-            )
-        )
+        self.package = package
         self.artifact = self.package.split(".")[-1]
         self.copyright = copyright
         self.target_dir = Path(target or ".").resolve()

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -134,7 +134,7 @@ def arg_parser() -> argparse.ArgumentParser:
         metavar="parser_info",
         type=str,
         default=None,
-        help="Optional parser name which is accessible via resulted parser API.",
+        help="Optional parser name which is accessible via resulted parser API (Python only)",
     )
 
     exgroup.add_argument(

--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -129,6 +129,14 @@ def arg_parser() -> argparse.ArgumentParser:
         help="Optional copyright of the input schema.",
     ),
 
+    parser.add_argument(
+        "--codegen-parser-info",
+        metavar="parser_info",
+        type=str,
+        default=None,
+        help="Optional parser name which is accessible via resulted parser API.",
+    )
+
     exgroup.add_argument(
         "--print-oneline",
         action="store_true",
@@ -323,6 +331,7 @@ def main(argsl: Optional[List[str]] = None) -> int:
             examples=args.codegen_examples,
             package=args.codegen_package,
             copyright=args.codegen_copyright,
+            parser_info=args.codegen_parser_info,
         )
         return 0
 

--- a/schema_salad/metaschema.py
+++ b/schema_salad/metaschema.py
@@ -674,6 +674,10 @@ def save_relative_uri(
         return save(uri, top=False, base_url=base_url)
 
 
+def parser_info() -> str:
+    return ""
+
+
 class Documented(Savable):
     pass
 

--- a/schema_salad/metaschema.py
+++ b/schema_salad/metaschema.py
@@ -675,7 +675,7 @@ def save_relative_uri(
 
 
 def parser_info() -> str:
-    return ""
+    return "org.w3id.cwl.salad"
 
 
 class Documented(Savable):

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -68,13 +68,19 @@ def fmt(text: str, indent: int) -> str:
 class PythonCodeGen(CodeGenBase):
     """Generation of Python code for a given Schema Salad definition."""
 
-    def __init__(self, out: IO[str], copyright: Optional[str]) -> None:
+    def __init__(
+        self,
+        out: IO[str],
+        copyright: Optional[str],
+        parser_info: Optional[str],
+    ) -> None:
         super().__init__()
         self.out = out
         self.current_class_is_abstract = False
         self.serializer = StringIO()
         self.idfield = ""
         self.copyright = copyright
+        self.parser_info = parser_info
 
     @staticmethod
     def safe_name(name: str) -> str:
@@ -111,6 +117,18 @@ class PythonCodeGen(CodeGenBase):
         self.out.write(python_codegen_support[python_codegen_support.find("\n") + 1 :])
         stream.close()
         self.out.write("\n\n")
+
+        if self.parser_info:
+            info = self.parser_info
+        else:
+            info = ""
+
+        self.out.write(
+            f"""
+def parser_info() -> str:
+    return "{info}"
+"""
+        )
 
         for primative in prims.values():
             self.declare_type(primative)

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -118,14 +118,9 @@ class PythonCodeGen(CodeGenBase):
         stream.close()
         self.out.write("\n\n")
 
-        if self.parser_info:
-            info = self.parser_info
-        else:
-            info = ""
-
         self.out.write(
             f"""def parser_info() -> str:
-    return "{info}"
+    return "{self.parser_info or ""}"
 
 
 """

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -124,9 +124,7 @@ class PythonCodeGen(CodeGenBase):
             info = ""
 
         self.out.write(
-            f"""
-
-def parser_info() -> str:
+            f"""def parser_info() -> str:
     return "{info}"
 
 

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -127,6 +127,7 @@ class PythonCodeGen(CodeGenBase):
             f"""
 def parser_info() -> str:
     return "{info}"
+
 """
         )
 

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -72,7 +72,7 @@ class PythonCodeGen(CodeGenBase):
         self,
         out: IO[str],
         copyright: Optional[str],
-        parser_info: Optional[str],
+        parser_info: str,
     ) -> None:
         super().__init__()
         self.out = out
@@ -120,7 +120,7 @@ class PythonCodeGen(CodeGenBase):
 
         self.out.write(
             f"""def parser_info() -> str:
-    return "{self.parser_info or ""}"
+    return "{self.parser_info}"
 
 
 """

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -125,8 +125,10 @@ class PythonCodeGen(CodeGenBase):
 
         self.out.write(
             f"""
+
 def parser_info() -> str:
     return "{info}"
+
 
 """
         )

--- a/schema_salad/tests/test_python_codegen.py
+++ b/schema_salad/tests/test_python_codegen.py
@@ -60,6 +60,14 @@ def python_codegen(
     )
 
 
+def test_default_parser_info(tmp_path: Path) -> None:
+    src_target = tmp_path / "src.py"
+    python_codegen(metaschema_file_uri, src_target)
+    assert os.path.exists(src_target)
+    with open(src_target) as f:
+        assert 'def parser_info() -> str:\n    return ""' in f.read()
+
+
 def test_parser_info(tmp_path: Path) -> None:
     src_target = tmp_path / "src.py"
     python_codegen(metaschema_file_uri, src_target, parser_info="cwl")

--- a/schema_salad/tests/test_python_codegen.py
+++ b/schema_salad/tests/test_python_codegen.py
@@ -65,7 +65,7 @@ def test_default_parser_info(tmp_path: Path) -> None:
     python_codegen(metaschema_file_uri, src_target)
     assert os.path.exists(src_target)
     with open(src_target) as f:
-        assert 'def parser_info() -> str:\n    return ""' in f.read()
+        assert 'def parser_info() -> str:\n    return "org.w3id.cwl.salad"' in f.read()
 
 
 def test_parser_info(tmp_path: Path) -> None:

--- a/schema_salad/tests/test_python_codegen.py
+++ b/schema_salad/tests/test_python_codegen.py
@@ -58,4 +58,4 @@ def test_parser_info(tmp_path: Path) -> None:
     python_codegen(metaschema_file_uri, src_target, parser_info="cwl")
     assert os.path.exists(src_target)
     with open(src_target) as f:
-        assert "def parser_info() -> str:    return \"cwl\"" in f.read()
+        assert 'def parser_info() -> str:    return "cwl"' in f.read()

--- a/schema_salad/tests/test_python_codegen.py
+++ b/schema_salad/tests/test_python_codegen.py
@@ -35,7 +35,9 @@ def test_meta_schema_gen_up_to_date(tmp_path: Path) -> None:
         assert f.read() == inspect.getsource(cg_metaschema)
 
 
-def python_codegen(file_uri: str, target: Path, parser_info: Optional[str] = None) -> None:
+def python_codegen(
+    file_uri: str, target: Path, parser_info: Optional[str] = None
+) -> None:
     document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
         file_uri
     )

--- a/schema_salad/tests/test_python_codegen.py
+++ b/schema_salad/tests/test_python_codegen.py
@@ -36,7 +36,10 @@ def test_meta_schema_gen_up_to_date(tmp_path: Path) -> None:
 
 
 def python_codegen(
-    file_uri: str, target: Path, parser_info: Optional[str] = None
+    file_uri: str,
+    target: Path,
+    parser_info: Optional[str] = None,
+    package: Optional[str] = None,
 ) -> None:
     document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
         file_uri
@@ -53,12 +56,21 @@ def python_codegen(
         document_loader,
         target=str(target),
         parser_info=parser_info,
+        package=package,
     )
 
 
 def test_parser_info(tmp_path: Path) -> None:
     src_target = tmp_path / "src.py"
     python_codegen(metaschema_file_uri, src_target, parser_info="cwl")
+    assert os.path.exists(src_target)
+    with open(src_target) as f:
+        assert 'def parser_info() -> str:\n    return "cwl"' in f.read()
+
+
+def test_use_of_package_for_parser_info(tmp_path: Path) -> None:
+    src_target = tmp_path / "src.py"
+    python_codegen(metaschema_file_uri, src_target, package="cwl")
     assert os.path.exists(src_target)
     with open(src_target) as f:
         assert 'def parser_info() -> str:\n    return "cwl"' in f.read()

--- a/schema_salad/tests/test_python_codegen.py
+++ b/schema_salad/tests/test_python_codegen.py
@@ -61,4 +61,4 @@ def test_parser_info(tmp_path: Path) -> None:
     python_codegen(metaschema_file_uri, src_target, parser_info="cwl")
     assert os.path.exists(src_target)
     with open(src_target) as f:
-        assert 'def parser_info() -> str:    return "cwl"' in f.read()
+        assert 'def parser_info() -> str:\n    return "cwl"' in f.read()

--- a/schema_salad/tests/test_python_codegen.py
+++ b/schema_salad/tests/test_python_codegen.py
@@ -1,7 +1,7 @@
 import inspect
 import os
 from pathlib import Path
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Optional, cast
 
 import schema_salad.metaschema as cg_metaschema
 from schema_salad import codegen
@@ -35,7 +35,7 @@ def test_meta_schema_gen_up_to_date(tmp_path: Path) -> None:
         assert f.read() == inspect.getsource(cg_metaschema)
 
 
-def python_codegen(file_uri: str, target: Path) -> None:
+def python_codegen(file_uri: str, target: Path, parser_info: Optional[str]) -> None:
     document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
         file_uri
     )
@@ -51,3 +51,11 @@ def python_codegen(file_uri: str, target: Path) -> None:
         document_loader,
         target=str(target),
     )
+
+
+def test_parser_info(tmp_path: Path) -> None:
+    src_target = tmp_path / "src.py"
+    python_codegen(metaschema_file_uri, src_target, parser_info="cwl")
+    assert os.path.exists(src_target)
+    with open(src_target) as f:
+        assert "def parser_info() -> str:    return \"cwl\"" in f.read()

--- a/schema_salad/tests/test_python_codegen.py
+++ b/schema_salad/tests/test_python_codegen.py
@@ -35,7 +35,7 @@ def test_meta_schema_gen_up_to_date(tmp_path: Path) -> None:
         assert f.read() == inspect.getsource(cg_metaschema)
 
 
-def python_codegen(file_uri: str, target: Path, parser_info: Optional[str]) -> None:
+def python_codegen(file_uri: str, target: Path, parser_info: Optional[str] = None) -> None:
     document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(
         file_uri
     )
@@ -50,6 +50,7 @@ def python_codegen(file_uri: str, target: Path, parser_info: Optional[str]) -> N
         schema_metadata,
         document_loader,
         target=str(target),
+        parser_info=parser_info,
     )
 
 


### PR DESCRIPTION
After merging this request, a code generated parser provides a function `parser_info` that returns the specified constant string.
It enables users to distinguish code generated parsers with the return value of `parser_info`.
