### PR TITLE
Make schema salad main log with logger if doc is valid

### DIFF
--- a/schema_salad/main.py
+++ b/schema_salad/main.py
@@ -443,7 +443,7 @@ def main(argsl: Optional[List[str]] = None) -> int:
         json_dump(doc_metadata, fp=sys.stdout, indent=4, default=str)
         return 0
 
-    print(f"Document `{args.document}` is valid")
+    _logger.info(f"Document `{args.document}` is valid")
 
     return 0
 


### PR DESCRIPTION
Hi,

I have a simple Python script that I am using to convert a YAML document into TriG. Before I process the YAML, I decided to use Schema Salad to validate the schema of the file.

It works fine, but I cannot execute `python yaml_to_trig.py > /tmp/some-file.trig` because of the like "Document `some-file.trig` is valid" that is always logged to `stdout`. I tested locally, and using the `_logger` object to log, the output is not written to `stdout` and I can successfully write the TriG file.

Cheers
Bruno