### PR TITLE
Add description of union types

### DIFF
--- a/schema_salad/metaschema/metaschema_base.yml
+++ b/schema_salad/metaschema/metaschema_base.yml
@@ -91,7 +91,9 @@ $graph:
         typeDSL: true
         refScope: 2
       doc: |
-        The field type
+        The field type. If it is an array, it indicates
+        that the field type is a union type of its elements.
+        Its elements may be duplicated.
 
 
 - name: RecordSchema

--- a/schema_salad/tests/metaschema-pre.yml
+++ b/schema_salad/tests/metaschema-pre.yml
@@ -161,7 +161,7 @@
                     "typeDSL": true,
                     "refScope": 2
                 },
-                "doc": "The field type\n"
+                "doc": "The field type. If it is an array, it indicates\nthat the field type is a union type of its elements.\nIts elements may be duplicated.\n"
             }
         ]
     },

--- a/schema_salad/tests/test_makedoc.py
+++ b/schema_salad/tests/test_makedoc.py
@@ -239,5 +239,5 @@ def test_detect_changes_in_html(metaschema_doc: str, tmp_path: Path) -> None:
     with open(result, "w") as h:
         h.write(metaschema_doc)
     assert (
-        hasher.hexdigest() == "360fcb7860e6ccc15db70a20f95247a0b5ee729dd3446747463e68054e186e59"
+        hasher.hexdigest() == "400bd8b4f3af31ffaeeb04b7780a140b0d26151645016e49a1a375964b67ea7e"
     ), result


### PR DESCRIPTION
This request is to solve #716 by clarifying:
- an array such as `[int, string]` indicates a union type of its elements, and
- its elements may be duplicated.

