### PR TITLE
[TypeScript codegen] Fix undefined typeguard for null values

### DIFF
--- a/schema_salad/typescript/index.ts
+++ b/schema_salad/typescript/index.ts
@@ -1,5 +1,6 @@
 export {
   loadDocument,
   loadDocumentByString,
+  ValidationException,
   ${generated_class_imports}
 } from './util/Internal'

--- a/schema_salad/typescript/test/Typeguards.spec.ts
+++ b/schema_salad/typescript/test/Typeguards.spec.ts
@@ -68,6 +68,7 @@ describe('Test Typeguards', () => {
   describe('Undefined', () => {
     it('Should return true', () => {
       assert.equal(TypeGuards.Undefined(undefined), true)
+      assert.equal(TypeGuards.Undefined(null), true)
     })
 
     it('Should return false', () => {
@@ -76,7 +77,6 @@ describe('Test Typeguards', () => {
       assert.equal(TypeGuards.Undefined(1), false)
       assert.equal(TypeGuards.Undefined(1.1), false)
       assert.equal(TypeGuards.Undefined({}), false)
-      assert.equal(TypeGuards.Undefined(null), false)
     })
   })
 

--- a/schema_salad/typescript/util/Typeguards.ts
+++ b/schema_salad/typescript/util/Typeguards.ts
@@ -17,7 +17,7 @@ export function String (doc: any): boolean {
 }
 
 export function Undefined (doc: any): boolean {
-  return typeof doc === 'undefined'
+  return doc == null
 }
 
 export function isDictionary (doc: any): doc is Dictionary {


### PR DESCRIPTION
This PR fixes the undefined typeguard, so it returns true for `null` and `undefined` and not just `undefined`.
I also added ValidationException to the module exports, which was missing before.