### PR TITLE
Rename configuration option removed in tox 4.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ commands =
   py{37,38,39,310,311}-mypy: make mypyc
   py37-mypy: make mypy_3.6
 
-whitelist_externals =
+allowlist_externals =
   py{36,37,38,39,310,311}-lint: flake8
   py{36,37,38,39,310,311}-lint: black
   py{36,37,38,39,310,311}-{mypy,shellcheck,lint,lintreadme,unit}: make
@@ -68,7 +68,7 @@ extras =
   py{36,37,38,39,310,311}-unit: pycodegen
 
 [testenv:py310-pydocstyle]
-whitelist_externals = make
+allowlist_externals = make
 commands = make diff_pydocstyle_report
 deps =
     pydocstyle


### PR DESCRIPTION
See https://tox.wiki/en/latest/changelog.html#deprecations-and-removals-4-0-0rc4