### PR TITLE
CI: use the final release of Python 3.11

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -35,23 +35,13 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        if: matrix.py-ver-minor != 11
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.py-semver }}
-
-      - name: Set up Python 3.11.0-rc.2
-        if: matrix.py-ver-minor == 11
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11.0-rc.2
-
-
-      - name: Cache for pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.step }}-${{ hashFiles('requirements.txt', 'tox.ini') }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            tox.ini
 
       - name: Upgrade setuptools and install tox
         run: |


### PR DESCRIPTION
except for wheel building as mypyc doesn't fully support Python 3.11