### PR TITLE
error messages: report model and value being checked

### DIFF
--- a/schema_salad/exceptions.py
+++ b/schema_salad/exceptions.py
@@ -15,9 +15,11 @@ class SchemaSaladException(Exception):
         sl: Optional[SourceLine] = None,
         children: Optional[Sequence["SchemaSaladException"]] = None,
         bullet_for_children: str = "",
+        detailed_message: Optional[str] = None,
     ) -> None:
         super().__init__(msg)
         self.message = self.args[0]
+        self.detailed_message = detailed_message
         self.file: Optional[str] = None
         self.start: Optional[tuple[int, int]] = None
         self.end: Optional[tuple[int, int]] = None
@@ -97,14 +99,23 @@ class SchemaSaladException(Exception):
         indent_per_level = 2
         spaces = (level * indent_per_level) * " "
         bullet = self.bullet + " " if len(self.bullet) > 0 and with_bullet else ""
-        return f"{self.prefix()}{spaces}{bullet}{self.message}"
+        message_string = (
+            self.detailed_message
+            if (len(self.children) < 1 and self.detailed_message)
+            else self.message
+        )
+        return f"{self.prefix()}{spaces}{bullet}{message_string}"
 
     def __str__(self) -> str:
         """Convert to a string using :py:meth:`pretty_str`."""
         return str(self.pretty_str())
 
     def pretty_str(self, level: int = 0) -> str:
-        messages = len(self.message)
+        messages = (
+            len(self.message)
+            if len(self.children) > 0
+            else len(self.detailed_message or self.message)
+        )
         my_summary = [self.summary(level, True)] if messages else []
         next_level = level + 1 if messages else level
 

--- a/schema_salad/metaschema.py
+++ b/schema_salad/metaschema.py
@@ -1237,7 +1237,10 @@ class RecordField(Documented):
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -1245,9 +1248,11 @@ class RecordField(Documented):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `name` field with value `{val}` is not valid because:",
+                                "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
 
