### PR TITLE
Fix the description of the record field annotation for link validation

### DIFF
--- a/schema_salad/metaschema/salad.md
+++ b/schema_salad/metaschema/salad.md
@@ -256,7 +256,8 @@ rules:
   field.
 
   * If the value of `jsonldPredicate` is an object, and that
-  object contains the field `_type` with the value `@id`, the field is a
+  object contains the field `_type` with the value `@id` and
+  the field `identity` with the value `false`, the field is a
   link field subject to [link validation](#Link_validation).
 
   * If the value of `jsonldPredicate` is an object which contains the


### PR DESCRIPTION
The [spec](https://www.commonwl.org/v1.2/SchemaSalad.html#Record_field_annotations) says:

> If the value of `jsonldPredicate` is an object, and that object contains the field `_type` with the value `@id`, the field is a link field subject to [link validation](https://www.commonwl.org/v1.2/SchemaSalad.html#Link_validation).

However, it is not correct because `identity: false` (or unspecified `identity`) is also needed as described in the section of [`JsonldPredicate#_type`](https://www.commonwl.org/v1.2/SchemaSalad.html#JsonldPredicate).

This request fixes it by clarifying the value of `identity` in addition to the field `_type`.