### PR TITLE
javacodegen: jackson-databind min version

### DIFF
--- a/schema_salad/java/pom.xml
+++ b/schema_salad/java/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.6</version>
+      <version>[2.13.2.1,)</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
To get fix for CVE-2020-36518