@@ -1288,7 +1293,10 @@ class RecordField(Documented):
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -1296,9 +1304,11 @@ class RecordField(Documented):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `doc` field with value `{val}` is not valid because:",
+                                "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
+                                detailed_message=f"the `doc` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         try:
@@ -1331,7 +1341,10 @@ class RecordField(Documented):
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -1339,9 +1352,11 @@ class RecordField(Documented):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `type` field with value `{val}` is not valid because:",
+                            "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         extension_fields: dict[str, Any] = {}
@@ -1482,7 +1497,10 @@ class RecordSchema(Saveable):
                             ValidationException(
                                 "the `fields` field is not valid because:",
                                 SourceLine(_doc, "fields", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -1490,9 +1508,11 @@ class RecordSchema(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `fields` field with value `{val}` is not valid because:",
+                                "the `fields` field is not valid because:",
                                 SourceLine(_doc, "fields", str),
                                 [e],
+                                detailed_message=f"the `fields` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         try:
@@ -1525,7 +1545,10 @@ class RecordSchema(Saveable):
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -1533,9 +1556,11 @@ class RecordSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `type` field with value `{val}` is not valid because:",
+                            "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         extension_fields: dict[str, Any] = {}
@@ -1682,7 +1707,10 @@ class EnumSchema(Saveable):
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -1690,9 +1718,11 @@ class EnumSchema(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `name` field with value `{val}` is not valid because:",
+                                "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
 
@@ -1734,7 +1764,10 @@ class EnumSchema(Saveable):
                         ValidationException(
                             "the `symbols` field is not valid because:",
                             SourceLine(_doc, "symbols", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -1742,9 +1775,11 @@ class EnumSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `symbols` field with value `{val}` is not valid because:",
+                            "the `symbols` field is not valid because:",
                             SourceLine(_doc, "symbols", str),
                             [e],
+                            detailed_message=f"the `symbols` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         try:
@@ -1777,7 +1812,10 @@ class EnumSchema(Saveable):
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -1785,9 +1823,11 @@ class EnumSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `type` field with value `{val}` is not valid because:",
+                            "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         extension_fields: dict[str, Any] = {}
@@ -1928,7 +1968,10 @@ class ArraySchema(Saveable):
                         ValidationException(
                             "the `items` field is not valid because:",
                             SourceLine(_doc, "items", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -1936,9 +1979,11 @@ class ArraySchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `items` field with value `{val}` is not valid because:",
+                            "the `items` field is not valid because:",
                             SourceLine(_doc, "items", str),
                             [e],
+                            detailed_message=f"the `items` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         try:
@@ -1971,7 +2016,10 @@ class ArraySchema(Saveable):
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -1979,9 +2027,11 @@ class ArraySchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `type` field with value `{val}` is not valid because:",
+                            "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         extension_fields: dict[str, Any] = {}
@@ -2117,7 +2167,10 @@ class MapSchema(Saveable):
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -2125,9 +2178,11 @@ class MapSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `type` field with value `{val}` is not valid because:",
+                            "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         try:
@@ -2160,7 +2215,10 @@ class MapSchema(Saveable):
                         ValidationException(
                             "the `values` field is not valid because:",
                             SourceLine(_doc, "values", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -2168,9 +2226,11 @@ class MapSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `values` field with value `{val}` is not valid because:",
+                            "the `values` field is not valid because:",
                             SourceLine(_doc, "values", str),
                             [e],
+                            detailed_message=f"the `values` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         extension_fields: dict[str, Any] = {}
@@ -2306,7 +2366,10 @@ class UnionSchema(Saveable):
                         ValidationException(
                             "the `names` field is not valid because:",
                             SourceLine(_doc, "names", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -2314,9 +2377,11 @@ class UnionSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `names` field with value `{val}` is not valid because:",
+                            "the `names` field is not valid because:",
                             SourceLine(_doc, "names", str),
                             [e],
+                            detailed_message=f"the `names` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         try:
@@ -2349,7 +2414,10 @@ class UnionSchema(Saveable):
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -2357,9 +2425,11 @@ class UnionSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `type` field with value `{val}` is not valid because:",
+                            "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         extension_fields: dict[str, Any] = {}
@@ -2544,7 +2614,10 @@ class JsonldPredicate(Saveable):
                             ValidationException(
                                 "the `_id` field is not valid because:",
                                 SourceLine(_doc, "_id", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2552,9 +2625,11 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `_id` field with value `{val}` is not valid because:",
+                                "the `_id` field is not valid because:",
                                 SourceLine(_doc, "_id", str),
                                 [e],
+                                detailed_message=f"the `_id` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         _type = None
@@ -2586,7 +2661,10 @@ class JsonldPredicate(Saveable):
                             ValidationException(
                                 "the `_type` field is not valid because:",
                                 SourceLine(_doc, "_type", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2594,9 +2672,11 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `_type` field with value `{val}` is not valid because:",
+                                "the `_type` field is not valid because:",
                                 SourceLine(_doc, "_type", str),
                                 [e],
+                                detailed_message=f"the `_type` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         _container = None
@@ -2628,7 +2708,10 @@ class JsonldPredicate(Saveable):
                             ValidationException(
                                 "the `_container` field is not valid because:",
                                 SourceLine(_doc, "_container", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2636,9 +2719,11 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `_container` field with value `{val}` is not valid because:",
+                                "the `_container` field is not valid because:",
                                 SourceLine(_doc, "_container", str),
                                 [e],
+                                detailed_message=f"the `_container` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         identity = None
@@ -2670,7 +2755,10 @@ class JsonldPredicate(Saveable):
                             ValidationException(
                                 "the `identity` field is not valid because:",
                                 SourceLine(_doc, "identity", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2678,9 +2766,11 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `identity` field with value `{val}` is not valid because:",
+                                "the `identity` field is not valid because:",
                                 SourceLine(_doc, "identity", str),
                                 [e],
+                                detailed_message=f"the `identity` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         noLinkCheck = None
@@ -2712,7 +2802,10 @@ class JsonldPredicate(Saveable):
                             ValidationException(
                                 "the `noLinkCheck` field is not valid because:",
                                 SourceLine(_doc, "noLinkCheck", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2720,9 +2813,11 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `noLinkCheck` field with value `{val}` is not valid because:",
+                                "the `noLinkCheck` field is not valid because:",
                                 SourceLine(_doc, "noLinkCheck", str),
                                 [e],
+                                detailed_message=f"the `noLinkCheck` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         mapSubject = None
@@ -2754,7 +2849,10 @@ class JsonldPredicate(Saveable):
                             ValidationException(
                                 "the `mapSubject` field is not valid because:",
                                 SourceLine(_doc, "mapSubject", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2762,9 +2860,11 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `mapSubject` field with value `{val}` is not valid because:",
+                                "the `mapSubject` field is not valid because:",
                                 SourceLine(_doc, "mapSubject", str),
                                 [e],
+                                detailed_message=f"the `mapSubject` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         mapPredicate = None
@@ -2796,7 +2896,10 @@ class JsonldPredicate(Saveable):
                             ValidationException(
                                 "the `mapPredicate` field is not valid because:",
                                 SourceLine(_doc, "mapPredicate", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2804,9 +2907,11 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `mapPredicate` field with value `{val}` is not valid because:",
+                                "the `mapPredicate` field is not valid because:",
                                 SourceLine(_doc, "mapPredicate", str),
                                 [e],
+                                detailed_message=f"the `mapPredicate` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         refScope = None
@@ -2838,7 +2943,10 @@ class JsonldPredicate(Saveable):
                             ValidationException(
                                 "the `refScope` field is not valid because:",
                                 SourceLine(_doc, "refScope", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2846,9 +2954,11 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `refScope` field with value `{val}` is not valid because:",
+                                "the `refScope` field is not valid because:",
                                 SourceLine(_doc, "refScope", str),
                                 [e],
+                                detailed_message=f"the `refScope` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         typeDSL = None
@@ -2880,7 +2990,10 @@ class JsonldPredicate(Saveable):
                             ValidationException(
                                 "the `typeDSL` field is not valid because:",
                                 SourceLine(_doc, "typeDSL", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2888,9 +3001,11 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `typeDSL` field with value `{val}` is not valid because:",
+                                "the `typeDSL` field is not valid because:",
                                 SourceLine(_doc, "typeDSL", str),
                                 [e],
+                                detailed_message=f"the `typeDSL` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         secondaryFilesDSL = None
@@ -2922,7 +3037,10 @@ class JsonldPredicate(Saveable):
                             ValidationException(
                                 "the `secondaryFilesDSL` field is not valid because:",
                                 SourceLine(_doc, "secondaryFilesDSL", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2930,9 +3048,11 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `secondaryFilesDSL` field with value `{val}` is not valid because:",
+                                "the `secondaryFilesDSL` field is not valid because:",
                                 SourceLine(_doc, "secondaryFilesDSL", str),
                                 [e],
+                                detailed_message=f"the `secondaryFilesDSL` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         subscope = None
@@ -2964,7 +3084,10 @@ class JsonldPredicate(Saveable):
                             ValidationException(
                                 "the `subscope` field is not valid because:",
                                 SourceLine(_doc, "subscope", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2972,9 +3095,11 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `subscope` field with value `{val}` is not valid because:",
+                                "the `subscope` field is not valid because:",
                                 SourceLine(_doc, "subscope", str),
                                 [e],
+                                detailed_message=f"the `subscope` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         extension_fields: dict[str, Any] = {}
@@ -3187,7 +3312,10 @@ class SpecializeDef(Saveable):
                         ValidationException(
                             "the `specializeFrom` field is not valid because:",
                             SourceLine(_doc, "specializeFrom", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -3195,9 +3323,11 @@ class SpecializeDef(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `specializeFrom` field with value `{val}` is not valid because:",
+                            "the `specializeFrom` field is not valid because:",
                             SourceLine(_doc, "specializeFrom", str),
                             [e],
+                            detailed_message=f"the `specializeFrom` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         try:
@@ -3230,7 +3360,10 @@ class SpecializeDef(Saveable):
                         ValidationException(
                             "the `specializeTo` field is not valid because:",
                             SourceLine(_doc, "specializeTo", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -3238,9 +3371,11 @@ class SpecializeDef(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `specializeTo` field with value `{val}` is not valid because:",
+                            "the `specializeTo` field is not valid because:",
                             SourceLine(_doc, "specializeTo", str),
                             [e],
+                            detailed_message=f"the `specializeTo` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         extension_fields: dict[str, Any] = {}
@@ -3411,7 +3546,10 @@ class SaladRecordField(RecordField):
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3419,9 +3557,11 @@ class SaladRecordField(RecordField):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `name` field with value `{val}` is not valid because:",
+                                "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
 
@@ -3462,7 +3602,10 @@ class SaladRecordField(RecordField):
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3470,9 +3613,11 @@ class SaladRecordField(RecordField):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `doc` field with value `{val}` is not valid because:",
+                                "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
+                                detailed_message=f"the `doc` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         try:
@@ -3505,7 +3650,10 @@ class SaladRecordField(RecordField):
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -3513,9 +3661,11 @@ class SaladRecordField(RecordField):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `type` field with value `{val}` is not valid because:",
+                            "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         jsonldPredicate = None
@@ -3547,7 +3697,10 @@ class SaladRecordField(RecordField):
                             ValidationException(
                                 "the `jsonldPredicate` field is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3555,9 +3708,11 @@ class SaladRecordField(RecordField):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `jsonldPredicate` field with value `{val}` is not valid because:",
+                                "the `jsonldPredicate` field is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
                                 [e],
+                                detailed_message=f"the `jsonldPredicate` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         default = None
@@ -3589,7 +3744,10 @@ class SaladRecordField(RecordField):
                             ValidationException(
                                 "the `default` field is not valid because:",
                                 SourceLine(_doc, "default", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3597,9 +3755,11 @@ class SaladRecordField(RecordField):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `default` field with value `{val}` is not valid because:",
+                                "the `default` field is not valid because:",
                                 SourceLine(_doc, "default", str),
                                 [e],
+                                detailed_message=f"the `default` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         extension_fields: dict[str, Any] = {}
@@ -3805,7 +3965,10 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3813,9 +3976,11 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `name` field with value `{val}` is not valid because:",
+                                "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
 
@@ -3856,7 +4021,10 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3864,9 +4032,11 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `inVocab` field with value `{val}` is not valid because:",
+                                "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
                                 [e],
+                                detailed_message=f"the `inVocab` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         fields = None
@@ -3898,7 +4068,10 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `fields` field is not valid because:",
                                 SourceLine(_doc, "fields", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3906,9 +4079,11 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `fields` field with value `{val}` is not valid because:",
+                                "the `fields` field is not valid because:",
                                 SourceLine(_doc, "fields", str),
                                 [e],
+                                detailed_message=f"the `fields` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         try:
@@ -3941,7 +4116,10 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -3949,9 +4127,11 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `type` field with value `{val}` is not valid because:",
+                            "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         doc = None
@@ -3983,7 +4163,10 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3991,9 +4174,11 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `doc` field with value `{val}` is not valid because:",
+                                "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
+                                detailed_message=f"the `doc` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docParent = None
@@ -4025,7 +4210,10 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4033,9 +4221,11 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docParent` field with value `{val}` is not valid because:",
+                                "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
                                 [e],
+                                detailed_message=f"the `docParent` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docChild = None
@@ -4067,7 +4257,10 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4075,9 +4268,11 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docChild` field with value `{val}` is not valid because:",
+                                "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
                                 [e],
+                                detailed_message=f"the `docChild` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docAfter = None
@@ -4109,7 +4304,10 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4117,9 +4315,11 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docAfter` field with value `{val}` is not valid because:",
+                                "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
                                 [e],
+                                detailed_message=f"the `docAfter` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         jsonldPredicate = None
@@ -4151,7 +4351,10 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `jsonldPredicate` field is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4159,9 +4362,11 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `jsonldPredicate` field with value `{val}` is not valid because:",
+                                "the `jsonldPredicate` field is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
                                 [e],
+                                detailed_message=f"the `jsonldPredicate` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         documentRoot = None
@@ -4193,7 +4398,10 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `documentRoot` field is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4201,9 +4409,11 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `documentRoot` field with value `{val}` is not valid because:",
+                                "the `documentRoot` field is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
                                 [e],
+                                detailed_message=f"the `documentRoot` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         abstract = None
@@ -4235,7 +4445,10 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `abstract` field is not valid because:",
                                 SourceLine(_doc, "abstract", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4243,9 +4456,11 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `abstract` field with value `{val}` is not valid because:",
+                                "the `abstract` field is not valid because:",
                                 SourceLine(_doc, "abstract", str),
                                 [e],
+                                detailed_message=f"the `abstract` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         extends = None
@@ -4277,7 +4492,10 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `extends` field is not valid because:",
                                 SourceLine(_doc, "extends", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4285,9 +4503,11 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `extends` field with value `{val}` is not valid because:",
+                                "the `extends` field is not valid because:",
                                 SourceLine(_doc, "extends", str),
                                 [e],
+                                detailed_message=f"the `extends` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         specialize = None
@@ -4319,7 +4539,10 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `specialize` field is not valid because:",
                                 SourceLine(_doc, "specialize", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4327,9 +4550,11 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `specialize` field with value `{val}` is not valid because:",
+                                "the `specialize` field is not valid because:",
                                 SourceLine(_doc, "specialize", str),
                                 [e],
+                                detailed_message=f"the `specialize` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         extension_fields: dict[str, Any] = {}
@@ -4593,7 +4818,10 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4601,9 +4829,11 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `name` field with value `{val}` is not valid because:",
+                                "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
 
@@ -4644,7 +4874,10 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4652,9 +4885,11 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `inVocab` field with value `{val}` is not valid because:",
+                                "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
                                 [e],
+                                detailed_message=f"the `inVocab` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         try:
@@ -4687,7 +4922,10 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                         ValidationException(
                             "the `symbols` field is not valid because:",
                             SourceLine(_doc, "symbols", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -4695,9 +4933,11 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `symbols` field with value `{val}` is not valid because:",
+                            "the `symbols` field is not valid because:",
                             SourceLine(_doc, "symbols", str),
                             [e],
+                            detailed_message=f"the `symbols` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         try:
@@ -4730,7 +4970,10 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -4738,9 +4981,11 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `type` field with value `{val}` is not valid because:",
+                            "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         doc = None
@@ -4772,7 +5017,10 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4780,9 +5028,11 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `doc` field with value `{val}` is not valid because:",
+                                "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
+                                detailed_message=f"the `doc` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docParent = None
@@ -4814,7 +5064,10 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4822,9 +5075,11 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docParent` field with value `{val}` is not valid because:",
+                                "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
                                 [e],
+                                detailed_message=f"the `docParent` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docChild = None
@@ -4856,7 +5111,10 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4864,9 +5122,11 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docChild` field with value `{val}` is not valid because:",
+                                "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
                                 [e],
+                                detailed_message=f"the `docChild` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docAfter = None
@@ -4898,7 +5158,10 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4906,9 +5169,11 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docAfter` field with value `{val}` is not valid because:",
+                                "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
                                 [e],
+                                detailed_message=f"the `docAfter` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         jsonldPredicate = None
@@ -4940,7 +5205,10 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `jsonldPredicate` field is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4948,9 +5216,11 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `jsonldPredicate` field with value `{val}` is not valid because:",
+                                "the `jsonldPredicate` field is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
                                 [e],
+                                detailed_message=f"the `jsonldPredicate` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         documentRoot = None
@@ -4982,7 +5252,10 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `documentRoot` field is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4990,9 +5263,11 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `documentRoot` field with value `{val}` is not valid because:",
+                                "the `documentRoot` field is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
                                 [e],
+                                detailed_message=f"the `documentRoot` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         extends = None
@@ -5024,7 +5299,10 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `extends` field is not valid because:",
                                 SourceLine(_doc, "extends", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5032,9 +5310,11 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `extends` field with value `{val}` is not valid because:",
+                                "the `extends` field is not valid because:",
                                 SourceLine(_doc, "extends", str),
                                 [e],
+                                detailed_message=f"the `extends` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         extension_fields: dict[str, Any] = {}
@@ -5275,7 +5555,10 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5283,9 +5566,11 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `name` field with value `{val}` is not valid because:",
+                                "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
 
@@ -5326,7 +5611,10 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5334,9 +5622,11 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `inVocab` field with value `{val}` is not valid because:",
+                                "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
                                 [e],
+                                detailed_message=f"the `inVocab` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         try:
@@ -5369,7 +5659,10 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -5377,9 +5670,11 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `type` field with value `{val}` is not valid because:",
+                            "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         try:
@@ -5412,7 +5707,10 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                         ValidationException(
                             "the `values` field is not valid because:",
                             SourceLine(_doc, "values", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -5420,9 +5718,11 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `values` field with value `{val}` is not valid because:",
+                            "the `values` field is not valid because:",
                             SourceLine(_doc, "values", str),
                             [e],
+                            detailed_message=f"the `values` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         doc = None
@@ -5454,7 +5754,10 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5462,9 +5765,11 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `doc` field with value `{val}` is not valid because:",
+                                "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
+                                detailed_message=f"the `doc` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docParent = None
@@ -5496,7 +5801,10 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5504,9 +5812,11 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docParent` field with value `{val}` is not valid because:",
+                                "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
                                 [e],
+                                detailed_message=f"the `docParent` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docChild = None
@@ -5538,7 +5848,10 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5546,9 +5859,11 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docChild` field with value `{val}` is not valid because:",
+                                "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
                                 [e],
+                                detailed_message=f"the `docChild` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docAfter = None
@@ -5580,7 +5895,10 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5588,9 +5906,11 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docAfter` field with value `{val}` is not valid because:",
+                                "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
                                 [e],
+                                detailed_message=f"the `docAfter` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         jsonldPredicate = None
@@ -5622,7 +5942,10 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `jsonldPredicate` field is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5630,9 +5953,11 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `jsonldPredicate` field with value `{val}` is not valid because:",
+                                "the `jsonldPredicate` field is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
                                 [e],
+                                detailed_message=f"the `jsonldPredicate` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         documentRoot = None
@@ -5664,7 +5989,10 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                             ValidationException(
                                 "the `documentRoot` field is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5672,9 +6000,11 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `documentRoot` field with value `{val}` is not valid because:",
+                                "the `documentRoot` field is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
                                 [e],
+                                detailed_message=f"the `documentRoot` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         extension_fields: dict[str, Any] = {}
@@ -5906,7 +6236,10 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5914,9 +6247,11 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `name` field with value `{val}` is not valid because:",
+                                "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
 
@@ -5957,7 +6292,10 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                             ValidationException(
                                 "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5965,9 +6303,11 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `inVocab` field with value `{val}` is not valid because:",
+                                "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
                                 [e],
+                                detailed_message=f"the `inVocab` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         try:
@@ -6000,7 +6340,10 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                         ValidationException(
                             "the `names` field is not valid because:",
                             SourceLine(_doc, "names", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -6008,9 +6351,11 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `names` field with value `{val}` is not valid because:",
+                            "the `names` field is not valid because:",
                             SourceLine(_doc, "names", str),
                             [e],
+                            detailed_message=f"the `names` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         try:
@@ -6043,7 +6388,10 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -6051,9 +6399,11 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `type` field with value `{val}` is not valid because:",
+                            "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         doc = None
@@ -6085,7 +6435,10 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6093,9 +6446,11 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `doc` field with value `{val}` is not valid because:",
+                                "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
+                                detailed_message=f"the `doc` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docParent = None
@@ -6127,7 +6482,10 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                             ValidationException(
                                 "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6135,9 +6493,11 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docParent` field with value `{val}` is not valid because:",
+                                "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
                                 [e],
+                                detailed_message=f"the `docParent` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docChild = None
@@ -6169,7 +6529,10 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                             ValidationException(
                                 "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6177,9 +6540,11 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docChild` field with value `{val}` is not valid because:",
+                                "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
                                 [e],
+                                detailed_message=f"the `docChild` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docAfter = None
@@ -6211,7 +6576,10 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                             ValidationException(
                                 "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6219,9 +6587,11 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docAfter` field with value `{val}` is not valid because:",
+                                "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
                                 [e],
+                                detailed_message=f"the `docAfter` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         documentRoot = None
@@ -6253,7 +6623,10 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                             ValidationException(
                                 "the `documentRoot` field is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6261,9 +6634,11 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `documentRoot` field with value `{val}` is not valid because:",
+                                "the `documentRoot` field is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
                                 [e],
+                                detailed_message=f"the `documentRoot` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         extension_fields: dict[str, Any] = {}
@@ -6479,7 +6854,10 @@ class Documentation(NamedType, DocType):
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6487,9 +6865,11 @@ class Documentation(NamedType, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `name` field with value `{val}` is not valid because:",
+                                "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
 
@@ -6530,7 +6910,10 @@ class Documentation(NamedType, DocType):
                             ValidationException(
                                 "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6538,9 +6921,11 @@ class Documentation(NamedType, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `inVocab` field with value `{val}` is not valid because:",
+                                "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
                                 [e],
+                                detailed_message=f"the `inVocab` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         doc = None
@@ -6572,7 +6957,10 @@ class Documentation(NamedType, DocType):
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6580,9 +6968,11 @@ class Documentation(NamedType, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `doc` field with value `{val}` is not valid because:",
+                                "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
+                                detailed_message=f"the `doc` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docParent = None
@@ -6614,7 +7004,10 @@ class Documentation(NamedType, DocType):
                             ValidationException(
                                 "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6622,9 +7015,11 @@ class Documentation(NamedType, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docParent` field with value `{val}` is not valid because:",
+                                "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
                                 [e],
+                                detailed_message=f"the `docParent` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docChild = None
@@ -6656,7 +7051,10 @@ class Documentation(NamedType, DocType):
                             ValidationException(
                                 "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6664,9 +7062,11 @@ class Documentation(NamedType, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docChild` field with value `{val}` is not valid because:",
+                                "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
                                 [e],
+                                detailed_message=f"the `docChild` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         docAfter = None
@@ -6698,7 +7098,10 @@ class Documentation(NamedType, DocType):
                             ValidationException(
                                 "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
-                                [ValidationException(f"Value `{val}` is a {val_type}, "
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6706,9 +7109,11 @@ class Documentation(NamedType, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                f"the `docAfter` field with value `{val}` is not valid because:",
+                                "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
                                 [e],
+                                detailed_message=f"the `docAfter` field with value `{val}` "
+                                "is not valid because:",
                             )
                         )
         try:
@@ -6741,7 +7146,10 @@ class Documentation(NamedType, DocType):
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value `{val}` is a {val_type}, "
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -6749,9 +7157,11 @@ class Documentation(NamedType, DocType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            f"the `type` field with value `{val}` is not valid because:",
+                            "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
                         )
                     )
         extension_fields: dict[str, Any] = {}

--- a/schema_salad/metaschema.py
+++ b/schema_salad/metaschema.py
@@ -752,7 +752,7 @@ class _UnionLoader(_Loader):
                                 if "id" in lc:
                                     errors.append(
                                         ValidationException(
-                                            f"checking object `{id}`",
+                                            f"checking object `{id}` using `{t}`",
                                             SourceLine(lc, "id", str),
                                             [e],
                                         )
@@ -760,7 +760,7 @@ class _UnionLoader(_Loader):
                                 else:
                                     errors.append(
                                         ValidationException(
-                                            f"checking object `{id}`",
+                                            f"checking object `{id}` using `{t}`",
                                             SourceLine(lc, doc.get("id"), str),
                                             [e],
                                         )
@@ -1230,13 +1230,14 @@ class RecordField(Documented):
                         )
                     )
                 else:
+                    val = _doc.get("name")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("name"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -1244,7 +1245,7 @@ class RecordField(Documented):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `name` field is not valid because:",
+                                f"the `name` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
                             )
@@ -1280,13 +1281,14 @@ class RecordField(Documented):
                         )
                     )
                 else:
+                    val = _doc.get("doc")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("doc"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -1294,7 +1296,7 @@ class RecordField(Documented):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `doc` field is not valid because:",
+                                f"the `doc` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
                             )
@@ -1322,13 +1324,14 @@ class RecordField(Documented):
                     )
                 )
             else:
+                val = _doc.get("type")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("type"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -1336,7 +1339,7 @@ class RecordField(Documented):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `type` field is not valid because:",
+                            f"the `type` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
                         )
@@ -1472,13 +1475,14 @@ class RecordSchema(Saveable):
                         )
                     )
                 else:
+                    val = _doc.get("fields")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("fields"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `fields` field is not valid because:",
                                 SourceLine(_doc, "fields", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -1486,7 +1490,7 @@ class RecordSchema(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `fields` field is not valid because:",
+                                f"the `fields` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "fields", str),
                                 [e],
                             )
@@ -1514,13 +1518,14 @@ class RecordSchema(Saveable):
                     )
                 )
             else:
+                val = _doc.get("type")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("type"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -1528,7 +1533,7 @@ class RecordSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `type` field is not valid because:",
+                            f"the `type` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
                         )
@@ -1670,13 +1675,14 @@ class EnumSchema(Saveable):
                         )
                     )
                 else:
+                    val = _doc.get("name")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("name"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -1684,7 +1690,7 @@ class EnumSchema(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `name` field is not valid because:",
+                                f"the `name` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
                             )
@@ -1721,13 +1727,14 @@ class EnumSchema(Saveable):
                     )
                 )
             else:
+                val = _doc.get("symbols")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("symbols"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `symbols` field is not valid because:",
                             SourceLine(_doc, "symbols", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -1735,7 +1742,7 @@ class EnumSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `symbols` field is not valid because:",
+                            f"the `symbols` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "symbols", str),
                             [e],
                         )
@@ -1763,13 +1770,14 @@ class EnumSchema(Saveable):
                     )
                 )
             else:
+                val = _doc.get("type")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("type"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -1777,7 +1785,7 @@ class EnumSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `type` field is not valid because:",
+                            f"the `type` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
                         )
@@ -1913,13 +1921,14 @@ class ArraySchema(Saveable):
                     )
                 )
             else:
+                val = _doc.get("items")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("items"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `items` field is not valid because:",
                             SourceLine(_doc, "items", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -1927,7 +1936,7 @@ class ArraySchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `items` field is not valid because:",
+                            f"the `items` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "items", str),
                             [e],
                         )
@@ -1955,13 +1964,14 @@ class ArraySchema(Saveable):
                     )
                 )
             else:
+                val = _doc.get("type")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("type"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -1969,7 +1979,7 @@ class ArraySchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `type` field is not valid because:",
+                            f"the `type` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
                         )
@@ -2100,13 +2110,14 @@ class MapSchema(Saveable):
                     )
                 )
             else:
+                val = _doc.get("type")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("type"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -2114,7 +2125,7 @@ class MapSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `type` field is not valid because:",
+                            f"the `type` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
                         )
@@ -2142,13 +2153,14 @@ class MapSchema(Saveable):
                     )
                 )
             else:
+                val = _doc.get("values")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("values"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `values` field is not valid because:",
                             SourceLine(_doc, "values", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -2156,7 +2168,7 @@ class MapSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `values` field is not valid because:",
+                            f"the `values` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "values", str),
                             [e],
                         )
@@ -2287,13 +2299,14 @@ class UnionSchema(Saveable):
                     )
                 )
             else:
+                val = _doc.get("names")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("names"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `names` field is not valid because:",
                             SourceLine(_doc, "names", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -2301,7 +2314,7 @@ class UnionSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `names` field is not valid because:",
+                            f"the `names` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "names", str),
                             [e],
                         )
@@ -2329,13 +2342,14 @@ class UnionSchema(Saveable):
                     )
                 )
             else:
+                val = _doc.get("type")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("type"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -2343,7 +2357,7 @@ class UnionSchema(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `type` field is not valid because:",
+                            f"the `type` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
                         )
@@ -2523,13 +2537,14 @@ class JsonldPredicate(Saveable):
                         )
                     )
                 else:
+                    val = _doc.get("_id")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("_id"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `_id` field is not valid because:",
                                 SourceLine(_doc, "_id", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2537,7 +2552,7 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `_id` field is not valid because:",
+                                f"the `_id` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "_id", str),
                                 [e],
                             )
@@ -2564,13 +2579,14 @@ class JsonldPredicate(Saveable):
                         )
                     )
                 else:
+                    val = _doc.get("_type")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("_type"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `_type` field is not valid because:",
                                 SourceLine(_doc, "_type", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2578,7 +2594,7 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `_type` field is not valid because:",
+                                f"the `_type` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "_type", str),
                                 [e],
                             )
@@ -2605,13 +2621,14 @@ class JsonldPredicate(Saveable):
                         )
                     )
                 else:
+                    val = _doc.get("_container")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("_container"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `_container` field is not valid because:",
                                 SourceLine(_doc, "_container", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2619,7 +2636,7 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `_container` field is not valid because:",
+                                f"the `_container` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "_container", str),
                                 [e],
                             )
@@ -2646,13 +2663,14 @@ class JsonldPredicate(Saveable):
                         )
                     )
                 else:
+                    val = _doc.get("identity")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("identity"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `identity` field is not valid because:",
                                 SourceLine(_doc, "identity", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2660,7 +2678,7 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `identity` field is not valid because:",
+                                f"the `identity` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "identity", str),
                                 [e],
                             )
@@ -2687,13 +2705,14 @@ class JsonldPredicate(Saveable):
                         )
                     )
                 else:
+                    val = _doc.get("noLinkCheck")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("noLinkCheck"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `noLinkCheck` field is not valid because:",
                                 SourceLine(_doc, "noLinkCheck", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2701,7 +2720,7 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `noLinkCheck` field is not valid because:",
+                                f"the `noLinkCheck` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "noLinkCheck", str),
                                 [e],
                             )
@@ -2728,13 +2747,14 @@ class JsonldPredicate(Saveable):
                         )
                     )
                 else:
+                    val = _doc.get("mapSubject")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("mapSubject"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `mapSubject` field is not valid because:",
                                 SourceLine(_doc, "mapSubject", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2742,7 +2762,7 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `mapSubject` field is not valid because:",
+                                f"the `mapSubject` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "mapSubject", str),
                                 [e],
                             )
@@ -2769,13 +2789,14 @@ class JsonldPredicate(Saveable):
                         )
                     )
                 else:
+                    val = _doc.get("mapPredicate")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("mapPredicate"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `mapPredicate` field is not valid because:",
                                 SourceLine(_doc, "mapPredicate", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2783,7 +2804,7 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `mapPredicate` field is not valid because:",
+                                f"the `mapPredicate` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "mapPredicate", str),
                                 [e],
                             )
@@ -2810,13 +2831,14 @@ class JsonldPredicate(Saveable):
                         )
                     )
                 else:
+                    val = _doc.get("refScope")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("refScope"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `refScope` field is not valid because:",
                                 SourceLine(_doc, "refScope", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2824,7 +2846,7 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `refScope` field is not valid because:",
+                                f"the `refScope` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "refScope", str),
                                 [e],
                             )
@@ -2851,13 +2873,14 @@ class JsonldPredicate(Saveable):
                         )
                     )
                 else:
+                    val = _doc.get("typeDSL")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("typeDSL"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `typeDSL` field is not valid because:",
                                 SourceLine(_doc, "typeDSL", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2865,7 +2888,7 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `typeDSL` field is not valid because:",
+                                f"the `typeDSL` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "typeDSL", str),
                                 [e],
                             )
@@ -2892,13 +2915,14 @@ class JsonldPredicate(Saveable):
                         )
                     )
                 else:
+                    val = _doc.get("secondaryFilesDSL")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("secondaryFilesDSL"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `secondaryFilesDSL` field is not valid because:",
                                 SourceLine(_doc, "secondaryFilesDSL", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2906,7 +2930,7 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `secondaryFilesDSL` field is not valid because:",
+                                f"the `secondaryFilesDSL` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "secondaryFilesDSL", str),
                                 [e],
                             )
@@ -2933,13 +2957,14 @@ class JsonldPredicate(Saveable):
                         )
                     )
                 else:
+                    val = _doc.get("subscope")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("subscope"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `subscope` field is not valid because:",
                                 SourceLine(_doc, "subscope", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -2947,7 +2972,7 @@ class JsonldPredicate(Saveable):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `subscope` field is not valid because:",
+                                f"the `subscope` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "subscope", str),
                                 [e],
                             )
@@ -3155,13 +3180,14 @@ class SpecializeDef(Saveable):
                     )
                 )
             else:
+                val = _doc.get("specializeFrom")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("specializeFrom"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `specializeFrom` field is not valid because:",
                             SourceLine(_doc, "specializeFrom", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -3169,7 +3195,7 @@ class SpecializeDef(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `specializeFrom` field is not valid because:",
+                            f"the `specializeFrom` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "specializeFrom", str),
                             [e],
                         )
@@ -3197,13 +3223,14 @@ class SpecializeDef(Saveable):
                     )
                 )
             else:
+                val = _doc.get("specializeTo")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("specializeTo"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `specializeTo` field is not valid because:",
                             SourceLine(_doc, "specializeTo", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -3211,7 +3238,7 @@ class SpecializeDef(Saveable):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `specializeTo` field is not valid because:",
+                            f"the `specializeTo` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "specializeTo", str),
                             [e],
                         )
@@ -3377,13 +3404,14 @@ class SaladRecordField(RecordField):
                         )
                     )
                 else:
+                    val = _doc.get("name")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("name"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3391,7 +3419,7 @@ class SaladRecordField(RecordField):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `name` field is not valid because:",
+                                f"the `name` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
                             )
@@ -3427,13 +3455,14 @@ class SaladRecordField(RecordField):
                         )
                     )
                 else:
+                    val = _doc.get("doc")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("doc"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3441,7 +3470,7 @@ class SaladRecordField(RecordField):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `doc` field is not valid because:",
+                                f"the `doc` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
                             )
@@ -3469,13 +3498,14 @@ class SaladRecordField(RecordField):
                     )
                 )
             else:
+                val = _doc.get("type")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("type"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -3483,7 +3513,7 @@ class SaladRecordField(RecordField):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `type` field is not valid because:",
+                            f"the `type` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
                         )
@@ -3510,13 +3540,14 @@ class SaladRecordField(RecordField):
                         )
                     )
                 else:
+                    val = _doc.get("jsonldPredicate")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("jsonldPredicate"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `jsonldPredicate` field is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3524,7 +3555,7 @@ class SaladRecordField(RecordField):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `jsonldPredicate` field is not valid because:",
+                                f"the `jsonldPredicate` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
                                 [e],
                             )
@@ -3551,13 +3582,14 @@ class SaladRecordField(RecordField):
                         )
                     )
                 else:
+                    val = _doc.get("default")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("default"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `default` field is not valid because:",
                                 SourceLine(_doc, "default", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3565,7 +3597,7 @@ class SaladRecordField(RecordField):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `default` field is not valid because:",
+                                f"the `default` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "default", str),
                                 [e],
                             )
@@ -3766,13 +3798,14 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("name")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("name"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3780,7 +3813,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `name` field is not valid because:",
+                                f"the `name` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
                             )
@@ -3816,13 +3849,14 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("inVocab")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("inVocab"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3830,7 +3864,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `inVocab` field is not valid because:",
+                                f"the `inVocab` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
                                 [e],
                             )
@@ -3857,13 +3891,14 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("fields")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("fields"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `fields` field is not valid because:",
                                 SourceLine(_doc, "fields", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3871,7 +3906,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `fields` field is not valid because:",
+                                f"the `fields` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "fields", str),
                                 [e],
                             )
@@ -3899,13 +3934,14 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     )
                 )
             else:
+                val = _doc.get("type")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("type"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -3913,7 +3949,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `type` field is not valid because:",
+                            f"the `type` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
                         )
@@ -3940,13 +3976,14 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("doc")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("doc"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3954,7 +3991,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `doc` field is not valid because:",
+                                f"the `doc` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
                             )
@@ -3981,13 +4018,14 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("docParent")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docParent"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -3995,7 +4033,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docParent` field is not valid because:",
+                                f"the `docParent` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docParent", str),
                                 [e],
                             )
@@ -4022,13 +4060,14 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("docChild")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docChild"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4036,7 +4075,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docChild` field is not valid because:",
+                                f"the `docChild` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docChild", str),
                                 [e],
                             )
@@ -4063,13 +4102,14 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("docAfter")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docAfter"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4077,7 +4117,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docAfter` field is not valid because:",
+                                f"the `docAfter` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
                                 [e],
                             )
@@ -4104,13 +4144,14 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("jsonldPredicate")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("jsonldPredicate"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `jsonldPredicate` field is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4118,7 +4159,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `jsonldPredicate` field is not valid because:",
+                                f"the `jsonldPredicate` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
                                 [e],
                             )
@@ -4145,13 +4186,14 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("documentRoot")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("documentRoot"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `documentRoot` field is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4159,7 +4201,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `documentRoot` field is not valid because:",
+                                f"the `documentRoot` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
                                 [e],
                             )
@@ -4186,13 +4228,14 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("abstract")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("abstract"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `abstract` field is not valid because:",
                                 SourceLine(_doc, "abstract", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4200,7 +4243,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `abstract` field is not valid because:",
+                                f"the `abstract` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "abstract", str),
                                 [e],
                             )
@@ -4227,13 +4270,14 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("extends")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("extends"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `extends` field is not valid because:",
                                 SourceLine(_doc, "extends", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4241,7 +4285,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `extends` field is not valid because:",
+                                f"the `extends` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "extends", str),
                                 [e],
                             )
@@ -4268,13 +4312,14 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("specialize")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("specialize"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `specialize` field is not valid because:",
                                 SourceLine(_doc, "specialize", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4282,7 +4327,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `specialize` field is not valid because:",
+                                f"the `specialize` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "specialize", str),
                                 [e],
                             )
@@ -4541,13 +4586,14 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("name")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("name"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4555,7 +4601,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `name` field is not valid because:",
+                                f"the `name` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
                             )
@@ -4591,13 +4637,14 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("inVocab")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("inVocab"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4605,7 +4652,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `inVocab` field is not valid because:",
+                                f"the `inVocab` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
                                 [e],
                             )
@@ -4633,13 +4680,14 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     )
                 )
             else:
+                val = _doc.get("symbols")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("symbols"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `symbols` field is not valid because:",
                             SourceLine(_doc, "symbols", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -4647,7 +4695,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `symbols` field is not valid because:",
+                            f"the `symbols` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "symbols", str),
                             [e],
                         )
@@ -4675,13 +4723,14 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     )
                 )
             else:
+                val = _doc.get("type")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("type"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -4689,7 +4738,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `type` field is not valid because:",
+                            f"the `type` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
                         )
@@ -4716,13 +4765,14 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("doc")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("doc"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4730,7 +4780,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `doc` field is not valid because:",
+                                f"the `doc` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
                             )
@@ -4757,13 +4807,14 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("docParent")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docParent"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4771,7 +4822,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docParent` field is not valid because:",
+                                f"the `docParent` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docParent", str),
                                 [e],
                             )
@@ -4798,13 +4849,14 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("docChild")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docChild"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4812,7 +4864,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docChild` field is not valid because:",
+                                f"the `docChild` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docChild", str),
                                 [e],
                             )
@@ -4839,13 +4891,14 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("docAfter")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docAfter"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4853,7 +4906,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docAfter` field is not valid because:",
+                                f"the `docAfter` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
                                 [e],
                             )
@@ -4880,13 +4933,14 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("jsonldPredicate")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("jsonldPredicate"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `jsonldPredicate` field is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4894,7 +4948,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `jsonldPredicate` field is not valid because:",
+                                f"the `jsonldPredicate` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
                                 [e],
                             )
@@ -4921,13 +4975,14 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("documentRoot")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("documentRoot"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `documentRoot` field is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4935,7 +4990,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `documentRoot` field is not valid because:",
+                                f"the `documentRoot` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
                                 [e],
                             )
@@ -4962,13 +5017,14 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("extends")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("extends"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `extends` field is not valid because:",
                                 SourceLine(_doc, "extends", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -4976,7 +5032,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `extends` field is not valid because:",
+                                f"the `extends` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "extends", str),
                                 [e],
                             )
@@ -5212,13 +5268,14 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("name")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("name"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5226,7 +5283,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `name` field is not valid because:",
+                                f"the `name` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
                             )
@@ -5262,13 +5319,14 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("inVocab")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("inVocab"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5276,7 +5334,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `inVocab` field is not valid because:",
+                                f"the `inVocab` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
                                 [e],
                             )
@@ -5304,13 +5362,14 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     )
                 )
             else:
+                val = _doc.get("type")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("type"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -5318,7 +5377,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `type` field is not valid because:",
+                            f"the `type` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
                         )
@@ -5346,13 +5405,14 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     )
                 )
             else:
+                val = _doc.get("values")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("values"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `values` field is not valid because:",
                             SourceLine(_doc, "values", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -5360,7 +5420,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `values` field is not valid because:",
+                            f"the `values` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "values", str),
                             [e],
                         )
@@ -5387,13 +5447,14 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("doc")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("doc"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5401,7 +5462,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `doc` field is not valid because:",
+                                f"the `doc` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
                             )
@@ -5428,13 +5489,14 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("docParent")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docParent"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5442,7 +5504,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docParent` field is not valid because:",
+                                f"the `docParent` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docParent", str),
                                 [e],
                             )
@@ -5469,13 +5531,14 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("docChild")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docChild"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5483,7 +5546,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docChild` field is not valid because:",
+                                f"the `docChild` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docChild", str),
                                 [e],
                             )
