### PR TITLE
Fix release tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+import schema_salad.schema
+
+@pytest.fixture(autouse=True, scope='function')
+def isolated_cache():
+    """A fixture to clear the schema_salad metaschema cache.
+
+    Auto-loaded (see autouse) fixture, loaded per test (function scope).
+    Prevents issues when running multiple tests that load metaschemas
+    multiple times or in parallel (`pytest-parallel`, `pytest-xdist`, etc).
+    """
+    schema_salad.schema.cached_metaschema = None

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -240,7 +240,7 @@ def test_error_message11() -> None:
     match = r"""
 ^.+test11\.cwl:7:1: checking field\s+`steps`
 .+test11\.cwl:8:3:   checking object\s+`.+test11\.cwl#step1`
-.+test11\.cwl:9:5:     Field `run`\s+contains\s+undefined\s+reference to
+.+test11\.cwl:9:5:     Field `run`\s+contains\s+undefined\s+reference\s+to
 \s+`file://.+/tests/test_schema/blub\.cwl`$"""[
         1:
     ]

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -72,7 +72,7 @@ def test_error_message2() -> None:
 
     t = "test_schema/test2.cwl"
     match = r"""
-^.+test2\.cwl:2:1: Field `class`\s+contains\s+undefined\s+reference to
+^.+test2\.cwl:2:1: Field `class`\s+contains\s+undefined\s+reference\s+to
 \s+`file://.+/schema_salad/tests/test_schema/xWorkflow`$"""[
         1:
     ]

--- a/schema_salad/tests/test_errors.py
+++ b/schema_salad/tests/test_errors.py
@@ -214,7 +214,7 @@ def test_error_message10() -> None:
 
     t = "test_schema/test10.cwl"
     match = r"""
-^.+test10\.cwl:2:1: Object\s+`.+test10\.cwl`\s+is not valid because
+^.+test10\.cwl:2:1: Object\s+`.+test10\.cwl`\s+is\s+not\s+valid\s+because
 \s+tried `Workflow`\s+but
 .+test10\.cwl:7:1:     the `steps`\s+field\s+is\s+not\s+valid\s+because
 \s+tried array\s+of\s+<WorkflowStep>\s+but


### PR DESCRIPTION
I tried writing a fixture to reset the cache prior to each test execution. In theory I think this should fix the issue when loading metaschemas multiple times within a test, or in parallel.