### PR TITLE
Fix initialization of class fields with instance type "string"

### DIFF
--- a/schema_salad/typescript_codegen.py
+++ b/schema_salad/typescript_codegen.py
@@ -525,13 +525,22 @@ export enum {enum_name} {{
                 )
             )
         if fieldname == "class":
-            self.current_constructor_signature.write(
-                ", {safename} = {type}.{val}".format(
-                    safename=safename,
-                    type=fieldtype.instance_type,
-                    val=self.current_class.replace("-", "_").replace(".", "_").upper(),
+            if fieldtype.instance_type == "string":
+                self.current_constructor_signature.write(
+                    ", {safename} = '{val}'".format(
+                        safename=safename, val=self.current_class
+                    )
                 )
-            )
+            else:
+                self.current_constructor_signature.write(
+                    ", {safename} = {type}.{val}".format(
+                        safename=safename,
+                        type=fieldtype.instance_type,
+                        val=self.current_class.replace("-", "_")
+                        .replace(".", "_")
+                        .upper(),
+                    )
+                )
         else:
             self.current_constructor_signature.write(
                 ", {safename}".format(


### PR DESCRIPTION
This PR fixes a bug causing class fields of type "string" being initialized as if they were of an enum type.