@@ -5510,13 +5573,14 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("docAfter")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docAfter"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5524,7 +5588,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docAfter` field is not valid because:",
+                                f"the `docAfter` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
                                 [e],
                             )
@@ -5551,13 +5615,14 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("jsonldPredicate")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("jsonldPredicate"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `jsonldPredicate` field is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5565,7 +5630,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `jsonldPredicate` field is not valid because:",
+                                f"the `jsonldPredicate` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "jsonldPredicate", str),
                                 [e],
                             )
@@ -5592,13 +5657,14 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                         )
                     )
                 else:
+                    val = _doc.get("documentRoot")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("documentRoot"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `documentRoot` field is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5606,7 +5672,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `documentRoot` field is not valid because:",
+                                f"the `documentRoot` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
                                 [e],
                             )
@@ -5833,13 +5899,14 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                         )
                     )
                 else:
+                    val = _doc.get("name")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("name"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5847,7 +5914,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `name` field is not valid because:",
+                                f"the `name` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
                             )
@@ -5883,13 +5950,14 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                         )
                     )
                 else:
+                    val = _doc.get("inVocab")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("inVocab"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -5897,7 +5965,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `inVocab` field is not valid because:",
+                                f"the `inVocab` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
                                 [e],
                             )
@@ -5925,13 +5993,14 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     )
                 )
             else:
