### PR TITLE
Use SourceLine in _resolve_idmap to include line number in error

### DIFF
--- a/schema_salad/ref_resolver.py
+++ b/schema_salad/ref_resolver.py
@@ -592,9 +592,11 @@ class Loader:
                                 )
                                 v.lc.filename = document.lc.filename
                             else:
+                                sl = SourceLine(document, idmapField, str)
                                 raise ValidationException(
                                     "mapSubject '{}' value '{}' is not a dict "
-                                    "and does not have a mapPredicate.".format(k, v)
+                                    "and does not have a mapPredicate.".format(k, v),
+                                    sl,
                                 )
                         else:
                             v = val

--- a/schema_salad/tests/missing_step_name.cwl
+++ b/schema_salad/tests/missing_step_name.cwl
@@ -1,0 +1,17 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: geoweaver workflow
+
+inputs:
+  code_folder:
+    type: File
+
+outputs: []
+
+steps:
+  run: HelloWorld.cwl
+  in:
+    folder: code_folder
+  out: []


### PR DESCRIPTION
Ref: https://github.com/common-workflow-language/cwltool/issues/1635

Before this PR:

```bash
(venv) kinow@ranma:~/Development/python/workspace/schema_salad$ schema-salad-tool schema_salad/tests/test_schema/CommonWorkflowLanguage.yml schema_salad/tests/missing_step_name.cwl
/home/kinow/Development/python/workspace/cwltool/venv/bin/schema-salad-tool Current version: 8.3.20220627005012
Document `schema_salad/tests/missing_step_name.cwl` failed validation:
mapSubject 'out' value 'None' is not a dict and does not have a mapPredicate.
```

After this PR:

```bash
(venv) kinow@ranma:~/Development/python/workspace/schema_salad$ schema-salad-tool schema_salad/tests/test_schema/CommonWorkflowLanguage.yml schema_salad/tests/missing_step_name.cwl
/home/kinow/Development/python/workspace/cwltool/venv/bin/schema-salad-tool Current version: 8.3.20220627005012
Document `schema_salad/tests/missing_step_name.cwl` failed validation:
schema_salad/tests/missing_step_name.cwl:13:1: mapSubject 'out' value 'None' is not a dict and does
                                               not have a mapPredicate.
```