### PR TITLE
Add support for `noLinkCheck` in codegen

### DIFF
--- a/schema_salad/codegen.py
+++ b/schema_salad/codegen.py
@@ -164,7 +164,9 @@ def codegen(
                     subscope = field.get("subscope")
                     fieldpred = field["name"]
                     optional = bool("https://w3id.org/cwl/salad#null" in field["type"])
-                    uri_loader = gen.uri_loader(gen.type_loader(field["type"]), True, False, None)
+                    uri_loader = gen.uri_loader(
+                        gen.type_loader(field["type"]), True, False, None, None
+                    )
                     gen.declare_id_field(
                         fieldpred,
                         uri_loader,
@@ -189,10 +191,16 @@ def codegen(
                         type_loader = gen.secondaryfilesdsl_loader(type_loader)
                     elif jld.get("_type") == "@id":
                         type_loader = gen.uri_loader(
-                            type_loader, jld.get("identity", False), False, ref_scope
+                            type_loader,
+                            jld.get("identity", False),
+                            False,
+                            ref_scope,
+                            jld.get("noLinkCheck"),
                         )
                     elif jld.get("_type") == "@vocab":
-                        type_loader = gen.uri_loader(type_loader, False, True, ref_scope)
+                        type_loader = gen.uri_loader(
+                            type_loader, False, True, ref_scope, jld.get("noLinkCheck")
+                        )
 
                     map_subject = jld.get("mapSubject")
                     if map_subject:

--- a/schema_salad/codegen_base.py
+++ b/schema_salad/codegen_base.py
@@ -115,6 +115,7 @@ class CodeGenBase:
         scoped_id: bool,
         vocab_term: bool,
         ref_scope: Optional[int],
+        no_link_check: Optional[bool],
     ) -> TypeDef:
         """Construct the TypeDef for the given URI loader."""
         raise NotImplementedError()

--- a/schema_salad/dotnet/util/Loaders/UriLoader.cs
+++ b/schema_salad/dotnet/util/Loaders/UriLoader.cs
@@ -8,17 +8,24 @@ internal class UriLoader : ILoader<object>
     readonly bool scopedID;
     readonly bool vocabTerm;
     readonly int? scopedRef;
+    readonly bool? noLinkCheck;
 
-    public UriLoader(in ILoader inner, in bool scopedID, in bool vocabTerm, in int? scopedRef)
+    public UriLoader(in ILoader inner, in bool scopedID, in bool vocabTerm, in int? scopedRef, in bool? noLinkCheck)
     {
         this.inner = inner;
         this.scopedID = scopedID;
         this.vocabTerm = vocabTerm;
         this.scopedRef = scopedRef;
+        this.noLinkCheck = noLinkCheck;
     }
 
     public object Load(in object doc_, in string baseuri, in LoadingOptions loadingOptions, in string? docRoot = null)
     {
+        LoadingOptions innerLoadingOptions = loadingOptions;
+        if (this.noLinkCheck != null)
+        {
+            innerLoadingOptions = new LoadingOptions(copyFrom: innerLoadingOptions, noLinkCheck: this.noLinkCheck);
+        }
         object doc = doc_;
         if (doc is IList)
         {
@@ -28,7 +35,7 @@ internal class UriLoader : ILoader<object>
             {
                 if (val is string valString)
                 {
-                    docWithExpansion.Add(loadingOptions.ExpandUrl(valString, baseuri, scopedID, vocabTerm, scopedRef));
+                    docWithExpansion.Add(innerLoadingOptions.ExpandUrl(valString, baseuri, scopedID, vocabTerm, scopedRef));
                 }
                 else
                 {
@@ -40,10 +47,10 @@ internal class UriLoader : ILoader<object>
         }
         else if (doc is string docString)
         {
-            doc = loadingOptions.ExpandUrl(docString, baseuri, scopedID, vocabTerm, scopedRef);
+            doc = innerLoadingOptions.ExpandUrl(docString, baseuri, scopedID, vocabTerm, scopedRef);
         }
 
-        return (object)inner.Load(doc, baseuri, loadingOptions);
+        return (object)inner.Load(doc, baseuri, innerLoadingOptions);
     }
 
     object ILoader.Load(in object doc, in string baseuri, in LoadingOptions loadingOptions, in string? docRoot)

--- a/schema_salad/dotnet/util/LoadingOptions.cs
+++ b/schema_salad/dotnet/util/LoadingOptions.cs
@@ -5,6 +5,7 @@ public class LoadingOptions
     public IFetcher fetcher;
     public string? fileUri;
     public Dictionary<string, string>? namespaces;
+    public bool? noLinkCheck;
     public List<string>? schemas;
     public Dictionary<string, object> idx;
     public Dictionary<string, string> vocab;
@@ -15,12 +16,14 @@ public class LoadingOptions
         in IFetcher? fetcher = null,
         in string? fileUri = null,
         in Dictionary<string, string>? namespaces = null,
+        in bool? noLinkCheck = null,
         in List<string>? schemas = null,
         in Dictionary<string, object>? idx = null,
         LoadingOptions? copyFrom = null)
     {
         this.fileUri = fileUri;
         this.namespaces = namespaces;
+        this.noLinkCheck = noLinkCheck;
         this.schemas = schemas;
         this.idx = idx ?? new Dictionary<string, object>();
 
@@ -40,6 +43,11 @@ public class LoadingOptions
             if (namespaces == null)
             {
                 this.namespaces = copyFrom.namespaces;
+            }
+
+            if (noLinkCheck == null)
+            {
+                this.noLinkCheck = copyFrom.noLinkCheck;
             }
 
             if (schemas == null)

--- a/schema_salad/dotnet_codegen.py
+++ b/schema_salad/dotnet_codegen.py
@@ -792,19 +792,21 @@ public class {enum_name} : IEnumClass<{enum_name}>
         scoped_id: bool,
         vocab_term: bool,
         ref_scope: Optional[int],
+        no_link_check: Optional[bool],
     ) -> TypeDef:
         """Construct the TypeDef for the given URI loader."""
         instance_type = inner.instance_type or "object"
         return self.declare_type(
             TypeDef(
                 instance_type=instance_type,
-                name=f"uri{inner.name}{scoped_id}{vocab_term}{ref_scope}",
+                name=f"uri{inner.name}{scoped_id}{vocab_term}{ref_scope}{no_link_check}",
                 loader_type="ILoader<object>",
-                init="new UriLoader({}, {}, {}, {})".format(
+                init="new UriLoader({}, {}, {}, {}, {})".format(
                     inner.name,
                     self.to_dotnet(scoped_id),
                     self.to_dotnet(vocab_term),
                     self.to_dotnet(ref_scope),
+                    self.to_dotnet(no_link_check),
                 ),
                 is_uri=True,
                 scoped_id=scoped_id,

--- a/schema_salad/java/main_utils/LoadingOptions.java
+++ b/schema_salad/java/main_utils/LoadingOptions.java
@@ -11,6 +11,7 @@ public class LoadingOptions {
   String fileUri;
   Map<String, String> namespaces;
   List<String> schemas;
+  Boolean noLinkCheck;
   Map<String, Object> idx;
   Map<String, String> vocab;
   Map<String, String> rvocab;
@@ -20,11 +21,13 @@ public class LoadingOptions {
       final String fileUri,
       final Map<String, String> namespaces,
       final List<String> schemas,
+      final Boolean noLinkCheck,
       final Map<String, Object> idx) {
     this.fetcher = fetcher;
     this.fileUri = fileUri;
     this.namespaces = namespaces;
     this.schemas = schemas;
+    this.noLinkCheck = noLinkCheck;
     this.idx = idx;
 
     if (namespaces != null) {

--- a/schema_salad/java/main_utils/LoadingOptionsBuilder.java
+++ b/schema_salad/java/main_utils/LoadingOptionsBuilder.java
@@ -11,6 +11,7 @@ public class LoadingOptionsBuilder {
   private Optional<Map<String, String>> namespaces = Optional.empty();
   private Optional<List<String>> schemas = Optional.empty();
   private Optional<LoadingOptions> copyFrom = Optional.empty();
+  private Optional<Boolean> noLinkCheck = Optional.empty();
 
   public LoadingOptionsBuilder() {}
 
@@ -34,11 +35,17 @@ public class LoadingOptionsBuilder {
     return this;
   }
 
+  public LoadingOptionsBuilder setNoLinkCheck(final Boolean noLinkCheck) {
+    this.noLinkCheck = Optional.of(noLinkCheck);
+    return this;
+  }
+
   public LoadingOptions build() {
     Fetcher fetcher = this.fetcher.orElse(null);
     String fileUri = this.fileUri.orElse(null);
     List<String> schemas = this.schemas.orElse(null);
     Map<String, String> namespaces = this.namespaces.orElse(null);
+    Boolean noLinkCheck = this.noLinkCheck.orElse(null);
     Map<String, Object> idx = new HashMap<String, Object>();
     if (this.copyFrom.isPresent()) {
       final LoadingOptions copyFrom = this.copyFrom.get();
@@ -53,10 +60,13 @@ public class LoadingOptionsBuilder {
         namespaces = copyFrom.namespaces;
         schemas = copyFrom.schemas; // Bug in Python codegen?
       }
+      if (noLinkCheck == null) {
+        noLinkCheck = copyFrom.noLinkCheck;
+      }
     }
     if (fetcher == null) {
       fetcher = new DefaultFetcher();
     }
-    return new LoadingOptions(fetcher, fileUri, namespaces, schemas, idx);
+    return new LoadingOptions(fetcher, fileUri, namespaces, schemas, noLinkCheck, idx);
   }
 }

--- a/schema_salad/java/main_utils/UriLoader.java
+++ b/schema_salad/java/main_utils/UriLoader.java
@@ -8,16 +8,19 @@ public class UriLoader<T> implements Loader<T> {
   private final boolean scopedId;
   private final boolean vocabTerm;
   private final Integer scopedRef;
+  private final Boolean noLinkCheck;
 
   public UriLoader(
       final Loader<T> innerLoader,
       final boolean scopedId,
       final boolean vocabTerm,
-      final Integer scopedRef) {
+      final Integer scopedRef,
+      final Boolean noLinkCheck) {
     this.innerLoader = innerLoader;
     this.scopedId = scopedId;
     this.vocabTerm = vocabTerm;
     this.scopedRef = scopedRef;
+    this.noLinkCheck = noLinkCheck;
   }
 
   private Object expandUrl(
@@ -35,18 +38,22 @@ public class UriLoader<T> implements Loader<T> {
       final String baseUri,
       final LoadingOptions loadingOptions,
       final String docRoot) {
+    LoadingOptions innerLoadingOptions = loadingOptions;
+    if (this.noLinkCheck != null) {
+      innerLoadingOptions = new LoadingOptionsBuilder().copiedFrom(loadingOptions).setNoLinkCheck(this.noLinkCheck).build();
+    }
     Object doc = doc_;
     if (doc instanceof List) {
       List<Object> docList = (List<Object>) doc;
       List<Object> docWithExpansion = new ArrayList<Object>();
       for (final Object el : docList) {
-        docWithExpansion.add(this.expandUrl(el, baseUri, loadingOptions));
+        docWithExpansion.add(this.expandUrl(el, baseUri, innerLoadingOptions));
       }
       doc = docWithExpansion;
     }
     if (doc instanceof String) {
-      doc = this.expandUrl(doc, baseUri, loadingOptions);
+      doc = this.expandUrl(doc, baseUri, innerLoadingOptions);
     }
-    return this.innerLoader.load(doc, baseUri, loadingOptions);
+    return this.innerLoader.load(doc, baseUri, innerLoadingOptions);
   }
 }

--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -715,17 +715,19 @@ public enum {clazz} {{
         scoped_id: bool,
         vocab_term: bool,
         ref_scope: Optional[int],
+        no_link_check: Optional[bool],
     ) -> TypeDef:
         instance_type = inner.instance_type or "Object"
         return self.declare_type(
             TypeDef(
                 instance_type=instance_type,  # ?
-                name=f"uri_{inner.name}_{scoped_id}_{vocab_term}_{ref_scope}",
-                init="new UriLoader({}, {}, {}, {})".format(
+                name=f"uri_{inner.name}_{scoped_id}_{vocab_term}_{ref_scope}_{no_link_check}",
+                init="new UriLoader({}, {}, {}, {}, {})".format(
                     inner.name,
                     self.to_java(scoped_id),
                     self.to_java(vocab_term),
                     self.to_java(ref_scope),
+                    self.to_java(no_link_check),
                 ),
                 is_uri=True,
                 scoped_id=scoped_id,

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -640,12 +640,13 @@ if self.{safename} is not None:
         scoped_id: bool,
         vocab_term: bool,
         ref_scope: Optional[int],
+        no_link_check: Optional[bool],
     ) -> TypeDef:
         """Construct the TypeDef for the given URI loader."""
         return self.declare_type(
             TypeDef(
-                f"uri_{inner.name}_{scoped_id}_{vocab_term}_{ref_scope}",
-                f"_URILoader({inner.name}, {scoped_id}, {vocab_term}, {ref_scope})",
+                f"uri_{inner.name}_{scoped_id}_{vocab_term}_{ref_scope}_{no_link_check}",
+                f"_URILoader({inner.name}, {scoped_id}, {vocab_term}, {ref_scope}, {no_link_check})",
                 is_uri=True,
                 scoped_id=scoped_id,
                 ref_scope=ref_scope,

--- a/schema_salad/typescript/util/LoadingOptions.ts
+++ b/schema_salad/typescript/util/LoadingOptions.ts
@@ -5,16 +5,18 @@ export class LoadingOptions {
   idx: Dictionary<any>
   fileUri?: string
   namespaces?: Dictionary<string>
+  noLinkCheck?: boolean
   schemas?: Dictionary<string>
   copyFrom?: LoadingOptions
   originalDoc: any
   vocab: Dictionary<string>
   rvocab: Dictionary<string>
 
-  constructor ({ fileUri, namespaces, schemas, originalDoc, copyFrom, fetcher }: {fileUri?: string, namespaces?: Dictionary<string>, schemas?: Dictionary<string>, originalDoc?: any, copyFrom?: LoadingOptions, fetcher?: Fetcher}) {
+  constructor ({ fileUri, namespaces, noLinkCheck, schemas, originalDoc, copyFrom, fetcher }: {fileUri?: string, namespaces?: Dictionary<string>, noLinkCheck?: boolean, schemas?: Dictionary<string>, originalDoc?: any, copyFrom?: LoadingOptions, fetcher?: Fetcher}) {
     this.idx = {}
     this.fileUri = fileUri
     this.namespaces = namespaces
+    this.noLinkCheck = noLinkCheck
     this.schemas = schemas
     this.originalDoc = originalDoc
 
@@ -28,6 +30,9 @@ export class LoadingOptions {
       }
       if (namespaces === undefined) {
         this.namespaces = copyFrom.namespaces
+      }
+      if (noLinkCheck === undefined) {
+        this.noLinkCheck = copyFrom.noLinkCheck
       }
       if (schemas === undefined) {
         this.schemas = copyFrom.schemas

--- a/schema_salad/typescript/util/loaders/UriLoader.ts
+++ b/schema_salad/typescript/util/loaders/UriLoader.ts
@@ -5,15 +5,20 @@ export class _URILoader implements Loader {
   scopedID: boolean
   vocabTerm: boolean
   scopedRef?: number
+  noLinkCheck?: boolean
 
-  constructor (inner: Loader, scopedID: boolean, vocabTerm: boolean, scopedRef?: number) {
+  constructor (inner: Loader, scopedID: boolean, vocabTerm: boolean, scopedRef?: number, noLinkCheck?: boolean) {
     this.inner = inner
     this.scopedID = scopedID
     this.vocabTerm = vocabTerm
     this.scopedRef = scopedRef
+    this.noLinkCheck = noLinkCheck
   }
 
   async load (doc: any, baseuri: string, loadingOptions: LoadingOptions, docRoot?: string): Promise<any> {
+    if (this.noLinkCheck !== undefined) {
+      loadingOptions = new LoadingOptions({ copyFrom: loadingOptions, noLinkCheck: this.noLinkCheck })
+    }
     if (Array.isArray(doc)) {
       const newDoc: any[] = []
       for (const val of doc) {

--- a/schema_salad/typescript_codegen.py
+++ b/schema_salad/typescript_codegen.py
@@ -670,17 +670,19 @@ export enum {enum_name} {{
         scoped_id: bool,
         vocab_term: bool,
         ref_scope: Optional[int],
+        no_link_check: Optional[bool],
     ) -> TypeDef:
         """Construct the TypeDef for the given URI loader."""
         instance_type = inner.instance_type or "any"
         return self.declare_type(
             TypeDef(
-                f"uri{inner.name}{scoped_id}{vocab_term}{ref_scope}",
-                "new _URILoader({}, {}, {}, {})".format(
+                f"uri{inner.name}{scoped_id}{vocab_term}{ref_scope}{no_link_check}",
+                "new _URILoader({}, {}, {}, {}, {})".format(
                     inner.name,
                     self.to_typescript(scoped_id),
                     self.to_typescript(vocab_term),
                     self.to_typescript(ref_scope),
+                    self.to_typescript(no_link_check),
                 ),
                 is_uri=True,
                 scoped_id=scoped_id,


### PR DESCRIPTION
This commit introduces support for the `noLinkCheck` `jsonldPredicate` in the Schema SALAD codegen toolchain, and in particular in the `URILoader` stack. When `noLinkCheck` is set to `true`, no link checking is performed for all the underlying objects hierarchy. The need to propagate its value to the hierarchy makes it necessary to modify also the `LoadingOptions` data structure.

All parsers but the Python one never perform link checking up to now, so this update makes no modification to their actual behaviour. However, it enables the `URILoader` classes to receive the `noLinkCheck` parameter for future implementations.