### PR TITLE
fix: cpp-generator escapes names stdin, stdout, stderr

### DIFF
--- a/schema_salad/cpp_codegen.py
+++ b/schema_salad/cpp_codegen.py
@@ -33,7 +33,18 @@ from .utils import aslist
 
 def replaceKeywords(s: str) -> str:
     """Rename keywords that are reserved in C++."""
-    if s in ("class", "enum", "int", "long", "float", "double", "default"):
+    if s in (
+        "class",
+        "enum",
+        "int",
+        "long",
+        "float",
+        "double",
+        "default",
+        "stdin",
+        "stdout",
+        "stderr",
+    ):
         s = s + "_"
     return s
 


### PR DESCRIPTION
msvc treats stdin, stdout, stderr as keywords (or maybe they are macros?). We need to escape these by adding an underscore "_".