### PR TITLE
cppgen: improved support of fields of type 'any'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,11 @@ flake8: FORCE
 schema_salad/metaschema.py: schema_salad/codegen_base.py schema_salad/python_codegen_support.py schema_salad/python_codegen.py schema_salad/metaschema/*.yml
 	schema-salad-tool --codegen python schema_salad/metaschema/metaschema.yml > $@
 
+vpath %.yml schema_salad/tests/cpp_tests
+
+schema_salad/tests/cpp_tests/%.h: %.yml
+	schema-salad-tool --codegen cpp --codegen-target $@ $<
+
 FORCE:
 
 # Use this to print the value of a Makefile variable

--- a/schema_salad/cpp_codegen.py
+++ b/schema_salad/cpp_codegen.py
@@ -700,29 +700,50 @@ inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
 }
 
 // declaring toYaml
-inline auto toYaml(bool v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(float v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(double v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(int32_t v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(int64_t v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(std::any const&) {
-    return YAML::Node{};
-}
+inline auto toYaml(bool v) { return YAML::Node{v}; }
+inline auto toYaml(float v) { return YAML::Node{v}; }
+inline auto toYaml(double v) { return YAML::Node{v}; }
+inline auto toYaml(char v) { return YAML::Node{v}; }
+inline auto toYaml(int8_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint8_t v) { return YAML::Node{v}; }
+inline auto toYaml(int16_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint16_t v) { return YAML::Node{v}; }
+inline auto toYaml(int32_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint32_t v) { return YAML::Node{v}; }
+inline auto toYaml(int64_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint64_t v) { return YAML::Node{v}; }
 inline auto toYaml(std::monostate const&) {
     return YAML::Node(YAML::NodeType::Undefined);
 }
 inline auto toYaml(std::string const& v) {
     return YAML::Node{v};
+}
+
+template <typename T, typename ...Args>
+auto anyToYaml_impl(std::any const& a) {
+    if (auto v = std::any_cast<T const>(&a)) {
+        return toYaml(*v);
+    }
+    if constexpr (sizeof...(Args) > 0) {
+        return anyToYaml_impl<Args...>(a);
+    }
+    return toYaml(std::monostate{});
+}
+
+inline auto toYaml(std::any const& a) {
+    return anyToYaml_impl<bool,
+                          float,
+                          double,
+                          char,
+                          int8_t,
+                          uint8_t,
+                          int16_t,
+                          uint16_t,
+                          int32_t,
+                          uint32_t,
+                          int64_t,
+                          uint64_t,
+                          std::string>(a);
 }
 
 // declaring fromYaml

--- a/schema_salad/tests/cpp_tests/01_single_record.h
+++ b/schema_salad/tests/cpp_tests/01_single_record.h
@@ -25,29 +25,50 @@ inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
 }
 
 // declaring toYaml
-inline auto toYaml(bool v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(float v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(double v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(int32_t v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(int64_t v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(std::any const&) {
-    return YAML::Node{};
-}
+inline auto toYaml(bool v) { return YAML::Node{v}; }
+inline auto toYaml(float v) { return YAML::Node{v}; }
+inline auto toYaml(double v) { return YAML::Node{v}; }
+inline auto toYaml(char v) { return YAML::Node{v}; }
+inline auto toYaml(int8_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint8_t v) { return YAML::Node{v}; }
+inline auto toYaml(int16_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint16_t v) { return YAML::Node{v}; }
+inline auto toYaml(int32_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint32_t v) { return YAML::Node{v}; }
+inline auto toYaml(int64_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint64_t v) { return YAML::Node{v}; }
 inline auto toYaml(std::monostate const&) {
     return YAML::Node(YAML::NodeType::Undefined);
 }
 inline auto toYaml(std::string const& v) {
     return YAML::Node{v};
+}
+
+template <typename T, typename ...Args>
+auto anyToYaml_impl(std::any const& a) {
+    if (auto v = std::any_cast<T const>(&a)) {
+        return toYaml(*v);
+    }
+    if constexpr (sizeof...(Args) > 0) {
+        return anyToYaml_impl<Args...>(a);
+    }
+    return toYaml(std::monostate{});
+}
+
+inline auto toYaml(std::any const& a) {
+    return anyToYaml_impl<bool,
+                          float,
+                          double,
+                          char,
+                          int8_t,
+                          uint8_t,
+                          int16_t,
+                          uint16_t,
+                          int32_t,
+                          uint32_t,
+                          int64_t,
+                          uint64_t,
+                          std::string>(a);
 }
 
 // declaring fromYaml

--- a/schema_salad/tests/cpp_tests/02_two_records.h
+++ b/schema_salad/tests/cpp_tests/02_two_records.h
@@ -25,29 +25,50 @@ inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
 }
 
 // declaring toYaml
-inline auto toYaml(bool v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(float v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(double v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(int32_t v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(int64_t v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(std::any const&) {
-    return YAML::Node{};
-}
+inline auto toYaml(bool v) { return YAML::Node{v}; }
+inline auto toYaml(float v) { return YAML::Node{v}; }
+inline auto toYaml(double v) { return YAML::Node{v}; }
+inline auto toYaml(char v) { return YAML::Node{v}; }
+inline auto toYaml(int8_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint8_t v) { return YAML::Node{v}; }
+inline auto toYaml(int16_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint16_t v) { return YAML::Node{v}; }
+inline auto toYaml(int32_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint32_t v) { return YAML::Node{v}; }
+inline auto toYaml(int64_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint64_t v) { return YAML::Node{v}; }
 inline auto toYaml(std::monostate const&) {
     return YAML::Node(YAML::NodeType::Undefined);
 }
 inline auto toYaml(std::string const& v) {
     return YAML::Node{v};
+}
+
+template <typename T, typename ...Args>
+auto anyToYaml_impl(std::any const& a) {
+    if (auto v = std::any_cast<T const>(&a)) {
+        return toYaml(*v);
+    }
+    if constexpr (sizeof...(Args) > 0) {
+        return anyToYaml_impl<Args...>(a);
+    }
+    return toYaml(std::monostate{});
+}
+
+inline auto toYaml(std::any const& a) {
+    return anyToYaml_impl<bool,
+                          float,
+                          double,
+                          char,
+                          int8_t,
+                          uint8_t,
+                          int16_t,
+                          uint16_t,
+                          int32_t,
+                          uint32_t,
+                          int64_t,
+                          uint64_t,
+                          std::string>(a);
 }
 
 // declaring fromYaml

--- a/schema_salad/tests/cpp_tests/03_simple_inheritance.h
+++ b/schema_salad/tests/cpp_tests/03_simple_inheritance.h
@@ -25,29 +25,50 @@ inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
 }
 
 // declaring toYaml
-inline auto toYaml(bool v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(float v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(double v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(int32_t v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(int64_t v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(std::any const&) {
-    return YAML::Node{};
-}
+inline auto toYaml(bool v) { return YAML::Node{v}; }
+inline auto toYaml(float v) { return YAML::Node{v}; }
+inline auto toYaml(double v) { return YAML::Node{v}; }
+inline auto toYaml(char v) { return YAML::Node{v}; }
+inline auto toYaml(int8_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint8_t v) { return YAML::Node{v}; }
+inline auto toYaml(int16_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint16_t v) { return YAML::Node{v}; }
+inline auto toYaml(int32_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint32_t v) { return YAML::Node{v}; }
+inline auto toYaml(int64_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint64_t v) { return YAML::Node{v}; }
 inline auto toYaml(std::monostate const&) {
     return YAML::Node(YAML::NodeType::Undefined);
 }
 inline auto toYaml(std::string const& v) {
     return YAML::Node{v};
+}
+
+template <typename T, typename ...Args>
+auto anyToYaml_impl(std::any const& a) {
+    if (auto v = std::any_cast<T const>(&a)) {
+        return toYaml(*v);
+    }
+    if constexpr (sizeof...(Args) > 0) {
+        return anyToYaml_impl<Args...>(a);
+    }
+    return toYaml(std::monostate{});
+}
+
+inline auto toYaml(std::any const& a) {
+    return anyToYaml_impl<bool,
+                          float,
+                          double,
+                          char,
+                          int8_t,
+                          uint8_t,
+                          int16_t,
+                          uint16_t,
+                          int32_t,
+                          uint32_t,
+                          int64_t,
+                          uint64_t,
+                          std::string>(a);
 }
 
 // declaring fromYaml

--- a/schema_salad/tests/cpp_tests/04_abstract_inheritance.h
+++ b/schema_salad/tests/cpp_tests/04_abstract_inheritance.h
@@ -25,29 +25,50 @@ inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
 }
 
 // declaring toYaml
-inline auto toYaml(bool v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(float v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(double v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(int32_t v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(int64_t v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(std::any const&) {
-    return YAML::Node{};
-}
+inline auto toYaml(bool v) { return YAML::Node{v}; }
+inline auto toYaml(float v) { return YAML::Node{v}; }
+inline auto toYaml(double v) { return YAML::Node{v}; }
+inline auto toYaml(char v) { return YAML::Node{v}; }
+inline auto toYaml(int8_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint8_t v) { return YAML::Node{v}; }
+inline auto toYaml(int16_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint16_t v) { return YAML::Node{v}; }
+inline auto toYaml(int32_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint32_t v) { return YAML::Node{v}; }
+inline auto toYaml(int64_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint64_t v) { return YAML::Node{v}; }
 inline auto toYaml(std::monostate const&) {
     return YAML::Node(YAML::NodeType::Undefined);
 }
 inline auto toYaml(std::string const& v) {
     return YAML::Node{v};
+}
+
+template <typename T, typename ...Args>
+auto anyToYaml_impl(std::any const& a) {
+    if (auto v = std::any_cast<T const>(&a)) {
+        return toYaml(*v);
+    }
+    if constexpr (sizeof...(Args) > 0) {
+        return anyToYaml_impl<Args...>(a);
+    }
+    return toYaml(std::monostate{});
+}
+
+inline auto toYaml(std::any const& a) {
+    return anyToYaml_impl<bool,
+                          float,
+                          double,
+                          char,
+                          int8_t,
+                          uint8_t,
+                          int16_t,
+                          uint16_t,
+                          int32_t,
+                          uint32_t,
+                          int64_t,
+                          uint64_t,
+                          std::string>(a);
 }
 
 // declaring fromYaml

--- a/schema_salad/tests/cpp_tests/05_specialization.h
+++ b/schema_salad/tests/cpp_tests/05_specialization.h
@@ -25,29 +25,50 @@ inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
 }
 
 // declaring toYaml
-inline auto toYaml(bool v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(float v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(double v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(int32_t v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(int64_t v) {
-    return YAML::Node{v};
-}
-inline auto toYaml(std::any const&) {
-    return YAML::Node{};
-}
+inline auto toYaml(bool v) { return YAML::Node{v}; }
+inline auto toYaml(float v) { return YAML::Node{v}; }
+inline auto toYaml(double v) { return YAML::Node{v}; }
+inline auto toYaml(char v) { return YAML::Node{v}; }
+inline auto toYaml(int8_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint8_t v) { return YAML::Node{v}; }
+inline auto toYaml(int16_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint16_t v) { return YAML::Node{v}; }
+inline auto toYaml(int32_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint32_t v) { return YAML::Node{v}; }
+inline auto toYaml(int64_t v) { return YAML::Node{v}; }
+inline auto toYaml(uint64_t v) { return YAML::Node{v}; }
 inline auto toYaml(std::monostate const&) {
     return YAML::Node(YAML::NodeType::Undefined);
 }
 inline auto toYaml(std::string const& v) {
     return YAML::Node{v};
+}
+
+template <typename T, typename ...Args>
+auto anyToYaml_impl(std::any const& a) {
+    if (auto v = std::any_cast<T const>(&a)) {
+        return toYaml(*v);
+    }
+    if constexpr (sizeof...(Args) > 0) {
+        return anyToYaml_impl<Args...>(a);
+    }
+    return toYaml(std::monostate{});
+}
+
+inline auto toYaml(std::any const& a) {
+    return anyToYaml_impl<bool,
+                          float,
+                          double,
+                          char,
+                          int8_t,
+                          uint8_t,
+                          int16_t,
+                          uint16_t,
+                          int32_t,
+                          uint32_t,
+                          int64_t,
+                          uint64_t,
+                          std::string>(a);
 }
 
 // declaring fromYaml


### PR DESCRIPTION
Currently, types of 'any' are simply ignored when generating output. This improves the handling of 'any' by adding explicit conversions to:

- float
- double
- char
- int8_t
- uint8_t
- int16_t
- uint16_t
- int32_t
- uint32_t
- int64_t
- uint64_t and
- std::string

required to fix https://github.com/deNBI-cibi/tool_description_lib/issues/59

also uploaded a new generated version to: https://github.com/common-workflow-lab/cwl-cpp-auto/pull/11