### PR TITLE
exceptions.py: don't compile with mypyc to prevent memory leaks

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -21,11 +21,14 @@ jobs:
       matrix:
         py-ver-major: [3]
         py-ver-minor: [6, 7, 8, 9, 10, 11]
-        step: [lint, bandit, unit, mypy]
+        step: [lint, bandit, unit, mypy, memleak]
         exclude:
           - py-ver-major: 3
             py-ver-minor: 6
             step: mypy
+          - py-ver-major: 3
+            py-ver-minor: 6
+            step: memleak
           - py-ver-major: 3
             py-ver-minor: 6
             step: lint
@@ -120,7 +123,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"  # quoted, otherwise that turns into the number 3.1
+          python-version: "3.11"
 
       - name: Cache for pip
         uses: actions/cache@v3

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ mypyc: $(PYSOURCES)
 	MYPYPATH=mypy-stubs SCHEMA_SALAD_USE_MYPYC=1 python setup.py test --addopts "${PYTEST_EXTRA}"
 
 mypyi:
-	MYPYPATH=mypy-stubs SCHEMA_SALAD_USE_MYPYC=1 python setup.py install
+	MYPYPATH=mypy-stubs SCHEMA_SALAD_USE_MYPYC=1 pip install .${EXTRAS}
 
 check-metaschema-diff:
 	docker run \

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -3,3 +3,5 @@ black>=19.10b0
 types-pkg_resources
 types-requests
 types-dataclasses
+cwl-utils
+objgraph

--- a/schema_salad/tests/memory-leak-check.py
+++ b/schema_salad/tests/memory-leak-check.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import sys
+
+import cwl_utils.parser
+import objgraph  # type: ignore[import]
+
+growth = []
+for _ in range(5):
+    growth = objgraph.growth(limit=50)
+    cwl_utils.parser.load_document_by_uri(sys.argv[1])
+objgraph.show_growth(limit=50)
+if len(growth) != 0:
+    exit(1)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ if USE_MYPYC and any(
     mypyc_targets = [
         # "schema_salad/codegen_base.py",  # interpreted classes cannot inherit from compiled
         # "schema_salad/codegen.py",
-        "schema_salad/exceptions.py",
+        # "schema_salad/exceptions.py", # leads to memory leaks
         "schema_salad/__init__.py",
         # "schema_salad/java_codegen.py",  # due to use of __name__
         "schema_salad/jsonld_context.py",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
   py{36,37,38,39,310,311}-unit,
   py{37,38,39,310,311}-bandit,
   py{37,38,39,310,311}-mypy,
+  py{37,38,39,310,311}-memleak,
   py310-lintreadme,
   py310-pydocstyle
 
@@ -28,6 +29,7 @@ description =
   py{36,37,38,39,310,311}-lint: Lint the Python code
   py{37,38,39,310,311}-bandit: Search for common security issues
   py{37,38,39,310,311}-mypy: Check for type safety
+  py{37,38,39,310,311}-memleak: Simple test for memory leaks with mypyc
   py310-pydocstyle: docstring style checker
   py310-lintreadme: Lint the README.rst->.md conversion
 
@@ -40,7 +42,9 @@ deps =
   py{36,37,38,39,310,311}-lint: flake8-bugbear < 22.13
   py{36,37,38,39,310,311}-lint: black
   py{37,38,39,310,311}-bandit: bandit < 1.8
-  py{37,38,39,310,311}-mypy: -rmypy-requirements.txt
+  py{37,38,39,310,311}-{mypy,memleak}: -rmypy-requirements.txt
+  py{37,38,39,310,311}-memleak: cwl-utils
+  py{37,38,39,310,311}-memleak: objgraph
 # don't forget to update dev-requirements.txt as well
 
 setenv =
@@ -54,12 +58,14 @@ commands =
   py{36,37,38,39,310,311}-lint: make format-check
   py{37,38,39,310,311}-mypy: make mypy
   py{37,38,39,310,311}-mypy: make mypyc
+  py{37,38,39,310,311}-memleak: make mypyi
+  py{37,38,39,310,311}-memleak: python schema_salad/tests/memory-leak-check.py schema_salad/tests/test_real_cwl/ICGC-TCGA-PanCancer/preprocess_vcf.cwl
   py37-mypy: make mypy_3.6
 
 allowlist_externals =
   py{36,37,38,39,310,311}-lint: flake8
   py{36,37,38,39,310,311}-lint: black
-  py{36,37,38,39,310,311}-{mypy,shellcheck,lint,lintreadme,unit}: make
+  py{36,37,38,39,310,311}-{mypy,memleak,shellcheck,lint,lintreadme,unit}: make
 
 skip_install =
   py{36,37,38,39,310,311}-lint: true


### PR DESCRIPTION
To prove the test, reverse the changes to `setup.py` and run `tox -r py311-memleak`