### PR TITLE
release no py37 wheels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           name: install cibuildwheel and other build reqs
           command: |
             python3 -m pip install --upgrade pip setuptools setuptools_scm[toml]
-            python3 -m pip install cibuildwheel
+            python3 -m pip install -rcibw-requirements.txt
             python3 -m setuptools_scm
 
       - run:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,131 +5,103 @@ on:
     types: [created]
   workflow_dispatch: {}
   repository_dispatch: {}
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
-  # strategy; can't use a matrix reference in "uses": https://github.com/orgs/community/discussions/25824#discussioncomment-3249394
-  musllinux:
-    runs-on: ubuntu-latest
-    steps:
-    - name: debug event name
-      run: echo ${{ github.event_name }}
-    - uses: actions/checkout@v3
-      if: ${{ github.event_name != 'repository_dispatch' }}
-      with:
-        fetch-depth: 0  # slow, but gets all the tags
-    - uses: actions/checkout@v3
-      if: ${{ github.event_name == 'repository_dispatch' }}
-      with:
-        fetch-depth: 0  # slow, but gets all the tags
-        ref: ${{ github.event.client_payload.ref }}
-    - name: set version
-      run: pip install setuptools_scm[toml] && python -m setuptools_scm
-    - name: Build musllinux_1_1 x86_64 Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.7.1-musllinux_1_1_x86_64
-      with:
-        pre-build-command: source .github/workflows/wheel-prep.sh
-        build-requirements: -rrequirements.txt -rmypy-requirements.txt
-        python-versions: 'cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
-    - name: Copy audited wheels to new directory
-      run: mkdir audited_wheels && cp dist/*-musllinux*.whl audited_wheels/
-    - name: Publish wheels to PyPI
-      if: ${{ github.event_name == 'release' || github.event.client_payload.publish_wheel}}
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        packages_dir: audited_wheels
-        skip_existing: true
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04 ] #  macOS-11
 
-  manylinux2014:
-    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      if: ${{ github.event_name != 'repository_dispatch' }}
-      with:
-        fetch-depth: 0  # slow, but gets all the tags
-    - uses: actions/checkout@v3
-      if: ${{ github.event_name == 'repository_dispatch' }}
-      with:
-        fetch-depth: 0  # slow, but gets all the tags
-        ref: ${{ github.event.client_payload.ref }}
-    - name: set version
-      run: pip install setuptools_scm[toml] && python -m setuptools_scm
-    - name: Build manylinux2014 x86_64 Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.7.1-manylinux2014_x86_64
-      with:
-        pre-build-command: source .github/workflows/wheel-prep.sh
-        build-requirements: -rrequirements.txt -rmypy-requirements.txt
-        python-versions: 'cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
-    - name: Copy audited wheels to new directory
-      run: mkdir audited_wheels && cp dist/*-manylinux*.whl audited_wheels/
-    - name: Publish wheels to PyPI
-      if: ${{ github.event_name == 'release' || github.event.client_payload.publish_wheel}}
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        packages_dir: audited_wheels
-        skip_existing: true
+      - uses: actions/checkout@v3
+        if: ${{ github.event_name != 'repository_dispatch' }}
+        with:
+          fetch-depth: 0  # slow, but gets all the tags
+      - uses: actions/checkout@v3
+        if: ${{ github.event_name == 'repository_dispatch' }}
+        with:
+          fetch-depth: 0  # slow, but gets all the tags
+          ref: ${{ github.event.client_payload.ref }}
 
-  manylinux_2_24:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      if: ${{ github.event_name != 'repository_dispatch' }}
-      with:
-        fetch-depth: 0  # slow, but gets all the tags
-    - uses: actions/checkout@v3
-      if: ${{ github.event_name == 'repository_dispatch' }}
-      with:
-        fetch-depth: 0  # slow, but gets all the tags
-        ref: ${{ github.event.client_payload.ref }}
-    - name: set version
-      run: pip install setuptools_scm[toml] && python -m setuptools_scm
-    - name: Build manylinux_2_24 x86_64 Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.7.1-manylinux_2_24_x86_64
-      with:
-        pre-build-command: source .github/workflows/wheel-prep.sh
-        build-requirements: -rrequirements.txt -rmypy-requirements.txt
-        python-versions: 'cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
-    - name: Copy audited wheels to new directory
-      run: mkdir audited_wheels && cp dist/*-manylinux*.whl audited_wheels/
-    - name: Publish wheels to PyPI
-      if: ${{ github.event_name == 'release' || github.event.client_payload.publish_wheel}}
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        packages_dir: audited_wheels
-        skip_existing: true
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v3
 
-  manylinux_2_28:
-    runs-on: ubuntu-latest
+      # - name: Set up QEMU
+      #   if: runner.os == 'Linux'
+      #   uses: docker/setup-qemu-action@v2
+      #   with:
+      #     platforms: all
+
+      - name: Install cibuildwheel
+        run: python -m pip install -rcibw-requirements.txt
+
+      - name: set version
+        run: pip install setuptools_scm[toml] && python -m setuptools_scm
+
+      - name: Build wheels
+        run: |
+          source .github/workflows/wheel-prep.sh
+          export CIBW_ENVIRONMENT="SCHEMA_SALAD_USE_MYPYC=1 MYPYPATH=/project/mypy-stubs SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}"
+          python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS_MACOS: x86_64 arm64
+          # configure cibuildwheel to build native 64-bit archs ('auto64'), and some
+          # emulated ones
+          # Linux arm64 wheels are built on circleci
+          CIBW_ARCHS_LINUX: auto64 # ppc64le s390x
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-      if: ${{ github.event_name != 'repository_dispatch' }}
-      with:
-        fetch-depth: 0  # slow, but gets all the tags
-    - uses: actions/checkout@v3
-      if: ${{ github.event_name == 'repository_dispatch' }}
-      with:
-        fetch-depth: 0  # slow, but gets all the tags
-        ref: ${{ github.event.client_payload.ref }}
-    - name: set version
-      run: pip install setuptools_scm[toml] && python -m setuptools_scm
-    - name: Build manylinux_2_28 x86_64 Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.7.1-manylinux_2_28_x86_64
-      with:
-        pre-build-command: source .github/workflows/wheel-prep.sh
-        build-requirements: -rrequirements.txt -rmypy-requirements.txt
-        python-versions: 'cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
-    - name: Copy audited wheels to new directory
-      run: mkdir audited_wheels && cp dist/*-manylinux*.whl audited_wheels/
-    - name: Publish wheels to PyPI
-      if: ${{ github.event_name == 'release' || github.event.client_payload.publish_wheel}}
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        packages_dir: audited_wheels
-        skip_existing: true
+      - uses: actions/checkout@v3
+        if: ${{ github.event_name != 'repository_dispatch' }}
+        with:
+          fetch-depth: 0  # slow, but gets all the tags
+      - uses: actions/checkout@v3
+        if: ${{ github.event_name == 'repository_dispatch' }}
+        with:
+          fetch-depth: 0  # slow, but gets all the tags
+          ref: ${{ github.event.client_payload.ref }}
+
+      - name: set version
+        run: pip install setuptools_scm[toml] && python -m setuptools_scm
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # To test: repository-url: https://test.pypi.org/legacy/
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip_existing: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         pre-build-command: source .github/workflows/wheel-prep.sh
         build-requirements: -rrequirements.txt -rmypy-requirements.txt
-        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
+        python-versions: 'cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
     - name: Copy audited wheels to new directory
       run: mkdir audited_wheels && cp dist/*-musllinux*.whl audited_wheels/
     - name: Publish wheels to PyPI
@@ -60,7 +60,7 @@ jobs:
       with:
         pre-build-command: source .github/workflows/wheel-prep.sh
         build-requirements: -rrequirements.txt -rmypy-requirements.txt
-        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
+        python-versions: 'cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
     - name: Copy audited wheels to new directory
       run: mkdir audited_wheels && cp dist/*-manylinux*.whl audited_wheels/
     - name: Publish wheels to PyPI
@@ -91,7 +91,7 @@ jobs:
       with:
         pre-build-command: source .github/workflows/wheel-prep.sh
         build-requirements: -rrequirements.txt -rmypy-requirements.txt
-        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
+        python-versions: 'cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
     - name: Copy audited wheels to new directory
       run: mkdir audited_wheels && cp dist/*-manylinux*.whl audited_wheels/
     - name: Publish wheels to PyPI
@@ -122,7 +122,7 @@ jobs:
       with:
         pre-build-command: source .github/workflows/wheel-prep.sh
         build-requirements: -rrequirements.txt -rmypy-requirements.txt
-        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
+        python-versions: 'cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
     - name: Copy audited wheels to new directory
       run: mkdir audited_wheels && cp dist/*-manylinux*.whl audited_wheels/
     - name: Publish wheels to PyPI

--- a/cibw-requirements.txt
+++ b/cibw-requirements.txt
@@ -1,0 +1,1 @@
+cibuildwheel==2.15.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=45",
     "setuptools_scm[toml]>=6.2",
-    'mypy==1.5.0',  # update mypy-requirements as well
+    'mypy==1.5.1',  # update mypy-requirements as well
     "black>=19.10b0",
     "types-pkg_resources",
     "types-requests",
@@ -21,9 +21,9 @@ before-build = "python -m pip install -r requirements.txt -r mypy-requirements.t
 test-command = "python -m pytest -n 2 --junitxml=/output/test-results/junit_$(python -V | awk '{print $2}')_${AUDITWHEEL_PLAT}.xml --pyargs schema_salad"
 test-requires = "-r test-requirements.txt"
 test-extras = "pycodegen"
-skip = "pp* cp36-* cp37-* cp312-*"
+skip = "pp* cp312-*"
 #      ^ skip building wheels on PyPy (any version)
-#           ^ skip building wheels on Python 3.6 / 3.7 (not supported) & 3.12 (not ready)
+#           ^ skip building wheels on 3.12 (not ready)
 build-verbosity = "1"
 
 [tool.black]


### PR DESCRIPTION
- stop building Python3.7 wheels
- switch to native cibuildwheel; RalfG/python-wheels-manylinux-build is deprecated
