### PR TITLE
Fix: allow missing `fields` field in SaladRecordSchema

### DIFF
--- a/schema_salad/avro/schema.py
+++ b/schema_salad/avro/schema.py
@@ -520,10 +520,7 @@ class RecordSchema(NamedSchema):
         other_props: Optional[PropsType] = None,
     ) -> None:
         # Ensure valid ctor args
-        if fields is None:
-            fail_msg = "Record schema requires a non-empty fields property."
-            raise SchemaParseException(fail_msg)
-        elif not isinstance(fields, list):
+        if not isinstance(fields, list):
             fail_msg = "Fields property must be a list of Avro schemas."
             raise SchemaParseException(fail_msg)
 
@@ -622,7 +619,7 @@ def make_avsc_object(json_data: JsonDataType, names: Optional[Names] = None) -> 
                     symbols = cast(List[str], symbols)
                 return EnumSchema(name, namespace, symbols, names, doc, other_props)
             if atype in ["record", "error"]:
-                fields = json_data.get("fields")
+                fields = json_data.get("fields", [])
                 if not isinstance(fields, list):
                     raise SchemaParseException(
                         '"fields" for type {} must be a list of mappings: {}'.format(

--- a/schema_salad/tests/test_java_codegen.py
+++ b/schema_salad/tests/test_java_codegen.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, cast
 from schema_salad import codegen
 from schema_salad.schema import load_schema
 
-from .util import cwl_file_uri, metaschema_file_uri, get_data
+from .util import cwl_file_uri, get_data, metaschema_file_uri
 
 
 def test_cwl_gen(tmp_path: Path) -> None:

--- a/schema_salad/tests/test_misc.py
+++ b/schema_salad/tests/test_misc.py
@@ -1,8 +1,5 @@
-import pytest
-
 from schema_salad.avro.schema import Names
-from schema_salad.exceptions import ValidationException
-from schema_salad.schema import load_and_validate, load_schema
+from schema_salad.schema import load_schema
 
 from .util import get_data
 
@@ -12,4 +9,3 @@ def test_misc() -> None:
     assert path
     document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(path)
     assert isinstance(avsc_names, Names)
-

--- a/schema_salad/tests/test_misc.py
+++ b/schema_salad/tests/test_misc.py
@@ -1,0 +1,15 @@
+import pytest
+
+from schema_salad.avro.schema import Names
+from schema_salad.exceptions import ValidationException
+from schema_salad.schema import load_and_validate, load_schema
+
+from .util import get_data
+
+
+def test_misc() -> None:
+    path = get_data("tests/test_schema/no_field_schema.yml")
+    assert path
+    document_loader, avsc_names, schema_metadata, metaschema_loader = load_schema(path)
+    assert isinstance(avsc_names, Names)
+

--- a/schema_salad/tests/test_python_codegen.py
+++ b/schema_salad/tests/test_python_codegen.py
@@ -8,7 +8,7 @@ from schema_salad import codegen
 from schema_salad.avro.schema import Names
 from schema_salad.schema import load_schema
 
-from .util import cwl_file_uri, metaschema_file_uri, basket_file_uri
+from .util import basket_file_uri, cwl_file_uri, metaschema_file_uri
 
 
 def test_cwl_gen(tmp_path: Path) -> None:

--- a/schema_salad/tests/test_schema/no_field_schema.yml
+++ b/schema_salad/tests/test_schema/no_field_schema.yml
@@ -1,0 +1,3 @@
+- name: EmptyType
+  documentRoot: true
+  type: record

--- a/schema_salad/tests/util.py
+++ b/schema_salad/tests/util.py
@@ -2,6 +2,7 @@ import os
 from typing import Optional, Text
 
 from pkg_resources import Requirement, ResolutionError, resource_filename
+
 from schema_salad import ref_resolver
 
 


### PR DESCRIPTION
TODO:
How to I integrate a proper test for this? I added a `schema_salad/tests/empty_type_schema.yml` file and I would like to check that it can be validated.


The field SaladRecordSchema::fields is optional. see:
 - https://www.commonwl.org/v1.2/SchemaSalad.html#SaladRecordSchema
 - https://github.com/common-workflow-language/schema_salad/blob/d123d9c81fd22337e37a0b7e59f92019b0fdae3f/schema_salad/metaschema/metaschema_base.yml#L111
This repairs the validation.
