### PR TITLE
javacodegen scope check: chop off the correct end of the fragment

### DIFF
--- a/schema_salad/java/main_utils/LoadingOptions.java
+++ b/schema_salad/java/main_utils/LoadingOptions.java
@@ -94,7 +94,7 @@ public class LoadingOptions {
       final ArrayList<String> sp = new ArrayList(Arrays.asList(splitbase.fragment.split("/")));
       int n = scopedRef;
       while (n > 0 && sp.size() > 0) {
-        sp.remove(0);
+        sp.remove(sp.size()-1);
         n -= 1;
       }
       sp.add(url);


### PR DESCRIPTION
@ZimmerA Seems you already fixed this in your typescript implementation, but I remember that you reported a similar issue?

https://github.com/common-workflow-language/schema_salad/blob/74e909b532c7c5b12480421f9cfd06b3d7e24704/schema_salad/typescript/util/loaders/Loader.ts#L70

The fix is validated in cwljava: https://github.com/common-workflow-lab/cwljava/pull/62/files