+                val = _doc.get("names")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("names"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `names` field is not valid because:",
                             SourceLine(_doc, "names", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -5939,7 +6008,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `names` field is not valid because:",
+                            f"the `names` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "names", str),
                             [e],
                         )
@@ -5967,13 +6036,14 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     )
                 )
             else:
+                val = _doc.get("type")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("type"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -5981,7 +6051,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `type` field is not valid because:",
+                            f"the `type` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
                         )
@@ -6008,13 +6078,14 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                         )
                     )
                 else:
+                    val = _doc.get("doc")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("doc"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6022,7 +6093,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `doc` field is not valid because:",
+                                f"the `doc` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
                             )
@@ -6049,13 +6120,14 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                         )
                     )
                 else:
+                    val = _doc.get("docParent")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docParent"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6063,7 +6135,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docParent` field is not valid because:",
+                                f"the `docParent` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docParent", str),
                                 [e],
                             )
@@ -6090,13 +6162,14 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                         )
                     )
                 else:
+                    val = _doc.get("docChild")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docChild"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6104,7 +6177,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docChild` field is not valid because:",
+                                f"the `docChild` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docChild", str),
                                 [e],
                             )
@@ -6131,13 +6204,14 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                         )
                     )
                 else:
+                    val = _doc.get("docAfter")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docAfter"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6145,7 +6219,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docAfter` field is not valid because:",
+                                f"the `docAfter` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
                                 [e],
                             )
