### PR TITLE
add missing basket examples

### DIFF
--- a/schema_salad/tests/basket.yml
+++ b/schema_salad/tests/basket.yml
@@ -1,0 +1,9 @@
+basket:
+  - product: bananas
+    price: 0.39
+    per: pound
+    weight: 1
+  - product: cucumbers
+    price: 0.79
+    per: item
+    count: 3

--- a/schema_salad/tests/basket_schema.yml
+++ b/schema_salad/tests/basket_schema.yml
@@ -1,0 +1,52 @@
+- name: Product
+  doc: |
+    The base type for a product.  This is an abstract type, so it
+    can't be used directly, but can be used to define other types.
+  type: record
+  abstract: true
+  fields:
+    product: string
+    price: float
+
+- name: ByWeight
+  doc: |
+    A product, sold by weight.  Products may be sold by pound or by
+    kilogram.  Weights may be fractional.
+  type: record
+  extends: Product
+  fields:
+    per:
+      type:
+        type: enum
+        symbols:
+          - pound
+          - kilogram
+      jsonldPredicate: "#per"
+    weight: float
+
+- name: ByCount
+  doc: |
+    A product, sold by count.  The count must be a integer value.
+  type: record
+  extends: Product
+  fields:
+    per:
+      type:
+        type: enum
+        symbols:
+          - item
+      jsonldPredicate: "#per"
+    count: int
+
+- name: Basket
+  doc: |
+    A basket of products.  The 'documentRoot' field indicates it is a
+    valid starting point for a document.  The 'basket' field will
+    validate subtypes of 'Product' (ByWeight and ByCount).
+  type: record
+  documentRoot: true
+  fields:
+    basket:
+      type:
+        type: array
+        items: Product


### PR DESCRIPTION
see https://github.com/common-workflow-language/schema_salad/issues/541

It turns out that the code in the README was ok as is, but for some reason the first few times I tried it I could not get it to work at all, so I thought that the examples in the README were missing something. That led me to search in the history. 
After adding them to the repo I found that it worked. 

Note that I am not a python programmer, I am new to yaml, and to the whole project, so it could have been simple things like formatting that were the problem. But that is good reason to add those examples to the repository, and perhaps even test them with the unit tests (but I am not sure how to do that yet) 

```tcsh
$ schema-salad-tool basket_schema.yml basket.yml
/Users/hjs/Library/Python/3.8/bin/schema-salad-tool Current version: 8.3.20220525163636
Document `basket.yml` is valid
```