### PR TITLE
Always re-run unittests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ setenv =
 
 commands =
   py{36,37,38,39,310,311}-unit: python -m pip install -U pip setuptools wheel
-  py{36,37,38,39,310,311}-unit: make coverage-report coverage.xml PYTEST_EXTRA="{posargs}"
+  py{36,37,38,39,310,311}-unit: make --always-make coverage-report coverage.xml PYTEST_EXTRA="{posargs}"
   py{37,38,39,310,311}-bandit: bandit --recursive --exclude schema_salad/tests/ schema_salad
   py{36,37,38,39,310,311}-lint: make flake8
   py{36,37,38,39,310,311}-lint: make format-check


### PR DESCRIPTION
Currently running `tox -e py310-unit` will only run the unit tests the first time the command is run. 

This is because `make coverage-report` (the command that tox runs for the unit tests) checks to see .coverage exists. However, .coverage is created the first time and not deleted so the tests will not be rerun. The simplest solution with the least amount of potential downstream issues would be to add a `--always-make` flag in the tox.ini file.