@@ -6172,13 +6246,14 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                         )
                     )
                 else:
+                    val = _doc.get("documentRoot")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("documentRoot"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `documentRoot` field is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6186,7 +6261,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `documentRoot` field is not valid because:",
+                                f"the `documentRoot` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "documentRoot", str),
                                 [e],
                             )
@@ -6397,13 +6472,14 @@ class Documentation(NamedType, DocType):
                         )
                     )
                 else:
+                    val = _doc.get("name")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("name"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `name` field is not valid because:",
                                 SourceLine(_doc, "name", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6411,7 +6487,7 @@ class Documentation(NamedType, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `name` field is not valid because:",
+                                f"the `name` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "name", str),
                                 [e],
                             )
@@ -6447,13 +6523,14 @@ class Documentation(NamedType, DocType):
                         )
                     )
                 else:
+                    val = _doc.get("inVocab")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("inVocab"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `inVocab` field is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6461,7 +6538,7 @@ class Documentation(NamedType, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `inVocab` field is not valid because:",
+                                f"the `inVocab` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "inVocab", str),
                                 [e],
                             )
@@ -6488,13 +6565,14 @@ class Documentation(NamedType, DocType):
                         )
                     )
                 else:
+                    val = _doc.get("doc")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("doc"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `doc` field is not valid because:",
                                 SourceLine(_doc, "doc", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6502,7 +6580,7 @@ class Documentation(NamedType, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `doc` field is not valid because:",
+                                f"the `doc` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "doc", str),
                                 [e],
                             )
@@ -6529,13 +6607,14 @@ class Documentation(NamedType, DocType):
                         )
                     )
                 else:
