### PR TITLE
Symbols with inVocab: false should still have avro-safe names

### DIFF
--- a/schema_salad/schema.py
+++ b/schema_salad/schema.py
@@ -532,7 +532,7 @@ def make_valid_avro(
     # Possibly could be integrated into our fork of avro/schema.py?
     if isinstance(items, MutableMapping):
         avro = copy.copy(items)
-        if avro.get("name") and avro.get("inVocab", True):
+        if avro.get("name"):
             if fielddef:
                 avro["name"] = avro_field_name(avro["name"])
             else:

--- a/schema_salad/tests/test_avro_names.py
+++ b/schema_salad/tests/test_avro_names.py
@@ -1,5 +1,6 @@
 """Avro related tests."""
 from schema_salad.schema import load_schema
+from schema_salad.avro.schema import Names
 
 from .util import get_data
 
@@ -9,4 +10,5 @@ def test_avro_loading() -> None:
     path = get_data("tests/test_schema/avro_naming.yml")
     assert path
     document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(path)
+    assert isinstance(avsc_names, Names)
     assert avsc_names.get_name("com.example.derived_schema.ExtendedThing", None)

--- a/schema_salad/tests/test_avro_names.py
+++ b/schema_salad/tests/test_avro_names.py
@@ -9,3 +9,4 @@ def test_avro_loading() -> None:
     path = get_data("tests/test_schema/avro_naming.yml")
     assert path
     document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(path)
+    assert avsc_names.get_name("com.example.derived_schema.ExtendedThing", None)


### PR DESCRIPTION
Because the avro-safe names are now namespaced (they didn't used to
be) we no longer want "out of vocabulary" symbols to be added as URLs.

Arvados-DCO-1.1-Signed-off-by: Peter Amstutz <peter.amstutz@curii.com>