### PR TITLE
Dotnet codegen: fix id value serialization

### DIFF
--- a/schema_salad/dotnet_codegen.py
+++ b/schema_salad/dotnet_codegen.py
@@ -707,7 +707,7 @@ public class {enum_name} : IEnumClass<{enum_name}>
             baseurl = "baseUrl"
         elif self.id_field_type.instance_type is not None:
             if self.id_field_type.instance_type.startswith("OneOf"):
-                baseurl = f"this.{self.safe_name(self.idfield)}.AsT1"
+                baseurl = f"(this.{self.safe_name(self.idfield)}.Value is None ? \"\" : {self.safe_name(self.idfield)}.Value)"
             else:
                 baseurl = f"this.{self.safe_name(self.idfield)}"
 

--- a/schema_salad/dotnet_codegen.py
+++ b/schema_salad/dotnet_codegen.py
@@ -707,7 +707,10 @@ public class {enum_name} : IEnumClass<{enum_name}>
             baseurl = "baseUrl"
         elif self.id_field_type.instance_type is not None:
             if self.id_field_type.instance_type.startswith("OneOf"):
-                baseurl = f"(this.{self.safe_name(self.idfield)}.Value is None ? \"\" : {self.safe_name(self.idfield)}.Value)"
+                baseurl = (
+                    f"(this.{self.safe_name(self.idfield)}.Value is "
+                    f'None ? "" : {self.safe_name(self.idfield)}.Value)'
+                )
             else:
                 baseurl = f"this.{self.safe_name(self.idfield)}"
 


### PR DESCRIPTION
This PR fixes a bug in the code produced by the .net codegen that caused serializing documents with an id value of "None" (empty id) to crash the process.