+                    val = _doc.get("docParent")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docParent"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docParent` field is not valid because:",
                                 SourceLine(_doc, "docParent", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6543,7 +6622,7 @@ class Documentation(NamedType, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docParent` field is not valid because:",
+                                f"the `docParent` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docParent", str),
                                 [e],
                             )
@@ -6570,13 +6649,14 @@ class Documentation(NamedType, DocType):
                         )
                     )
                 else:
+                    val = _doc.get("docChild")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docChild"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docChild` field is not valid because:",
                                 SourceLine(_doc, "docChild", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6584,7 +6664,7 @@ class Documentation(NamedType, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docChild` field is not valid because:",
+                                f"the `docChild` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docChild", str),
                                 [e],
                             )
@@ -6611,13 +6691,14 @@ class Documentation(NamedType, DocType):
                         )
                     )
                 else:
+                    val = _doc.get("docAfter")
                     if error_message != str(e):
-                        val_type = convert_typing(extract_type(type(_doc.get("docAfter"))))
+                        val_type = convert_typing(extract_type(type(val)))
                         _errors__.append(
                             ValidationException(
                                 "the `docAfter` field is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
-                                [ValidationException(f"Value is a {val_type}, "
+                                [ValidationException(f"Value `{val}` is a {val_type}, "
                                                      f"but valid {to_print} for this field "
                                                      f"{verb_tensage} {error_message}")],
                             )
@@ -6625,7 +6706,7 @@ class Documentation(NamedType, DocType):
                     else:
                         _errors__.append(
                             ValidationException(
-                                "the `docAfter` field is not valid because:",
+                                f"the `docAfter` field with value `{val}` is not valid because:",
                                 SourceLine(_doc, "docAfter", str),
                                 [e],
                             )
@@ -6653,13 +6734,14 @@ class Documentation(NamedType, DocType):
                     )
                 )
             else:
+                val = _doc.get("type")
                 if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(_doc.get("type"))))
+                    val_type = convert_typing(extract_type(type(val)))
                     _errors__.append(
                         ValidationException(
                             "the `type` field is not valid because:",
                             SourceLine(_doc, "type", str),
-                            [ValidationException(f"Value is a {val_type}, "
+                            [ValidationException(f"Value `{val}` is a {val_type}, "
                                                  f"but valid {to_print} for this field "
                                                  f"{verb_tensage} {error_message}")],
                         )
@@ -6667,7 +6749,7 @@ class Documentation(NamedType, DocType):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "the `type` field is not valid because:",
+                            f"the `type` field with value `{val}` is not valid because:",
                             SourceLine(_doc, "type", str),
                             [e],
                         )

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -628,7 +628,10 @@ if _errors__:
 {spc}                        ValidationException(
 {spc}                            \"the `{fieldname}` field is not valid because:\",
 {spc}                            SourceLine(_doc, "{fieldname}", str),
-{spc}                            [ValidationException(f"Value `{{val}}` is a {{val_type}}, "
+{spc}                            [ValidationException(f"Value is a {{val_type}}, "
+{spc}                                                 f"but valid {{to_print}} for this field "
+{spc}                                                 f"{{verb_tensage}} {{error_message}}",
+{spc}                                                 detailed_message=f"Value `{{val}}` is a {{val_type}}, "
 {spc}                                                 f"but valid {{to_print}} for this field "
 {spc}                                                 f"{{verb_tensage}} {{error_message}}")],
 {spc}                        )
@@ -636,9 +639,11 @@ if _errors__:
 {spc}                else:
 {spc}                    _errors__.append(
 {spc}                        ValidationException(
-{spc}                            f"the `{fieldname}` field with value `{{val}}` is not valid because:\",
+{spc}                            "the `{fieldname}` field is not valid because:",
 {spc}                            SourceLine(_doc, "{fieldname}", str),
 {spc}                            [e],
+{spc}                            detailed_message=f"the `{fieldname}` field with value `{{val}}` "
+{spc}                            "is not valid because:\",
 {spc}                        )
 {spc}                    )
 """.format(

--- a/schema_salad/python_codegen.py
+++ b/schema_salad/python_codegen.py
@@ -621,13 +621,14 @@ if _errors__:
 {spc}                    )
 {spc}                )
 {spc}            else:
+{spc}                val = _doc.get("{fieldname}")
 {spc}                if error_message != str(e):
-{spc}                    val_type = convert_typing(extract_type(type(_doc.get("{fieldname}"))))
+{spc}                    val_type = convert_typing(extract_type(type(val)))
 {spc}                    _errors__.append(
 {spc}                        ValidationException(
 {spc}                            \"the `{fieldname}` field is not valid because:\",
 {spc}                            SourceLine(_doc, "{fieldname}", str),
-{spc}                            [ValidationException(f"Value is a {{val_type}}, "
+{spc}                            [ValidationException(f"Value `{{val}}` is a {{val_type}}, "
 {spc}                                                 f"but valid {{to_print}} for this field "
 {spc}                                                 f"{{verb_tensage}} {{error_message}}")],
 {spc}                        )
@@ -635,7 +636,7 @@ if _errors__:
 {spc}                else:
 {spc}                    _errors__.append(
 {spc}                        ValidationException(
-{spc}                            \"the `{fieldname}` field is not valid because:\",
+{spc}                            f"the `{fieldname}` field with value `{{val}}` is not valid because:\",
 {spc}                            SourceLine(_doc, "{fieldname}", str),
 {spc}                            [e],
 {spc}                        )

--- a/schema_salad/python_codegen_support.py
+++ b/schema_salad/python_codegen_support.py
@@ -749,7 +749,7 @@ class _UnionLoader(_Loader):
                                 if "id" in lc:
                                     errors.append(
                                         ValidationException(
-                                            f"checking object `{id}`",
+                                            f"checking object `{id}` using `{t}`",
                                             SourceLine(lc, "id", str),
                                             [e],
                                         )
@@ -757,7 +757,7 @@ class _UnionLoader(_Loader):
                                 else:
                                     errors.append(
                                         ValidationException(
-                                            f"checking object `{id}`",
+                                            f"checking object `{id}` using `{t}`",
                                             SourceLine(lc, doc.get("id"), str),
                                             [e],
                                         )

--- a/schema_salad/tests/test_codegen_errors.py
+++ b/schema_salad/tests/test_codegen_errors.py
@@ -43,9 +43,9 @@ def test_error_message4(tmp_path: Path) -> None:
     match = r"""^.*test4.cwl:2:1:\s+Object\s+`.*test4.cwl`\s+is\s+not\s+valid\s+because:
 .*test4\.cwl:6:1:\s+the\s+`outputs`\s+field\s+is\s+not\s+valid\s+because:
 \s+array\s+item\s+is\s+invalid\s+because
-.*test4\.cwl:7:3:\s+checking\s+object\s+`.*test4\.cwl#bar`
+.*test4\.cwl:7:3:\s+checking\s+object\s+`.*test4\.cwl#bar`\s+using\s+`WorkflowOutputParameter`
 \s+the\s+`type`\s+field\s+is\s+not\s+valid\s+because:
-\s+Value\s+is\s+a\s+int,\s+but\s+valid\s+types\s+for\s+this\s+field\s+are\s+\((str|object),\s+(str|object)\)"""
+\s+Value\s+`12`\s+is\s+a\s+int,\s+but\s+valid\s+types\s+for\s+this\s+field\s+are\s+\((str|object),\s+(str|object)\)"""
     path = get_data("tests/" + t)
     assert path
     with pytest.raises(ValidationException, match=match):
@@ -83,7 +83,7 @@ def test_error_message7(tmp_path: Path) -> None:
     match = r"""^.*test7\.cwl:2:1:\s+Object\s+`.*test7\.cwl`\s+is\s+not\s+valid\s+because:
 .*test7\.cwl:8:1:\s+the\s+`steps`\s+field\s+is\s+not\s+valid\s+because:
 \s+array\s+item\s+is\s+invalid\s+because
-.*test7\.cwl:9:3:\s+checking\s+object\s+`.*test7.cwl#step1`
+.*test7\.cwl:9:3:\s+checking\s+object\s+`.*test7.cwl#step1`\s+using\s+`WorkflowStep`
 \s+\*\s+missing\s+required\s+field\s+`run`
 .*test7\.cwl:10:5:\s+\*\s+invalid\s+field\s+`scatter_method`,\s+expected\s+one\s+of:\s+.*\s+.*\s+.*\s+.*\s+.*\s+.*\s+.*\s+.*\s+.*\s+.*$"""
     path = get_data("tests/" + t)
@@ -97,7 +97,7 @@ def test_error_message8(tmp_path: Path) -> None:
     match = r"""^.*test8.cwl:2:1:\s+Object\s+`.*test8.cwl`\s+is\s+not\s+valid\s+because:
 .*test8\.cwl:8:1:\s+the\s+`steps`\s+field\s+is\s+not\s+valid\s+because:
 \s+array\s+item\s+is\s+invalid\s+because
-.*test8\.cwl:9:3:\s+checking\s+object\s+`.*test8\.cwl#step1`
+.*test8\.cwl:9:3:\s+checking\s+object\s+`.*test8\.cwl#step1`\s+using\s+`WorkflowStep`
 \s+\*\s+missing\s+required\s+field\s+`run`
 .*test8\.cwl:10:5:\s+\*\s+the\s+`scatterMethod`\s+field\s+is\s+not\s+valid\s+because:
 \s+contains\s+undefined\s+reference\s+to\s+`file:///.*/tests/test_schema/abc`$"""
@@ -112,10 +112,10 @@ def test_error_message9(tmp_path: Path) -> None:
     match = r"""^.*test9.cwl:2:1:\s+Object\s+`.*test9.cwl`\s+is\s+not\s+valid\s+because:
 .*test9\.cwl:8:1:\s+the\s+`steps`\s+field\s+is\s+not\s+valid\s+because:
 \s+array\s+item\s+is\s+invalid\s+because
-.*test9\.cwl:9:3:\s+checking\s+object\s+`.*test9\.cwl#step1`
+.*test9\.cwl:9:3:\s+checking\s+object\s+`.*test9\.cwl#step1`\s+using\s+`WorkflowStep`
 \s+\*\s+missing\s+required\s+field\s+`run`
 .*test9\.cwl:10:5:\s+\*\s+the\s+`scatterMethod`\s+field\s+is\s+not\s+valid\s+because:
-\s+Value\s+is\s+a\s+int,\s+but\s+valid\s+values\s+for\s+this\s+field\s+are\s+\("(dotproduct|nested_crossproduct|flat_crossproduct)",\s+"(dotproduct|nested_crossproduct|flat_crossproduct)",\s+"(dotproduct|nested_crossproduct|flat_crossproduct)"\)"""
+\s+Value\s+`12`\s+is\s+a\s+int,\s+but\s+valid\s+values\s+for\s+this\s+field\s+are\s+\("(dotproduct|nested_crossproduct|flat_crossproduct)",\s+"(dotproduct|nested_crossproduct|flat_crossproduct)",\s+"(dotproduct|nested_crossproduct|flat_crossproduct)"\)"""
     path = get_data("tests/" + t)
     assert path
     with pytest.raises(ValidationException, match=match):
@@ -142,7 +142,7 @@ def test_error_message11(tmp_path: Path) -> None:
     match = r"""^.*test11\.cwl:2:1:\s+Object\s+`.*test11.cwl`\s+is\s+not\s+valid\s+because:
 .*test11\.cwl:8:1:\s+the\s+`steps`\s+field\s+is\s+not\s+valid\s+because:
 \s+array\s+item\s+is\s+invalid\s+because
-.*test11\.cwl:9:3:\s+checking\s+object\s+`.*test11\.cwl#step1`
+.*test11\.cwl:9:3:\s+checking\s+object\s+`.*test11\.cwl#step1`\s+using\s+`WorkflowStep`
 .*test11\.cwl:10:5:\s+the\s+`run`\s+field\s+is\s+not\s+valid\s+because:\s+contains\s+undefined\s+reference\s+to\s+`file:///.*/tests/test_schema/blub\.cwl`$"""
     path = get_data("tests/" + t)
     assert path
@@ -156,7 +156,7 @@ def test_error_message15(tmp_path: Path) -> None:
     match = r"""^.*test15\.cwl:3:1:\s+Object\s+`.*test15\.cwl`\s+is\s+not\s+valid\s+because:
 .*test15\.cwl:6:1:\s+the\s+`inputs`\s+field\s+is\s+not\s+valid\s+because:
 \s+array\s+item\s+is\s+invalid\s+because
-.*test15\.cwl:7:3:\s+checking\s+object\s+`.*test15\.cwl#message`
+.*test15\.cwl:7:3:\s+checking\s+object\s+`.*test15\.cwl#message`\s+using\s+`CommandInputParameter`
 .*test15\.cwl:9:5:\s+the\s+`inputBinding`\s+field\s+is\s+not\s+valid\s+because:
 \s+tried\s+`CommandLineBinding`\s+but
 .*test15\.cwl:11:7:\s+\*\s+invalid\s+field\s+`invalid_field`,\s+expected\s+one\s+of:\s+`loadContents`,\s+`position`,\s+`prefix`,\s+`separate`,\s+`itemSeparator`,\s+`valueFrom`,\s+`shellQuote`


### PR DESCRIPTION
This gxformat2 document has a wrong type on the max of a float parameter.
```
class: GalaxyWorkflow
doc: |
  Simple workflow that no-op cats a file.
inputs:
  the_input:
    type: File
    doc: input doc
  the_collection:
    type: collection
    collection_type: list
  the_integer:
    type: int
    min: 1
    max: 3
  the_float:
    type: float
    min: 1.0
    max: 3.0a
outputs:
  the_output:
    outputSource: cat/out_file1
steps:
  cat:
    tool_id: cat1
    doc: cat doc
    in:
      input1: the_input
```

Before:
```
.. ERROR: Validation failed schema/v19_09/examples/valid1.yml:1:1:   Object `valid1.yml` is not valid because:
schema/v19_09/examples/valid1.yml:4:1:     the `inputs` field is not valid because:
                                            array item is invalid because
schema/v19_09/examples/valid1.yml:15:3:       checking object `valid1.yml#the_float`
                                                * checking object `valid1.yml#the_float`
schema/v19_09/examples/valid1.yml:17:5:           * invalid field `min`, expected one of: `label`,
                                                  `doc`, `id`, `default`, `position`, `optional`, `type`,
                                                  `regex`
schema/v19_09/examples/valid1.yml:18:5:           * invalid field `max`, expected one of: `label`,
                                                  `doc`, `id`, `default`, `position`, `optional`, `type`,
                                                  `regex`
schema/v19_09/examples/valid1.yml:15:3:         * checking object `valid1.yml#the_float`
schema/v19_09/examples/valid1.yml:18:5:           the `max` field is not valid because:
                                                    Value is a str, but valid types for this field
                                                    are (int, float)
schema/v19_09/examples/valid1.yml:15:3:         * checking object `valid1.yml#the_float`
schema/v19_09/examples/valid1.yml:18:5:           * the `max` field is not valid because:
                                                    Value is a str, but valid types for this field
                                                    are (int, float)
schema/v19_09/examples/valid1.yml:16:5:           * the `type` field is not valid because:
                                                    Expected one of ('integer', 'int')
schema/v19_09/examples/valid1.yml:15:3:         * checking object `valid1.yml#the_float`
schema/v19_09/examples/valid1.yml:16:5:           * the `type` field is not valid because:
                                                    Value is a str, but valid values for this field
                                                    are ("File", "data")
schema/v19_09/examples/valid1.yml:17:5:           * invalid field `min`, expected one of: `label`,
                                                  `doc`, `id`, `default`, `position`, `optional`, `format`,
                                                  `type`
schema/v19_09/examples/valid1.yml:18:5:           * invalid field `max`, expected one of: `label`,
                                                  `doc`, `id`, `default`, `position`, `optional`, `format`,
                                                  `type`
schema/v19_09/examples/valid1.yml:15:3:         * checking object `valid1.yml#the_float`
schema/v19_09/examples/valid1.yml:16:5:           * the `type` field is not valid because:
                                                    Expected one of ('collection',)
schema/v19_09/examples/valid1.yml:17:5:           * invalid field `min`, expected one of: `label`,
                                                  `doc`, `id`, `default`, `position`, `optional`, `format`,
                                                  `type`, `collection_type`
schema/v19_09/examples/valid1.yml:18:5:           * invalid field `max`, expected one of: `label`,
                                                  `doc`, `id`, `default`, `position`, `optional`, `format`,
                                                  `type`, `collection_type`
```

After:
```
.. ERROR: Validation failed schema/v19_09/examples/valid1.yml:1:1:   Object `valid1.yml` is not valid because:
schema/v19_09/examples/valid1.yml:4:1:     the `inputs` field with value `ordereddict([('the_input',
                                          ordereddict([('type', 'File'), ('doc', 'input doc')])),
                                          ('the_collection', ordereddict([('type', 'collection'),
                                          ('collection_type', 'list')])), ('the_integer',
                                          ordereddict([('type', 'int'), ('min', 1), ('max', 3)])),
                                          ('the_float', ordereddict([('type', 'float'), ('min', 1.0),
                                          ('max', '3.0a')]))])` is not valid because:
                                            array item is invalid because
schema/v19_09/examples/valid1.yml:15:3:       checking object `valid1.yml#the_float` using
                                              `WorkflowInputParameterLoader`
                                                * checking object `valid1.yml#the_float` using
                                                `WorkflowTextParameter`
schema/v19_09/examples/valid1.yml:17:5:           * invalid field `min`, expected one of: `label`,
                                                  `doc`, `id`, `default`, `position`, `optional`, `type`,
                                                  `regex`
schema/v19_09/examples/valid1.yml:18:5:           * invalid field `max`, expected one of: `label`,
                                                  `doc`, `id`, `default`, `position`, `optional`, `type`,
                                                  `regex`
schema/v19_09/examples/valid1.yml:15:3:         * checking object `valid1.yml#the_float` using
                                                `WorkflowFloatParameter`
schema/v19_09/examples/valid1.yml:18:5:           the `max` field is not valid because:
                                                    Value `3.0a` is a str, but valid types for this
                                                    field are (float, int)
schema/v19_09/examples/valid1.yml:15:3:         * checking object `valid1.yml#the_float` using
                                                `WorkflowIntegerParameter`
schema/v19_09/examples/valid1.yml:18:5:           * the `max` field is not valid because:
                                                    Value `3.0a` is a str, but valid types for this
                                                    field are (float, int)
schema/v19_09/examples/valid1.yml:16:5:           * the `type` field with value `float` is not
                                                  valid because:
                                                    Expected one of ('integer', 'int')
schema/v19_09/examples/valid1.yml:15:3:         * checking object `valid1.yml#the_float` using
                                                `WorkflowDataParameter`
schema/v19_09/examples/valid1.yml:16:5:           * the `type` field is not valid because:
                                                    Value `float` is a str, but valid values for
                                                    this field are ("data", "File")
schema/v19_09/examples/valid1.yml:17:5:           * invalid field `min`, expected one of: `label`,
                                                  `doc`, `id`, `default`, `position`, `optional`, `format`,
                                                  `type`
schema/v19_09/examples/valid1.yml:18:5:           * invalid field `max`, expected one of: `label`,
                                                  `doc`, `id`, `default`, `position`, `optional`, `format`,
                                                  `type`
schema/v19_09/examples/valid1.yml:15:3:         * checking object `valid1.yml#the_float` using
                                                `WorkflowCollectionParameter`
schema/v19_09/examples/valid1.yml:16:5:           * the `type` field with value `float` is not
                                                  valid because:
                                                    Expected one of ('collection',)
schema/v19_09/examples/valid1.yml:17:5:           * invalid field `min`, expected one of: `label`,
                                                  `doc`, `id`, `default`, `position`, `optional`, `format`,
                                                  `type`, `collection_type`
schema/v19_09/examples/valid1.yml:18:5:           * invalid field `max`, expected one of: `label`,
                                                  `doc`, `id`, `default`, `position`, `optional`, `format`,
                                                  `type`, `collection_type`
```

I don't know if we like the top level dictionary dump there, but in terms of understanding why a document didn't validate I find the after version much easier to understand.