### PR TITLE
Fix codegen error when a schema does not contain $base

### DIFF
--- a/schema_salad/codegen.py
+++ b/schema_salad/codegen.py
@@ -43,6 +43,11 @@ def codegen(
 
     gen = None  # type: Optional[CodeGenBase]
     base = schema_metadata.get("$base", schema_metadata.get("id"))
+    # ``urlsplit`` decides whether to return an encoded result based
+    # on the object type. To ensure the code behaves the same for Py
+    # 3.6+, we enforce that the input value is of type ``str``.
+    if base is None:
+        base = ""
     sp = urlsplit(base)
     pkg = (
         package

--- a/schema_salad/tests/basket.yml
+++ b/schema_salad/tests/basket.yml
@@ -1,0 +1,9 @@
+# N.B.: this example is used in a test that needs a file without $base,
+#       so please do not include $base here.
+- name: Basket
+  doc: A basket of products.
+  type: record
+  documentRoot: true
+  fields:
+    product: string
+    price: float

--- a/schema_salad/tests/test_java_codegen.py
+++ b/schema_salad/tests/test_java_codegen.py
@@ -2,10 +2,10 @@ import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
-from schema_salad import codegen, ref_resolver
+from schema_salad import codegen
 from schema_salad.schema import load_schema
 
-from .util import get_data
+from .util import cwl_file_uri, metaschema_file_uri, get_data
 
 
 def test_cwl_gen(tmp_path: Path) -> None:
@@ -39,16 +39,6 @@ def test_meta_schema_gen(tmp_path: Path) -> None:
     assert pom_xml_path.exists()
     src_dir = target_dir / "src" / "main" / "java" / "org" / "w3id" / "cwl" / "salad"
     assert src_dir.exists()
-
-
-def get_data_uri(resource_path: str) -> str:
-    path = get_data(resource_path)
-    assert path
-    return ref_resolver.file_uri(path)
-
-
-cwl_file_uri = get_data_uri("tests/test_schema/CommonWorkflowLanguage.yml")
-metaschema_file_uri = get_data_uri("metaschema/metaschema.yml")
 
 
 def java_codegen(file_uri: str, target: Path, examples: Optional[Path] = None) -> None:

--- a/schema_salad/tests/test_python_codegen.py
+++ b/schema_salad/tests/test_python_codegen.py
@@ -8,7 +8,7 @@ from schema_salad import codegen
 from schema_salad.avro.schema import Names
 from schema_salad.schema import load_schema
 
-from .test_java_codegen import cwl_file_uri, metaschema_file_uri
+from .util import cwl_file_uri, metaschema_file_uri, basket_file_uri
 
 
 def test_cwl_gen(tmp_path: Path) -> None:
@@ -33,6 +33,14 @@ def test_meta_schema_gen_up_to_date(tmp_path: Path) -> None:
     assert os.path.exists(src_target)
     with open(src_target) as f:
         assert f.read() == inspect.getsource(cg_metaschema)
+
+
+def test_meta_schema_gen_no_base(tmp_path: Path) -> None:
+    src_target = tmp_path / "src.py"
+    python_codegen(basket_file_uri, src_target)
+    assert os.path.exists(src_target)
+    with open(src_target) as f:
+        assert "class Basket" in f.read()
 
 
 def python_codegen(

--- a/schema_salad/tests/util.py
+++ b/schema_salad/tests/util.py
@@ -2,9 +2,15 @@ import os
 from typing import Optional, Text
 
 from pkg_resources import Requirement, ResolutionError, resource_filename
+from schema_salad import ref_resolver
 
 
 def get_data(filename):  # type: (Text) -> Optional[Text]
+    """Get the file path for a given schema file name.
+
+    It is able to find file names in the ``schema_salad`` namespace, but
+    also able to load schema files from the ``tests`` directory.
+    """
     filename = os.path.normpath(filename)  # normalizing path depending on OS
     # or else it will cause problem when joining path
     filepath = None
@@ -13,5 +19,25 @@ def get_data(filename):  # type: (Text) -> Optional[Text]
     except ResolutionError:
         pass
     if not filepath or not os.path.isfile(filepath):
-        filepath = os.path.join(os.path.dirname(__file__), os.pardir, filename)
+        # First try to load it from the local directory, probably ``./tests/``.
+        filepath = os.path.join(os.path.dirname(__file__), filename)
+        if not os.path.isfile(filepath):
+            # If that didn't work, then default to tests/../${filename},
+            # note that we return the parent as it is expected that __file__
+            # is a test file.
+            filepath = os.path.join(os.path.dirname(__file__), os.pardir, filename)
     return filepath
+
+
+def get_data_uri(resource_path: str) -> str:
+    """Get the file URI for tests."""
+    path = get_data(resource_path)
+    assert path
+    return ref_resolver.file_uri(path)
+
+
+# Schemas used in tests
+
+cwl_file_uri = get_data_uri("tests/test_schema/CommonWorkflowLanguage.yml")
+metaschema_file_uri = get_data_uri("metaschema/metaschema.yml")
+basket_file_uri = get_data_uri("basket.yml")


### PR DESCRIPTION
Fixes an issue reported by Simon Gene Gottlieb on Matrix:

>(...)
>With schema-salad-tool --codegen python CommonWorkflowLanguage.yaml and a very large python >documents falls out
>(...)
>Now I wanted to use the quick-start example, but I get some python error. I reduced the schema example >to:

```
- name: Basket
  doc: A basket of products.
  type: record
  documentRoot: true
  fields:
    product: string
    price: float
```

I used the schema above and a simple `test.yaml` with one record, and `schema-salad-tool schema.yaml test.yaml` passed with no errors. But the codegen gave me the same error (Simon was using Py3.10, I think, I'm on 3.9, FWIW).

Here's a quick fix for that, but that probably needs some review, e.g.:

- [x] does this PR's fix look correct? 
  * I think so
- [x] probably needs a unit test?
  * Added one! :tada: 
- [x] why didn't we get some failed CI runs before?
  * Ah! Because the error only happened when `$base` resolved to something that was not a `str`, and that only occurred when the schema didn't have `$base`; our unit tests did not cover that case, hence the error never occurring.

-Bruno