### PR TITLE
Update package json and tsconfig in typescript codegen

### DIFF
--- a/schema_salad/typescript/package.json
+++ b/schema_salad/typescript/package.json
@@ -2,7 +2,8 @@
   "name": "${project_name}",
   "version": "${version}",
   "description": "${project_description}",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "nyc --reporter=lcov mocha --require ts-node/register src/test/**/*.ts",
     "doc": "rm -rf ./docs && typedoc src/index.ts"
@@ -32,5 +33,8 @@
     "node-fetch": "^2.6.6",
     "uri-js": "^4.4.1",
     "uuid": "^8.3.2"
-  }
+  },
+  "files": [
+    "/dist"
+  ]
 }

--- a/schema_salad/typescript/package.json
+++ b/schema_salad/typescript/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "nyc --reporter=lcov mocha --require ts-node/register src/test/**/*.ts",
-    "doc": "rm -rf ./docs && typedoc src/index.ts"
+    "doc": "rimraf ./docs && typedoc src/index.ts"
   },
   "license": "${license_name}",
   "devDependencies": {
@@ -26,7 +26,8 @@
     "ts-node": "^10.4.0",
     "typedoc": "^0.22.10",
     "typescript": "^4.4.4",
-    "codecov.io": "^0.1.6"
+    "codecov.io": "^0.1.6",
+    "rimraf": "^3.0.2"
   },
   "dependencies": {
     "js-yaml": "^4.1.0",

--- a/schema_salad/typescript/package.json
+++ b/schema_salad/typescript/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "build": "rimraf ./dist && tsc",
     "test": "nyc --reporter=lcov mocha --require ts-node/register src/test/**/*.ts",
     "doc": "rimraf ./docs && typedoc src/index.ts"
   },

--- a/schema_salad/typescript/tsconfig.json
+++ b/schema_salad/typescript/tsconfig.json
@@ -12,6 +12,7 @@
   },
   "include": ["./src/**/*"],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "./src/test"
   ]
 }


### PR DESCRIPTION
This adds some missing scripts and properties in package.json and tsconfig.json. I also added rimraf as a dependency, because rm -rf does not work on Windows.