### PR TITLE
resolve invalid definition in .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ queue_rules:
       - base=main
 
 pull_request_rules:
-  - name: Automatic merge on approval and when when GitHub branch protection passes on main
+  - name: Automatic merge on approval and when GitHub branch protection passes on main
     conditions:
       - "#approved-reviews-by>=1"
       - base=main
@@ -12,8 +12,7 @@ pull_request_rules:
       queue:
         method: merge
         name: default
-        
-pull_request_rules:
+
   - name: Automatic merge for leadership team members when there are no reviewers
     conditions:
       - "#review-requested=0"


### PR DESCRIPTION
## Fixes

- Duplicate keys (invalid YAML) were defined instead of simply using the list.
- Fixed a repeated word.