### PR TITLE
fixes #805 The value of copyFrom.fetcher is not used in the LoadingOp…

### DIFF
--- a/schema_salad/typescript/test/LoadingOptions.spec.ts
+++ b/schema_salad/typescript/test/LoadingOptions.spec.ts
@@ -1,0 +1,29 @@
+import { assert } from 'chai'
+import { Fetcher, LoadingOptions } from '../util/Internal'
+
+class TestFetcher implements Fetcher {
+  checkExists(url: string): boolean {
+    return true
+  }
+  async fetchText(url: string, contentTypes?: string[] | undefined): Promise<string> {
+    return "TestFetcher"
+  }
+  urljoin(baseUrl: string, url: string): string {
+    return `${baseUrl}/${url}`
+  }
+}
+
+describe('Test LoadingOptions', () => {
+  describe('copyFrom', () => {
+    const original = new LoadingOptions({fetcher: new TestFetcher()})
+    it('should have the same Fetcher as the original', async () => {
+      const copy = new LoadingOptions({copyFrom:original})
+      assert.equal(copy.fetcher,original.fetcher)
+    })
+    it('fetcher should take precedence over copyFrom', async () => {
+      const fetcher = new TestFetcher()
+      const copy = new LoadingOptions({fetcher,copyFrom:original})
+      assert.equal(copy.fetcher,fetcher)
+    })
+  })
+})

--- a/schema_salad/typescript/util/LoadingOptions.ts
+++ b/schema_salad/typescript/util/LoadingOptions.ts
@@ -25,7 +25,7 @@ export class LoadingOptions {
     if (copyFrom != null) {
       this.idx = copyFrom.idx
       if (fetcher === undefined) {
-        this.fetcher = copyFrom.fetcher
+        fetcher = copyFrom.fetcher
       }
       if (fileUri === undefined) {
         this.fileUri = copyFrom.fileUri


### PR DESCRIPTION
The LoadingOptions.fetcher must be the same as the fetcher specified in the constructor's copyFrom, but it is not. 
Initially, the value of copyFrom.fetcher is set to this.fetcher, but it is always overwritten later by the fetcher specified in the arguments or by DefaultFetcher. 
I have corrected this by setting copyFrom.fetcher to fetcher instead of this.fetcher.