### PR TITLE
Avoid mypy error on adding newGraph from cache to graph

### DIFF
--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -146,24 +146,29 @@ class LoadingOptions:
                 if self.fileuri is not None
                 else pathlib.Path(schema).resolve().as_uri()
             )
-            try:
-                if fetchurl not in self.cache or self.cache[fetchurl] is True:
-                    _logger.debug("Getting external schema %s", fetchurl)
+            if fetchurl not in self.cache or self.cache[fetchurl] is True:
+                _logger.debug("Getting external schema %s", fetchurl)
+                try:
                     content = self.fetcher.fetch_text(fetchurl)
-                    self.cache[fetchurl] = newGraph = Graph()
-                    for fmt in ["xml", "turtle"]:
-                        try:
-                            newGraph.parse(
-                                data=content, format=fmt, publicID=str(fetchurl)
-                            )
-                            break
-                        except (xml.sax.SAXParseException, TypeError, BadSyntax):
-                            pass
-                graph += self.cache[fetchurl]
-            except Exception as e:
-                _logger.warning(
-                    "Could not load extension schema %s: %s", fetchurl, str(e)
-                )
+                except Exception as e:
+                    _logger.warning(
+                        "Could not load extension schema %s: %s", fetchurl, str(e)
+                    )
+                    continue
+                newGraph = Graph()
+                err_msg = "unknown error"
+                for fmt in ["xml", "turtle"]:
+                    try:
+                        newGraph.parse(data=content, format=fmt, publicID=str(fetchurl))
+                        self.cache[fetchurl] = newGraph
+                        graph += newGraph
+                        break
+                    except (xml.sax.SAXParseException, TypeError, BadSyntax) as e:
+                        err_msg = str(e)
+                else:
+                    _logger.warning(
+                        "Could not load extension schema %s: %s", fetchurl, err_msg
+                    )
         self.cache[key] = graph
         return graph
 

--- a/schema_salad/tests/test_examples.py
+++ b/schema_salad/tests/test_examples.py
@@ -56,6 +56,18 @@ def test_print_rdf() -> None:
     )
 
 
+def test_print_rdf_invalid_external_ref() -> None:
+    """Test --print-rdf when document references unfetchable external schema."""
+    schema_path = get_data("tests/test_schema/CommonWorkflowLanguage.yml")
+    document_path = get_data(
+        "tests/test_real_cwl/bio-cwl-tools/bamtools_stats_invalid_schema_ref.cwl"
+    )
+    assert schema_path and document_path
+    assert 0 == schema_salad.main.main(
+        argsl=["--print-rdf", schema_path, document_path]
+    )
+
+
 def test_print_pre_schema() -> None:
     """Test --print-pre only schema."""
     schema_path = get_data("tests/test_schema/CommonWorkflowLanguage.yml")

--- a/schema_salad/tests/test_real_cwl/bio-cwl-tools/bamtools_stats_invalid_schema_ref.cwl
+++ b/schema_salad/tests/test_real_cwl/bio-cwl-tools/bamtools_stats_invalid_schema_ref.cwl
@@ -3,17 +3,17 @@ cwlVersion: v1.0
 class: CommandLineTool
 
 requirements:
-  InlineJavascriptRequirement: {}
-  ShellCommandRequirement: {}
+- class: InlineJavascriptRequirement
+- class: ShellCommandRequirement
 
 hints:
-  DockerRequirement:
-    dockerPull: biowardrobe2/bamtools:v2.4.1
-  SoftwareRequirement:
-    packages:
-      bamtools:
-        specs: [ "http://identifiers.org/biotools/bamtools" ]
-        version: [ "2.4.1" ]
+- class: DockerRequirement
+  dockerPull: biowardrobe2/bamtools:v2.4.1
+- class: SoftwareRequirement
+  packages:
+    bamtools:
+      specs: [ "http://identifiers.org/biotools/bamtools" ]
+      version: [ "2.4.1" ]
 
 inputs:
 
@@ -127,7 +127,7 @@ $namespaces:
   s: http://schema.org/
 
 $schemas:
-- https://github.com/schemaorg/schemaorg/raw/main/data/releases/11.01/schemaorg-current-http.rdf
+- http://schema.org/version/9.0/schemaorg-current-http.rdf
 
 s:name: "bamtools_stats"
 s:license: http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Fixes:

```
gxformat2/schema/v19_09.py:167: error: Argument 1 to "__iadd__" of "Graph" has incompatible type "Union[str, Graph, bool]"; expected "Iterable[Tuple[Node, Node, Node]]"  [arg-type]
```
and should also be a little more helpful when the external schema can't be parsed or fetched (not familiar with the code base, but isn't there a need to be more transparent about this??).