### PR TITLE
PrimitiveType is a list of type **names**; not a list of types.

### DIFF
--- a/schema_salad/metaschema.py
+++ b/schema_salad/metaschema.py
@@ -3517,7 +3517,24 @@ PrimitiveTypeLoader = _EnumLoader(
     ),
     "PrimitiveType",
 )
+"""
+Names of salad data types (based on Avro schema declarations).
+
+Refer to the [Avro schema declaration documentation](https://avro.apache.org/docs/current/spec.html#schemas) for
+detailed information.
+
+null: no value
+boolean: a binary value
+int: 32-bit signed integer
+long: 64-bit signed integer
+float: single precision (32-bit) IEEE 754 floating-point number
+double: double precision (64-bit) IEEE 754 floating-point number
+string: Unicode character sequence
+"""
 AnyLoader = _EnumLoader(("Any",), "Any")
+"""
+The **Any** type validates for any non-null value.
+"""
 RecordFieldLoader = _RecordLoader(RecordField)
 RecordSchemaLoader = _RecordLoader(RecordSchema)
 EnumSchemaLoader = _RecordLoader(EnumSchema)

--- a/schema_salad/metaschema/metaschema_base.yml
+++ b/schema_salad/metaschema/metaschema_base.yml
@@ -39,8 +39,9 @@ $graph:
     - "xsd:string"
   doc:
     - |
-      Salad data types are based on Avro schema declarations.  Refer to the
-      [Avro schema declaration documentation](https://avro.apache.org/docs/current/spec.html#schemas) for
+      Names of salad data types (based on Avro schema declarations).
+
+      Refer to the [Avro schema declaration documentation](https://avro.apache.org/docs/current/spec.html#schemas) for
       detailed information.
     - "null: no value"
     - "boolean: a binary value"

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -406,14 +406,24 @@ if _errors__:
             if type_declaration["type"] in ("enum", "https://w3id.org/cwl/salad#enum"):
                 for sym in type_declaration["symbols"]:
                     self.add_vocab(shortname(sym), sym)
+                if "doc" in type_declaration:
+                    doc = type_declaration["doc"]
+                    if isinstance(doc, MutableSequence):
+                        formated_doc = "\n".join(doc)
+                    else:
+                        formated_doc = doc.strip()
+                    docstring = f'\n"""\n{formated_doc}\n"""'
+                else:
+                    docstring = ""
                 return self.declare_type(
                     TypeDef(
                         self.safe_name(type_declaration["name"]) + "Loader",
-                        '_EnumLoader(("{}",), "{}")'.format(
+                        '_EnumLoader(("{}",), "{}"){}'.format(
                             '", "'.join(
                                 schema.avro_field_name(sym) for sym in type_declaration["symbols"]
                             ),
                             self.safe_name(type_declaration["name"]),
+                            docstring,
                         ),
                     )
                 )

--- a/schema_salad/tests/metaschema-pre.yml
+++ b/schema_salad/tests/metaschema-pre.yml
@@ -105,7 +105,7 @@
             "http://www.w3.org/2001/XMLSchema#string"
         ],
         "doc": [
-            "Salad data types are based on Avro schema declarations.  Refer to the\n[Avro schema declaration documentation](https://avro.apache.org/docs/current/spec.html#schemas) for\ndetailed information.\n",
+            "Names of salad data types (based on Avro schema declarations).\n\nRefer to the [Avro schema declaration documentation](https://avro.apache.org/docs/current/spec.html#schemas) for\ndetailed information.\n",
             "null: no value",
             "boolean: a binary value",
             "int: 32-bit signed integer",

--- a/schema_salad/tests/test_makedoc.py
+++ b/schema_salad/tests/test_makedoc.py
@@ -239,5 +239,5 @@ def test_detect_changes_in_html(metaschema_doc: str, tmp_path: Path) -> None:
     with open(result, "w") as h:
         h.write(metaschema_doc)
     assert (
-        hasher.hexdigest() == "0dec6861574d2a80f5f5cd177103747e893fe6b23d1ec9b2b37850408d9ca1d1"
+        hasher.hexdigest() == "5fd520208b242c0fbf50235c83c88bc462f2b8d67b3dfbb9ffb399d7851fdab2"
     ), result


### PR DESCRIPTION
Bonus: Python codegen: preserve enum doc fields