### PR TITLE
wheels: drop musllinux 1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,13 +89,6 @@ workflows:
           build: "*manylinux*"
           image: quay.io/pypa/manylinux_2_28_aarch64
       - arm-wheels:
-          name: arm-wheels-musllinux_1_1
-          filters:
-            tags:
-              only: /.*/
-          build: "*musllinux*"
-          image: quay.io/pypa/musllinux_1_1_aarch64
-      - arm-wheels:
           name: arm-wheels-musllinux_1_2
           filters:
             tags:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,8 +23,6 @@ jobs:
         include:
           - image: manylinux_2_28_x86_64
             build: "*manylinux*"
-          - image: musllinux_1_1_x86_64
-            build: "*musllinux*"
           - image: musllinux_1_2_x86_64
             build: "*musllinux*"
 


### PR DESCRIPTION
> musl libc 1.1 is EOL and Alpine Linux 3.12 also (support ended 2 years ago, May 1st, 2022).

https://github.com/pypa/manylinux/issues/1629
