### PR TITLE
Fix/cpp gen storing yaml

### DIFF
--- a/schema_salad/cpp_codegen.py
+++ b/schema_salad/cpp_codegen.py
@@ -432,7 +432,7 @@ class EnumDefinition:
         target.write("\n")
 
 
-# !TODO way tot many functions, most of these shouldn't exists
+# !TODO way to many functions, most of these shouldn't exists
 def isPrimitiveType(v: Any) -> bool:
     """Check if v is a primitve type."""
     if not isinstance(v, str):
@@ -762,10 +762,10 @@ inline auto expandType(YAML::Node type) -> YAML::Node {
 }
 
 inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
-    for (auto const& e : n1) {
-        n2[e.first.as<std::string>()] = e.second;
+    for (auto const& e : n2) {
+        n1[e.first.as<std::string>()] = e.second;
     }
-    return n2;
+    return n1;
 }
 
 // declaring toYaml

--- a/schema_salad/cpp_codegen.py
+++ b/schema_salad/cpp_codegen.py
@@ -134,7 +134,9 @@ class ClassDefinition:
         else:
             target.write(f"{fullInd}{ind}{virtual}~{self.classname}(){override} = default;\n")
 
-        target.write(f"{fullInd}{ind}{virtual}auto toYaml([[maybe_unused]] store_config const& config) const -> YAML::Node{override};\n")
+        target.write(
+            f"{fullInd}{ind}{virtual}auto toYaml([[maybe_unused]] store_config const& config) const -> YAML::Node{override};\n"
+        )
         target.write(f"{fullInd}{ind}{virtual}void fromYaml(YAML::Node const& n){override};\n")
         target.write(f"{fullInd}}};\n")
         target.write(f"{fullInd}}}\n\n")
@@ -155,7 +157,7 @@ class ClassDefinition:
             f"{fullInd}{ind}using ::cpp_gen::toYaml;\n"
             f"{fullInd}{ind}auto n = YAML::Node{{}};\n"
             f"{fullInd}{ind}if (config.generateTags) {{\n"
-            f"{fullInd}{ind}{ind}n.SetTag(\"{self.classname}\");\n"
+            f'{fullInd}{ind}{ind}n.SetTag("{self.classname}");\n'
             f"{fullInd}{ind}}}\n"
         )
         for e in extends:
@@ -164,13 +166,15 @@ class ClassDefinition:
         for field in self.fields:
             fieldname = safename(field.name)
 
-            target.write(f"{fullInd}{ind}{{\n");
-            target.write(f"{fullInd}{ind}{ind} auto member = toYaml(*{fieldname}, config);\n");
+            target.write(f"{fullInd}{ind}{{\n")
+            target.write(f"{fullInd}{ind}{ind} auto member = toYaml(*{fieldname}, config);\n")
             if field.typeDSL:
-                target.write(f"{fullInd}{ind}{ind} member = simplifyType(member, config);\n");
-            target.write(f"{fullInd}{ind}{ind} member = convertListToMap(member, {q(field.mapSubject)}, {q(field.mapPredicate)}, config);\n");
-            target.write(f"{fullInd}{ind}{ind}addYamlField(n, {q(field.name)}, member);\n");
-            target.write(f"{fullInd}{ind}}}\n");
+                target.write(f"{fullInd}{ind}{ind} member = simplifyType(member, config);\n")
+            target.write(
+                f"{fullInd}{ind}{ind} member = convertListToMap(member, {q(field.mapSubject)}, {q(field.mapPredicate)}, config);\n"
+            )
+            target.write(f"{fullInd}{ind}{ind}addYamlField(n, {q(field.name)}, member);\n")
+            target.write(f"{fullInd}{ind}}}\n")
 
         target.write(f"{fullInd}{ind}return n;\n{fullInd}}}\n")
 
@@ -279,7 +283,9 @@ class MapDefinition:
             valueType = f"std::variant<{', '.join(self._remove_namespace(v) for v in self.values)}>"
         target.write(f"struct {self.classname} {{\n")
         target.write(f"{ind}heap_object<std::map<std::string, {valueType}>> value;\n")
-        target.write(f"{ind}auto toYaml([[maybe_unused]] store_config const& config) const -> YAML::Node;\n")
+        target.write(
+            f"{ind}auto toYaml([[maybe_unused]] store_config const& config) const -> YAML::Node;\n"
+        )
         target.write(f"{ind}void fromYaml(YAML::Node const& n);\n")
         target.write("};\n")
         target.write("}\n\n")
@@ -333,7 +339,9 @@ class UnionDefinition:
         target.write(f"{ind}{self.types} *value = nullptr;\n")
         target.write(f"{ind}{self.classname}();\n")
         target.write(f"{ind}~{self.classname}();\n")
-        target.write(f"{ind}auto toYaml([[maybe_unused]] store_config const& config) const -> YAML::Node;\n")
+        target.write(
+            f"{ind}auto toYaml([[maybe_unused]] store_config const& config) const -> YAML::Node;\n"
+        )
         target.write(f"{ind}void fromYaml(YAML::Node const& n);\n")
         target.write("};\n")
         target.write("}\n\n")
@@ -423,9 +431,11 @@ class EnumDefinition:
         target.write(f"{ind}out = iter->second;\n}}\n")
 
         # Write toYaml function
-        target.write(f"inline auto toYaml({name} v, [[maybe_unused]] store_config const& config) {{\n")
+        target.write(
+            f"inline auto toYaml({name} v, [[maybe_unused]] store_config const& config) {{\n"
+        )
         target.write(f"{ind}auto n = YAML::Node{{std::string{{to_string(v)}}}};\n")
-        target.write(f"{ind}if (config.generateTags) n.SetTag(\"{name}\");\n")
+        target.write(f'{ind}if (config.generateTags) n.SetTag("{name}");\n')
         target.write(f"{ind}return n;\n}}\n")
 
         # Write fromYaml function
@@ -1215,11 +1225,9 @@ void fromYaml(YAML::Node const& n, std::variant<Args...>& v){
             rootTypes.append(f"{cd.namespace}::{cd.classname}")
         documentRootType = f", ".join(rootTypes)
 
-
-#      self.documentRootTypes.append(cd)
-
         self.target.write(f"using DocumentRootType = std::variant<{documentRootType}>;")
-        self.target.write("""
+        self.target.write(
+            """
 auto load_document_from_yaml(YAML::Node n) -> DocumentRootType {
     DocumentRootType root;
     fromYaml(n, root);
@@ -1248,7 +1256,8 @@ auto store_document_as_string(DocumentRootType const& root, store_config config=
     return ss.str();
 }
 
-}""")
+}"""
+        )
 
     def parseRecordField(self, field: dict[str, Any]) -> FieldDefinition:
         """Parse a record field."""

--- a/schema_salad/cpp_codegen.py
+++ b/schema_salad/cpp_codegen.py
@@ -152,7 +152,7 @@ class ClassDefinition:
         # Write toYaml function
         target.write(
             f"{fullInd}inline auto {self.namespace}::{self.classname}::toYaml([[maybe_unused]] store_config const& config) const -> YAML::Node {{\n"
-            f"{fullInd}{ind}using ::toYaml;\n"
+            f"{fullInd}{ind}using ::cpp_gen::toYaml;\n"
             f"{fullInd}{ind}auto n = YAML::Node{{}};\n"
             f"{fullInd}{ind}if (config.generateTags) {{\n"
             f"{fullInd}{ind}{ind}n.SetTag(\"{self.classname}\");\n"
@@ -178,7 +178,7 @@ class ClassDefinition:
         functionname = f"{self.namespace}::{self.classname}::fromYaml"
         target.write(
             f"{fullInd}inline void {functionname}([[maybe_unused]] YAML::Node const& n) {{\n"
-            f"{fullInd}{ind}using ::fromYaml;\n"
+            f"{fullInd}{ind}using ::cpp_gen::fromYaml;\n"
         )
         for e in extends:
             target.write(f"{fullInd}{ind}{e}::fromYaml(n);\n")
@@ -290,7 +290,7 @@ class MapDefinition:
         functionname = f"{self.namespace}::{self.classname}::toYaml"
         target.write(
             f"{fullInd}inline auto {functionname}([[maybe_unused]] store_config const& config) const -> YAML::Node {{\n"
-            f"{fullInd}{ind}using ::toYaml;\n"
+            f"{fullInd}{ind}using ::cpp_gen::toYaml;\n"
             f"{fullInd}{ind}return toYaml(*value, config);\n"
             f"{fullInd}}}\n"
         )
@@ -299,7 +299,7 @@ class MapDefinition:
         functionname = f"{self.namespace}::{self.classname}::fromYaml"
         target.write(
             f"{fullInd}inline void {functionname}([[maybe_unused]] YAML::Node const& n) {{\n"
-            f"{fullInd}{ind}using ::fromYaml;\n"
+            f"{fullInd}{ind}using ::cpp_gen::fromYaml;\n"
             f"{fullInd}{ind}fromYaml(n, *value);\n"
             f"{fullInd}}}\n"
         )
@@ -363,7 +363,7 @@ class UnionDefinition:
         functionname = f"{self.namespace}::{self.classname}::toYaml"
         target.write(
             f"{fullInd}inline auto {functionname}([[maybe_unused]] store_config const& config) const -> YAML::Node {{\n"
-            f"{fullInd}{ind}using ::toYaml;\n"
+            f"{fullInd}{ind}using ::cpp_gen::toYaml;\n"
             f"{fullInd}{ind}return toYaml(*value, config);\n"
             f"{fullInd}}}\n"
         )
@@ -372,7 +372,7 @@ class UnionDefinition:
         functionname = f"{self.namespace}::{self.classname}::fromYaml"
         target.write(
             f"{fullInd}inline void {functionname}([[maybe_unused]] YAML::Node const& n) {{\n"
-            f"{fullInd}{ind}using ::fromYaml;\n"
+            f"{fullInd}{ind}using ::cpp_gen::fromYaml;\n"
             f"{fullInd}{ind}fromYaml(n, *value);\n"
             f"{fullInd}}}\n"
         )
@@ -700,6 +700,8 @@ class CppCodeGen(CodeGenBase):
 #include <variant>
 #include <vector>
 #include <yaml-cpp/yaml.h>
+
+namespace cpp_gen {
 
 struct store_config {
     bool simplifyTypes = true;
@@ -1244,6 +1246,8 @@ auto store_document_as_string(DocumentRootType const& root, store_config config=
     auto ss = std::stringstream{};
     store_document(root, ss, config);
     return ss.str();
+}
+
 }""")
 
     def parseRecordField(self, field: dict[str, Any]) -> FieldDefinition:

--- a/schema_salad/cpp_codegen.py
+++ b/schema_salad/cpp_codegen.py
@@ -225,10 +225,11 @@ class ClassDefinition:
 
         # write type detection function
         if not self.abstract:
-            e = f"{self.namespace}::{self.classname}"
+            e = f"::{self.namespace}::{self.classname}"
             target.write(
+                f"namespace {common_namespace} {{\n"
                 f"template <>\n"
-                f"struct {common_namespace}::DetectAndExtractFromYaml<{e}> {{\n"
+                f"struct DetectAndExtractFromYaml<{e}> {{\n"
                 f"    auto operator()(YAML::Node const& n) const -> std::optional<{e}> {{\n"
                 f"        if (!n.IsDefined()) return std::nullopt;\n"
                 f"        if (!n.IsMap()) return std::nullopt;\n"
@@ -244,7 +245,7 @@ class ClassDefinition:
                     "            return res;\n"
                     f"        }} catch(...) {{}}\n\n"
                 )
-            target.write("        return std::nullopt;\n    }\n};\n")
+            target.write("        return std::nullopt;\n    }\n};\n}\n")
 
 
 class FieldDefinition:
@@ -1167,10 +1168,8 @@ public:
         # incomplete types.
         # Therefore, the destructor is defined here, after all classes have been defined.
         self.target.write(
-            f"""template <typename T>
-{common_namespace}::heap_object<T>::~heap_object() = default;
-
-"""
+            f"namespace {common_namespace} {{\n"
+            f"template <typename T> heap_object<T>::~heap_object() = default;\n}}\n\n"
         )
 
         # write implementations
@@ -1299,7 +1298,7 @@ auto load_document_from_string(std::string document) -> DocumentRootType {
     return load_document_from_yaml(YAML::Load(document));
 }
 auto load_document(std::filesystem::path path) -> DocumentRootType {
-    return load_document_from_yaml(YAML::LoadFile(path));
+    return load_document_from_yaml(YAML::LoadFile(path.string()));
 }
 void store_document(DocumentRootType const& root, std::ostream& ostream, store_config config={}) {
     auto y = toYaml(root, config);

--- a/schema_salad/cpp_codegen.py
+++ b/schema_salad/cpp_codegen.py
@@ -880,7 +880,7 @@ inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std
     auto map = YAML::Node{};
     for (YAML::Node n : list) {
         auto key = n[mapSubject].as<std::string>();
-        if (mapPredicate.empty()|| n[mapPredicate].IsMap()) {
+        if (mapPredicate.empty() || n[mapPredicate].IsMap() || n.size() > 2) {
             n.remove(mapSubject);
             map[key] = n;
         } else {

--- a/schema_salad/cpp_codegen.py
+++ b/schema_salad/cpp_codegen.py
@@ -1244,7 +1244,7 @@ void store_document(DocumentRootType const& root, std::ostream& ostream, store_c
 
     YAML::Emitter out;
     out << y;
-    ostream << out.c_str();
+    ostream << out.c_str() << std::endl;
 }
 void store_document(DocumentRootType const& root, std::filesystem::path const& path, store_config config={}) {
     auto ofs = std::ofstream{path};

--- a/schema_salad/cpp_codegen.py
+++ b/schema_salad/cpp_codegen.py
@@ -61,7 +61,7 @@ def safename(name: str) -> str:
 
 
 def safenamespacename(name: str) -> str:
-    """Create a C++ safe name for namespaces"""
+    """Create a C++ safe name for namespaces."""
     name = re.sub("^[a-zA-Z0-9]+://", "", name)  # remove protocol
     name = re.sub("//+", "", name)  # remove duplicate slashes
     name = re.sub("/$", "", name)  # remove trailing slashes
@@ -149,7 +149,8 @@ class ClassDefinition:
             target.write(f"{fullInd}{ind}{virtual}~{self.classname}(){override} = default;\n")
 
         target.write(
-            f"{fullInd}{ind}{virtual}auto toYaml([[maybe_unused]] {common_namespace}::store_config const& config) const -> YAML::Node{override};\n"
+            f"{fullInd}{ind}{virtual}auto toYaml([[maybe_unused]] "
+            f"{common_namespace}::store_config const& config) const -> YAML::Node{override};\n"
         )
         target.write(f"{fullInd}{ind}{virtual}void fromYaml(YAML::Node const& n){override};\n")
         target.write(f"{fullInd}}};\n")
@@ -169,7 +170,8 @@ class ClassDefinition:
 
         # Write toYaml function
         target.write(
-            f"{fullInd}inline auto {self.namespace}::{self.classname}::toYaml([[maybe_unused]] ::{common_namespace}::store_config const& config) const -> YAML::Node {{\n"
+            f"{fullInd}inline auto {self.namespace}::{self.classname}::toYaml([[maybe_unused]] "
+            f"::{common_namespace}::store_config const& config) const -> YAML::Node {{\n"
             f"{fullInd}{ind}using ::{common_namespace}::toYaml;\n"
             f"{fullInd}{ind}auto n = YAML::Node{{}};\n"
             f"{fullInd}{ind}if (config.generateTags) {{\n"
@@ -187,7 +189,8 @@ class ClassDefinition:
             if field.typeDSL:
                 target.write(f"{fullInd}{ind}{ind} member = simplifyType(member, config);\n")
             target.write(
-                f"{fullInd}{ind}{ind} member = convertListToMap(member, {q(field.mapSubject)}, {q(field.mapPredicate)}, config);\n"
+                f"{fullInd}{ind}{ind} member = convertListToMap(member, "
+                f"{q(field.mapSubject)}, {q(field.mapPredicate)}, config);\n"
             )
             target.write(f"{fullInd}{ind}{ind}addYamlField(n, {q(field.name)}, member);\n")
             target.write(f"{fullInd}{ind}}}\n")
@@ -211,7 +214,8 @@ class ClassDefinition:
 
             target.write(
                 f"{fullInd}{ind}{{\n"
-                f"{fullInd}{ind}{ind}auto nodeAsList = convertMapToList(n[{q(field.name)}], {q(field.mapSubject)}, {q(field.mapPredicate)});\n"
+                f"{fullInd}{ind}{ind}auto nodeAsList = convertMapToList("
+                f"n[{q(field.name)}], {q(field.mapSubject)}, {q(field.mapPredicate)});\n"
                 f"{fullInd}{ind}{ind}auto expandedNode = {expandType}(nodeAsList);\n"
                 f"{fullInd}{ind}{ind}fromYaml(expandedNode, *{fieldname});\n"
                 f"{fullInd}{ind}}}\n"
@@ -233,13 +237,14 @@ class ClassDefinition:
             for field in self.fields:
                 fieldname = safename(field.name)
                 target.write(
-                    f"        if constexpr (::{common_namespace}::IsConstant<decltype(res.{fieldname})::value_t>::value) try {{\n"
+                    f"        if constexpr (::{common_namespace}::IsConstant<"
+                    f"decltype(res.{fieldname})::value_t>::value) try {{\n"
                     f"            fromYaml(n[{q(field.name)}], *res.{fieldname});\n"
-                    f"            fromYaml(n, res);\n"
-                    f"            return res;\n"
+                    "            fromYaml(n, res);\n"
+                    "            return res;\n"
                     f"        }} catch(...) {{}}\n\n"
                 )
-            target.write(f"        return std::nullopt;\n" f"    }}\n" f"}};\n")
+            target.write("        return std::nullopt;\n    }\n};\n")
 
 
 class FieldDefinition:
@@ -300,7 +305,8 @@ class MapDefinition:
         target.write(f"struct {self.classname} {{\n")
         target.write(f"{ind}heap_object<std::map<std::string, {valueType}>> value;\n")
         target.write(
-            f"{ind}auto toYaml([[maybe_unused]] ::{common_namespace}::store_config const& config) const -> YAML::Node;\n"
+            f"{ind}auto toYaml([[maybe_unused]] "
+            f"::{common_namespace}::store_config const& config) const -> YAML::Node;\n"
         )
         target.write(f"{ind}void fromYaml(YAML::Node const& n);\n")
         target.write("};\n")
@@ -313,7 +319,8 @@ class MapDefinition:
         # Write toYaml function
         functionname = f"{self.namespace}::{self.classname}::toYaml"
         target.write(
-            f"{fullInd}inline auto {functionname}([[maybe_unused]] ::{common_namespace}::store_config const& config) const -> YAML::Node {{\n"
+            f"{fullInd}inline auto {functionname}([[maybe_unused]] "
+            f"::{common_namespace}::store_config const& config) const -> YAML::Node {{\n"
             f"{fullInd}{ind}using ::{common_namespace}::toYaml;\n"
             f"{fullInd}{ind}return toYaml(*value, config);\n"
             f"{fullInd}}}\n"
@@ -358,7 +365,8 @@ class UnionDefinition:
         target.write(f"{ind}{self.classname}();\n")
         target.write(f"{ind}~{self.classname}();\n")
         target.write(
-            f"{ind}auto toYaml([[maybe_unused]] ::{common_namespace}::store_config const& config) const -> YAML::Node;\n"
+            f"{ind}auto toYaml([[maybe_unused]] "
+            f"::{common_namespace}::store_config const& config) const -> YAML::Node;\n"
         )
         target.write(f"{ind}void fromYaml(YAML::Node const& n);\n")
         target.write("};\n")
@@ -390,7 +398,8 @@ class UnionDefinition:
         # Write toYaml function
         functionname = f"{self.namespace}::{self.classname}::toYaml"
         target.write(
-            f"{fullInd}inline auto {functionname}([[maybe_unused]] ::{common_namespace}::store_config const& config) const -> YAML::Node {{\n"
+            f"{fullInd}inline auto {functionname}([[maybe_unused]] "
+            f"::{common_namespace}::store_config const& config) const -> YAML::Node {{\n"
             f"{fullInd}{ind}using ::{common_namespace}::toYaml;\n"
             f"{fullInd}{ind}return toYaml(*value, config);\n"
             f"{fullInd}}}\n"
@@ -458,7 +467,8 @@ class EnumDefinition:
         # Write toYaml function
         target.write(f"namespace {common_namespace} {{\n")
         target.write(
-            f"inline auto toYaml({name} v, [[maybe_unused]] ::{common_namespace}::store_config const& config) {{\n"
+            f"inline auto toYaml({name} v, [[maybe_unused]] "
+            f"::{common_namespace}::store_config const& config) {{\n"
         )
         target.write(f"{ind}auto n = YAML::Node{{std::string{{to_string(v)}}}};\n")
         target.write(f'{ind}if (config.generateTags) n.SetTag("{name}");\n')
@@ -917,7 +927,8 @@ inline void addYamlField(YAML::Node& node, std::string const& key, YAML::Node va
     }
 }
 
-inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std::string const& mapPredicate, store_config const& config) {
+inline auto convertListToMap(YAML::Node list, std::string const& mapSubject,
+                             std::string const& mapPredicate, store_config const& config) {
     if (!config.transformListsToMaps) return list;
     if (mapSubject.empty()) return list;
     if (list.size() == 0) return list;
@@ -933,7 +944,8 @@ inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std
     }
     return map;
 }
-inline auto convertMapToList(YAML::Node map, std::string const& mapSubject, std::string const& mapPredicate) {
+inline auto convertMapToList(YAML::Node map, std::string const& mapSubject,
+                             std::string const& mapPredicate) {
     if (mapSubject.empty()) return map;
     if (!map.IsDefined()) return map;
     if (!map.IsMap()) return map;
@@ -1273,7 +1285,7 @@ void fromYaml(YAML::Node const& n, std::variant<Args...>& v){
         rootTypes = []
         for cd in self.documentRootTypes:
             rootTypes.append(f"{cd.namespace}::{cd.classname}")
-        documentRootType = f", ".join(rootTypes)
+        documentRootType = ", ".join(rootTypes)
 
         self.target.write(f"using DocumentRootType = std::variant<{documentRootType}>;")
         self.target.write(

--- a/schema_salad/cpp_codegen.py
+++ b/schema_salad/cpp_codegen.py
@@ -151,10 +151,9 @@ class ClassDefinition:
 
         # Write toYaml function
         target.write(
-            f"""{fullInd}inline auto {self.namespace}::{self.classname}::toYaml() const -> YAML::Node {{
-{fullInd}{ind}using ::toYaml;
-{fullInd}{ind}auto n = YAML::Node{{}};
-"""
+            f"{fullInd}inline auto {self.namespace}::{self.classname}::toYaml() const -> YAML::Node {{\n"
+            f"{fullInd}{ind}using ::toYaml;\n"
+            f"{fullInd}{ind}auto n = YAML::Node{{}};\n"
         )
         for e in extends:
             target.write(f"{fullInd}{ind}n = mergeYaml(n, {e}::toYaml());\n")
@@ -163,8 +162,8 @@ class ClassDefinition:
             fieldname = safename(field.name)
             if field.remap != "":
                 target.write(
-                    f"""{fullInd}{ind}addYamlField(n, {q(field.name)},
-{fullInd}{ind}{ind}convertListToMap(toYaml(*{fieldname}), {q(field.remap)}));\n"""
+                    f"{fullInd}{ind}addYamlField(n, {q(field.name)}, "
+                    f"convertListToMap(toYaml(*{fieldname}), {q(field.mapSubject)}));\n"
                 )
             else:
                 target.write(
@@ -176,9 +175,8 @@ class ClassDefinition:
         # Write fromYaml function
         functionname = f"{self.namespace}::{self.classname}::fromYaml"
         target.write(
-            f"""{fullInd}inline void {functionname}([[maybe_unused]] YAML::Node const& n) {{
-{fullInd}{ind}using ::fromYaml;
-"""
+            f"{fullInd}inline void {functionname}([[maybe_unused]] YAML::Node const& n) {{\n"
+            f"{fullInd}{ind}using ::fromYaml;\n"
         )
         for e in extends:
             target.write(f"{fullInd}{ind}{e}::fromYaml(n);\n")
@@ -187,9 +185,8 @@ class ClassDefinition:
             fieldname = safename(field.name)
             if field.remap != "":
                 target.write(
-                    f"""
-                    {fullInd}{ind}fromYaml(convertMapToList(n[{q(field.name)}],
-{q(field.remap)}), *{fieldname});\n"""
+                    f"{fullInd}{ind}fromYaml(convertMapToList(n[{q(field.name)}],"
+                    f"{q(field.mapSubject)}), *{fieldname});\n"
                 )
             else:
                 target.write(f"{fullInd}{ind}fromYaml(n[{q(field.name)}], *{fieldname});\n")
@@ -200,32 +197,26 @@ class ClassDefinition:
         if not self.abstract:
             e = f"{self.namespace}::{self.classname}"
             target.write(
-                f"""
-template <>
-struct DetectAndExtractFromYaml<{e}> {{
-    auto operator()(YAML::Node const& n) const -> std::optional<{e}> {{
-        if (!n.IsDefined()) return std::nullopt;
-        if (!n.IsMap()) return std::nullopt;
-        auto res = {e}{{}};
-"""
+                f"template <>\n"
+                f"struct DetectAndExtractFromYaml<{e}> {{\n"
+                f"    auto operator()(YAML::Node const& n) const -> std::optional<{e}> {{\n"
+                f"        if (!n.IsDefined()) return std::nullopt;\n"
+                f"        if (!n.IsMap()) return std::nullopt;\n"
+                f"        auto res = {e}{{}};\n"
             )
             for field in self.fields:
                 fieldname = safename(field.name)
                 target.write(
-                    f"""
-        if constexpr (IsConstant<decltype(res.{fieldname})::value_t>::value) try {{
-            fromYaml(n[{q(field.name)}], *res.{fieldname});
-            fromYaml(n, res);
-            return res;
-        }} catch(...) {{}}
-"""
+                    f"        if constexpr (IsConstant<decltype(res.{fieldname})::value_t>::value) try {{\n"
+                    f"            fromYaml(n[{q(field.name)}], *res.{fieldname});\n"
+                    f"            fromYaml(n, res);\n"
+                    f"            return res;\n"
+                    f"        }} catch(...) {{}}\n"
                 )
             target.write(
-                """
-        return std::nullopt;
-    }
-};
-"""
+                f"        return std::nullopt;\n"
+                f"    }}\n"
+                f"}};\n"
             )
 
 
@@ -286,19 +277,19 @@ class MapDefinition:
         # Write toYaml function
         functionname = f"{self.namespace}::{self.classname}::toYaml"
         target.write(
-            f"""{fullInd}inline auto {functionname}() const -> YAML::Node {{
-{fullInd}{ind}using ::toYaml;
-{fullInd}{ind}return toYaml(*value);\n{fullInd}}}\n
-"""
+            f"{fullInd}inline auto {functionname}() const -> YAML::Node {{\n"
+            f"{fullInd}{ind}using ::toYaml;\n"
+            f"{fullInd}{ind}return toYaml(*value);\n"
+            f"{fullInd}}}\n"
         )
 
         # Write fromYaml function
         functionname = f"{self.namespace}::{self.classname}::fromYaml"
         target.write(
-            f"""{fullInd}inline void {functionname}([[maybe_unused]] YAML::Node const& n) {{
-{fullInd}{ind}using ::fromYaml;
-{fullInd}{ind}fromYaml(n, *value);\n{fullInd}}}\n
-"""
+            f"{fullInd}inline void {functionname}([[maybe_unused]] YAML::Node const& n) {{\n"
+            f"{fullInd}{ind}using ::fromYaml;\n"
+            f"{fullInd}{ind}fromYaml(n, *value);\n"
+            f"{fullInd}}}\n"
         )
 
 
@@ -340,39 +331,38 @@ class UnionDefinition:
         # Write constructor
         functionname = f"{self.namespace}::{self.classname}::{self.classname}"
         target.write(
-            f"""{fullInd}{functionname}() {{
-{fullInd}{ind}value = new {self.types}();\n{fullInd}}}\n
-"""
+            f"{fullInd}{functionname}() {{\n"
+            f"{fullInd}{ind}value = new {self.types}();\n"
+            f"{fullInd}}}\n"
         )
 
         # Write destructor
         functionname = f"{self.namespace}::{self.classname}::~{self.classname}"
         target.write(
-            f"""{fullInd}{functionname}() {{
-{fullInd}{ind}if (value != nullptr) {{
-{fullInd}{ind}{ind}delete value;
-{fullInd}{ind}{ind}value = nullptr;
-{fullInd}{ind}}}
-{fullInd}}}\n
-"""
+            f"{fullInd}{functionname}() {{\n"
+            f"{fullInd}{ind}if (value != nullptr) {{\n"
+            f"{fullInd}{ind}{ind}delete value;\n"
+            f"{fullInd}{ind}{ind}value = nullptr;\n"
+            f"{fullInd}{ind}}}\n"
+            f"{fullInd}}}\n"
         )
 
         # Write toYaml function
         functionname = f"{self.namespace}::{self.classname}::toYaml"
         target.write(
-            f"""{fullInd}inline auto {functionname}() const -> YAML::Node {{
-{fullInd}{ind}using ::toYaml;
-{fullInd}{ind}return toYaml(*value);\n{fullInd}}}\n
-"""
+            f"{fullInd}inline auto {functionname}() const -> YAML::Node {{\n"
+            f"{fullInd}{ind}using ::toYaml;\n"
+            f"{fullInd}{ind}return toYaml(*value);\n"
+            f"{fullInd}}}\n"
         )
 
         # Write fromYaml function
         functionname = f"{self.namespace}::{self.classname}::fromYaml"
         target.write(
-            f"""{fullInd}inline void {functionname}([[maybe_unused]] YAML::Node const& n) {{
-{fullInd}{ind}using ::fromYaml;
-{fullInd}{ind}fromYaml(n, *value);\n{fullInd}}}\n
-"""
+            f"{fullInd}inline void {functionname}([[maybe_unused]] YAML::Node const& n) {{\n"
+            f"{fullInd}{ind}using ::fromYaml;\n"
+            f"{fullInd}{ind}fromYaml(n, *value);\n"
+            f"{fullInd}}}\n"
         )
 
 

--- a/schema_salad/cpp_codegen.py
+++ b/schema_salad/cpp_codegen.py
@@ -59,15 +59,17 @@ def safename(name: str) -> str:
     classname = re.sub("[^a-zA-Z0-9]", "_", name)
     return replaceKeywords(classname)
 
+
 def safenamespacename(name: str) -> str:
     """Create a C++ safe name for namespaces"""
-    name = re.sub("^[a-zA-Z0-9]+://", "", name) # remove protocol
-    name = re.sub("//+", "", name) # remove duplicate slashes
-    name = re.sub("/$", "", name) # remove trailing slashes
+    name = re.sub("^[a-zA-Z0-9]+://", "", name)  # remove protocol
+    name = re.sub("//+", "", name)  # remove duplicate slashes
+    name = re.sub("/$", "", name)  # remove trailing slashes
     name = re.sub("[^a-zA-Z0-9/]", "_", name)
     name = re.sub("[/]", "::", name)
 
     return name
+
 
 # TODO: this should be somehow not really exists
 def safename2(name: dict[str, str]) -> str:
@@ -122,7 +124,9 @@ class ClassDefinition:
         """Write forward declaration."""
         target.write(f"{fullInd}namespace {self.namespace} {{ struct {self.classname}; }}\n")
 
-    def writeDefinition(self, target: IO[Any], fullInd: str, ind: str, common_namespace: str) -> None:
+    def writeDefinition(
+        self, target: IO[Any], fullInd: str, ind: str, common_namespace: str
+    ) -> None:
         """Write definition of the class."""
         target.write(f"{fullInd}namespace {self.namespace} {{\n")
         target.write(f"{fullInd}struct {self.classname}")
@@ -151,7 +155,9 @@ class ClassDefinition:
         target.write(f"{fullInd}}};\n")
         target.write(f"{fullInd}}}\n\n")
 
-    def writeImplDefinition(self, target: IO[str], fullInd: str, ind: str, common_namespace: str) -> None:
+    def writeImplDefinition(
+        self, target: IO[str], fullInd: str, ind: str, common_namespace: str
+    ) -> None:
         """Write definition with implementation."""
         extends = list(map(safename2, self.extends))
 
@@ -300,7 +306,9 @@ class MapDefinition:
         target.write("};\n")
         target.write("}\n\n")
 
-    def writeImplDefinition(self, target: IO[str], fullInd: str, ind: str, common_namespace: str) -> None:
+    def writeImplDefinition(
+        self, target: IO[str], fullInd: str, ind: str, common_namespace: str
+    ) -> None:
         """Write definition with implementation."""
         # Write toYaml function
         functionname = f"{self.namespace}::{self.classname}::toYaml"
@@ -356,7 +364,9 @@ class UnionDefinition:
         target.write("};\n")
         target.write("}\n\n")
 
-    def writeImplDefinition(self, target: IO[str], fullInd: str, ind: str, common_namespace: str) -> None:
+    def writeImplDefinition(
+        self, target: IO[str], fullInd: str, ind: str, common_namespace: str
+    ) -> None:
         """Write definition with implementation."""
         # Write constructor
         functionname = f"{self.namespace}::{self.classname}::{self.classname}"
@@ -695,7 +705,14 @@ class CppCodeGen(CodeGenBase):
     def epilogue(self, root_loader: Optional[TypeDef]) -> None:
         # find common namespace
 
-        common_namespace = os.path.commonprefix(list(map(lambda x: x.namespace, list(self.classDefinitions.values()) + list(self.enumDefinitions.values()))))
+        common_namespace = os.path.commonprefix(
+            list(
+                map(
+                    lambda x: x.namespace,
+                    list(self.classDefinitions.values()) + list(self.enumDefinitions.values()),
+                )
+            )
+        )
         common_namespace = re.sub("(::)+$", "", common_namespace)
 
         """Generate final part of our cpp file."""
@@ -738,7 +755,8 @@ class CppCodeGen(CodeGenBase):
         )
 
         self.target.write(f"namespace {common_namespace} {{\n")
-        self.target.write("""
+        self.target.write(
+            """
 struct store_config {
     bool simplifyTypes = true;
     bool transformListsToMaps = true;
@@ -1145,12 +1163,15 @@ public:
 
         # write implementations
         for key in self.classDefinitions:
-            self.classDefinitions[key].writeImplDefinition(self.target, "", "    ", common_namespace)
+            self.classDefinitions[key].writeImplDefinition(
+                self.target, "", "    ", common_namespace
+            )
         for key in self.mapDefinitions:
             self.mapDefinitions[key].writeImplDefinition(self.target, "", "    ", common_namespace)
         for key in self.unionDefinitions:
-            self.unionDefinitions[key].writeImplDefinition(self.target, "", "    ", common_namespace)
-
+            self.unionDefinitions[key].writeImplDefinition(
+                self.target, "", "    ", common_namespace
+            )
 
         self.target.write(f"namespace {common_namespace} {{\n")
         self.target.write(

--- a/schema_salad/cpp_codegen.py
+++ b/schema_salad/cpp_codegen.py
@@ -580,6 +580,8 @@ class CppCodeGen(CodeGenBase):
                 return "bool"
             elif type_declaration[0] == "https://w3id.org/cwl/salad#Any":
                 return "std::any"
+            elif type_declaration[0] == "https://w3id.org/cwl/cwl#Expression":
+                return "cwl_expression_string"
             elif type_declaration[0] in (
                 "PrimitiveType",
                 "https://w3id.org/cwl/salad#PrimitiveType",
@@ -815,6 +817,19 @@ struct DetectAndExtractFromYaml {
         return std::nullopt;
     }
 };
+
+// special cwl expression string
+struct cwl_expression_string {
+    std::string s;
+
+    auto toYaml() const {
+        return YAML::Node{s};
+    }
+    void fromYaml(YAML::Node const& n) {
+        s = n.as<std::string>();
+    }
+};
+
 
 template <>
 struct DetectAndExtractFromYaml<std::monostate> {

--- a/schema_salad/tests/cpp_tests/01_single_record.h
+++ b/schema_salad/tests/cpp_tests/01_single_record.h
@@ -181,7 +181,8 @@ inline void addYamlField(YAML::Node& node, std::string const& key, YAML::Node va
     }
 }
 
-inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std::string const& mapPredicate, store_config const& config) {
+inline auto convertListToMap(YAML::Node list, std::string const& mapSubject,
+                             std::string const& mapPredicate, store_config const& config) {
     if (!config.transformListsToMaps) return list;
     if (mapSubject.empty()) return list;
     if (list.size() == 0) return list;
@@ -197,7 +198,8 @@ inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std
     }
     return map;
 }
-inline auto convertMapToList(YAML::Node map, std::string const& mapSubject, std::string const& mapPredicate) {
+inline auto convertMapToList(YAML::Node map, std::string const& mapSubject,
+                             std::string const& mapPredicate) {
     if (mapSubject.empty()) return map;
     if (!map.IsDefined()) return map;
     if (!map.IsMap()) return map;

--- a/schema_salad/tests/cpp_tests/01_single_record.h
+++ b/schema_salad/tests/cpp_tests/01_single_record.h
@@ -381,8 +381,9 @@ struct MyRecord {
 };
 }
 
-template <typename T>
-example_com::heap_object<T>::~heap_object() = default;
+namespace example_com {
+template <typename T> heap_object<T>::~heap_object() = default;
+}
 
 inline auto example_com::MyRecord::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
     using ::example_com::toYaml;
@@ -405,12 +406,13 @@ inline void example_com::MyRecord::fromYaml([[maybe_unused]] YAML::Node const& n
         fromYaml(expandedNode, *name);
     }
 }
+namespace example_com {
 template <>
-struct example_com::DetectAndExtractFromYaml<example_com::MyRecord> {
-    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecord> {
+struct DetectAndExtractFromYaml<::example_com::MyRecord> {
+    auto operator()(YAML::Node const& n) const -> std::optional<::example_com::MyRecord> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = example_com::MyRecord{};
+        auto res = ::example_com::MyRecord{};
 
         if constexpr (::example_com::IsConstant<decltype(res.name)::value_t>::value) try {
             fromYaml(n["name"], *res.name);
@@ -421,6 +423,7 @@ struct example_com::DetectAndExtractFromYaml<example_com::MyRecord> {
         return std::nullopt;
     }
 };
+}
 namespace example_com {
 
 template <typename T>
@@ -525,7 +528,7 @@ auto load_document_from_string(std::string document) -> DocumentRootType {
     return load_document_from_yaml(YAML::Load(document));
 }
 auto load_document(std::filesystem::path path) -> DocumentRootType {
-    return load_document_from_yaml(YAML::LoadFile(path));
+    return load_document_from_yaml(YAML::LoadFile(path.string()));
 }
 void store_document(DocumentRootType const& root, std::ostream& ostream, store_config config={}) {
     auto y = toYaml(root, config);

--- a/schema_salad/tests/cpp_tests/01_single_record.h
+++ b/schema_salad/tests/cpp_tests/01_single_record.h
@@ -9,6 +9,8 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <map>
 #include <optional>
 #include <string>
@@ -17,45 +19,123 @@
 #include <vector>
 #include <yaml-cpp/yaml.h>
 
-inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
-    for (auto const& e : n1) {
-        n2[e.first.as<std::string>()] = e.second;
+namespace example_com {
+
+struct store_config {
+    bool simplifyTypes = true;
+    bool transformListsToMaps = true;
+    bool generateTags = false;
+};
+
+inline auto simplifyType(YAML::Node type, store_config const& config) -> YAML::Node {
+    if (!config.simplifyTypes) return type;
+    auto is_optional = [](YAML::Node const & node) {
+        return node.IsSequence() && node.size() == 2u && node[0].Scalar() == "null";
+    };
+
+    auto is_array = [](YAML::Node const & node) {
+        return node.IsMap() && node["type"].Scalar() == "array" && node["items"].IsScalar();
+    };
+
+    // 1. Collapsing optional scalar types into one option
+    if (is_optional(type) && type[1].IsScalar()) {
+        type = type[1].as<std::string>() + "?";
     }
-    return n2;
+
+    // 2. Collapsing array types into one option
+    if (is_array(type)) {
+        type = type["items"].as<std::string>() + "[]";
+    }
+
+    // 3. Collapsing optional array types into one option
+    if (is_optional(type) && is_array(type[1])) {
+        type = type[1]["items"].as<std::string>() + "[]?";
+    }
+
+    return type;
+}
+
+inline auto expandType(YAML::Node type) -> YAML::Node {
+    auto ends_with = [](std::string str, std::string suffix) {
+        if (str.size() < suffix.size()) return false;
+        auto str_suffix = str.substr(str.size()-suffix.size(), suffix.size());
+        return str_suffix == suffix;
+    };
+
+    // 0. If not a scalar type, nothing to do
+    if (!type.IsDefined() || !type.IsScalar()) {
+        return type;
+    }
+
+    auto str = type.as<std::string>();
+    // 1. Check if optional array type and expand
+    if (ends_with(str, "[]?")) {
+        auto result = YAML::Node{};
+        result.push_back(YAML::Node{"null"});
+        auto array = YAML::Node{};
+        array["type"] = "array";
+        array["items"] = expandType(YAML::Node(str.substr(0, str.size()-3)));
+        result.push_back(array);
+        return result;
+    }
+
+    // 2. Expand array
+    if (ends_with(str, "[]")) {
+        auto array = YAML::Node{};
+        array["type"] = "array";
+        array["items"] = expandType(YAML::Node(str.substr(0, str.size()-2)));
+        return array;
+    }
+
+    // 3. Expand optional scalar type
+    if (ends_with(str, "?")) {
+        auto result = YAML::Node{};
+        result.push_back(YAML::Node{"null"});
+        result.push_back(expandType(YAML::Node(str.substr(0, str.size()-1))));
+        return result;
+    }
+    return type;
+}
+
+inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
+    for (auto const& e : n2) {
+        n1[e.first.as<std::string>()] = e.second;
+    }
+    return n1;
 }
 
 // declaring toYaml
-inline auto toYaml(bool v) { return YAML::Node{v}; }
-inline auto toYaml(float v) { return YAML::Node{v}; }
-inline auto toYaml(double v) { return YAML::Node{v}; }
-inline auto toYaml(char v) { return YAML::Node{v}; }
-inline auto toYaml(int8_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint8_t v) { return YAML::Node{v}; }
-inline auto toYaml(int16_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint16_t v) { return YAML::Node{v}; }
-inline auto toYaml(int32_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint32_t v) { return YAML::Node{v}; }
-inline auto toYaml(int64_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint64_t v) { return YAML::Node{v}; }
-inline auto toYaml(std::monostate const&) {
+inline auto toYaml(bool v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(float v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(double v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(char v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int8_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint8_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int16_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint16_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int32_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint32_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int64_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint64_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(std::monostate const&, [[maybe_unused]] store_config const&) {
     return YAML::Node(YAML::NodeType::Undefined);
 }
-inline auto toYaml(std::string const& v) {
+inline auto toYaml(std::string const& v, [[maybe_unused]] store_config const&) {
     return YAML::Node{v};
 }
 
 template <typename T, typename ...Args>
-auto anyToYaml_impl(std::any const& a) {
+auto anyToYaml_impl(std::any const& a, [[maybe_unused]] store_config const& config) {
     if (auto v = std::any_cast<T const>(&a)) {
-        return toYaml(*v);
+        return toYaml(*v, config);
     }
     if constexpr (sizeof...(Args) > 0) {
-        return anyToYaml_impl<Args...>(a);
+        return anyToYaml_impl<Args...>(a, config);
     }
-    return toYaml(std::monostate{});
+    return toYaml(std::monostate{}, config);
 }
 
-inline auto toYaml(std::any const& a) {
+inline auto toYaml(std::any const& a, [[maybe_unused]] store_config const& config) {
     return anyToYaml_impl<bool,
                           float,
                           double,
@@ -68,7 +148,7 @@ inline auto toYaml(std::any const& a) {
                           uint32_t,
                           int64_t,
                           uint64_t,
-                          std::string>(a);
+                          std::string>(a, config);
 }
 
 // declaring fromYaml
@@ -101,23 +181,37 @@ inline void addYamlField(YAML::Node& node, std::string const& key, YAML::Node va
     }
 }
 
-inline auto convertListToMap(YAML::Node list, std::string const& key_name) {
+inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std::string const& mapPredicate, store_config const& config) {
+    if (!config.transformListsToMaps) return list;
+    if (mapSubject.empty()) return list;
     if (list.size() == 0) return list;
     auto map = YAML::Node{};
     for (YAML::Node n : list) {
-        auto key = n[key_name].as<std::string>();
-        n.remove(key_name);
-        map[key] = n;
+        auto key = n[mapSubject].as<std::string>();
+        if (mapPredicate.empty() || n[mapPredicate].IsMap() || n.size() > 2) {
+            n.remove(mapSubject);
+            map[key] = n;
+        } else {
+            map[key] = n[mapPredicate];
+        }
     }
     return map;
 }
-inline auto convertMapToList(YAML::Node map, std::string const& key_name) {
+inline auto convertMapToList(YAML::Node map, std::string const& mapSubject, std::string const& mapPredicate) {
+    if (mapSubject.empty()) return map;
     if (!map.IsDefined()) return map;
     if (!map.IsMap()) return map;
     auto list = YAML::Node{};
     for (auto n : map) {
-        n.second[key_name] = n.first;
-        list.push_back(n.second);
+        if (mapPredicate.empty() || n.second.IsMap()) {
+            n.second[mapSubject] = n.first;
+            list.push_back(n.second);
+        } else {
+            auto n2 = YAML::Node{};
+            n2[mapSubject] = n.first;
+            n2[mapPredicate] = n.second;
+            list.push_back(n2);
+        }
     }
     return list;
 }
@@ -126,13 +220,13 @@ template <typename T> struct IsConstant : std::false_type {};
 
 // fwd declaring toYaml
 template <typename T>
-auto toYaml(std::vector<T> const& v) -> YAML::Node;
+auto toYaml(std::vector<T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename T>
-auto toYaml(std::map<std::string, T> const& v) -> YAML::Node;
+auto toYaml(std::map<std::string, T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename T>
-auto toYaml(T const& t) -> YAML::Node;
+auto toYaml(T const& t, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename ...Args>
-auto toYaml(std::variant<Args...> const& t) -> YAML::Node;
+auto toYaml(std::variant<Args...> const& t, [[maybe_unused]] store_config const& config) -> YAML::Node;
 
 // fwd declaring fromYaml
 template <typename T>
@@ -150,6 +244,23 @@ struct DetectAndExtractFromYaml {
         return std::nullopt;
     }
 };
+
+// special cwl expression string
+struct cwl_expression_string {
+    std::string s;
+
+    auto toYaml([[maybe_unused]] store_config const& config) const {
+        auto n = YAML::Node{s};
+        if (config.generateTags) {
+            n.SetTag("Expression");
+        }
+        return n;
+    }
+    void fromYaml(YAML::Node const& n) {
+        s = n.as<std::string>();
+    }
+};
+
 
 template <>
 struct DetectAndExtractFromYaml<std::monostate> {
@@ -257,38 +368,49 @@ public:
     }
 };
 
-namespace https___example_com_ { struct MyRecord; }
-namespace https___example_com_ {
+}
+namespace example_com { struct MyRecord; }
+namespace example_com {
 struct MyRecord {
     heap_object<std::string> name;
     virtual ~MyRecord() = default;
-    virtual auto toYaml() const -> YAML::Node;
+    virtual auto toYaml([[maybe_unused]] example_com::store_config const& config) const -> YAML::Node;
     virtual void fromYaml(YAML::Node const& n);
 };
 }
 
 template <typename T>
-heap_object<T>::~heap_object() = default;
+example_com::heap_object<T>::~heap_object() = default;
 
-inline auto https___example_com_::MyRecord::toYaml() const -> YAML::Node {
-    using ::toYaml;
+inline auto example_com::MyRecord::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
+    using ::example_com::toYaml;
     auto n = YAML::Node{};
-    addYamlField(n, "name", toYaml(*name));
+    if (config.generateTags) {
+        n.SetTag("MyRecord");
+    }
+    {
+         auto member = toYaml(*name, config);
+         member = convertListToMap(member, "", "", config);
+        addYamlField(n, "name", member);
+    }
     return n;
 }
-inline void https___example_com_::MyRecord::fromYaml([[maybe_unused]] YAML::Node const& n) {
-    using ::fromYaml;
-    fromYaml(n["name"], *name);
+inline void example_com::MyRecord::fromYaml([[maybe_unused]] YAML::Node const& n) {
+    using ::example_com::fromYaml;
+    {
+        auto nodeAsList = convertMapToList(n["name"], "", "");
+        auto expandedNode = (nodeAsList);
+        fromYaml(expandedNode, *name);
+    }
 }
-
 template <>
-struct DetectAndExtractFromYaml<https___example_com_::MyRecord> {
-    auto operator()(YAML::Node const& n) const -> std::optional<https___example_com_::MyRecord> {
+struct example_com::DetectAndExtractFromYaml<example_com::MyRecord> {
+    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecord> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = https___example_com_::MyRecord{};
+        auto res = example_com::MyRecord{};
 
-        if constexpr (IsConstant<decltype(res.name)::value_t>::value) try {
+        if constexpr (::example_com::IsConstant<decltype(res.name)::value_t>::value) try {
             fromYaml(n["name"], *res.name);
             fromYaml(n, res);
             return res;
@@ -297,38 +419,39 @@ struct DetectAndExtractFromYaml<https___example_com_::MyRecord> {
         return std::nullopt;
     }
 };
+namespace example_com {
 
 template <typename T>
-auto toYaml(std::vector<T> const& v) -> YAML::Node {
+auto toYaml(std::vector<T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node {
     auto n = YAML::Node(YAML::NodeType::Sequence);
     for (auto const& e : v) {
-        n.push_back(toYaml(e));
+        n.push_back(toYaml(e, config));
     }
     return n;
 }
 
 template <typename T>
-auto toYaml(std::map<std::string, T> const& v) -> YAML::Node {
+auto toYaml(std::map<std::string, T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node {
     auto n = YAML::Node(YAML::NodeType::Map);
     for (auto const& [key, value] : v) {
-        n[key] = toYaml(value);
+        n[key] = toYaml(value, config);
     }
     return n;
 }
 
 template <typename T>
-auto toYaml(T const& t) -> YAML::Node {
+auto toYaml(T const& t, [[maybe_unused]] store_config const& config) -> YAML::Node {
     if constexpr (std::is_enum_v<T>) {
-        return toYaml(t);
+        return toYaml(t, config);
     } else {
-        return t.toYaml();
+        return t.toYaml(config);
     }
 }
 
 template <typename ...Args>
-auto toYaml(std::variant<Args...> const& t) -> YAML::Node {
-    return std::visit([](auto const& e) {
-        return toYaml(e);
+auto toYaml(std::variant<Args...> const& t, store_config const& config) -> YAML::Node {
+    return std::visit([config](auto const& e) {
+        return toYaml(e, config);
     }, t);
 }
 
@@ -389,4 +512,34 @@ template <typename ...Args>
 void fromYaml(YAML::Node const& n, std::variant<Args...>& v){
     bool found = detectAndExtractFromYaml<std::variant<Args...>, Args...>(n, v);
     if (!found) throw std::runtime_error{"didn't find any overload"};
+}
+using DocumentRootType = std::variant<>;
+auto load_document_from_yaml(YAML::Node n) -> DocumentRootType {
+    DocumentRootType root;
+    fromYaml(n, root);
+    return root;
+}
+auto load_document_from_string(std::string document) -> DocumentRootType {
+    return load_document_from_yaml(YAML::Load(document));
+}
+auto load_document(std::filesystem::path path) -> DocumentRootType {
+    return load_document_from_yaml(YAML::LoadFile(path));
+}
+void store_document(DocumentRootType const& root, std::ostream& ostream, store_config config={}) {
+    auto y = toYaml(root, config);
+
+    YAML::Emitter out;
+    out << y;
+    ostream << out.c_str() << std::endl;
+}
+void store_document(DocumentRootType const& root, std::filesystem::path const& path, store_config config={}) {
+    auto ofs = std::ofstream{path};
+    store_document(root, ofs, config);
+}
+auto store_document_as_string(DocumentRootType const& root, store_config config={}) -> std::string {
+    auto ss = std::stringstream{};
+    store_document(root, ss, config);
+    return ss.str();
+}
+
 }

--- a/schema_salad/tests/cpp_tests/02_two_records.h
+++ b/schema_salad/tests/cpp_tests/02_two_records.h
@@ -181,7 +181,8 @@ inline void addYamlField(YAML::Node& node, std::string const& key, YAML::Node va
     }
 }
 
-inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std::string const& mapPredicate, store_config const& config) {
+inline auto convertListToMap(YAML::Node list, std::string const& mapSubject,
+                             std::string const& mapPredicate, store_config const& config) {
     if (!config.transformListsToMaps) return list;
     if (mapSubject.empty()) return list;
     if (list.size() == 0) return list;
@@ -197,7 +198,8 @@ inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std
     }
     return map;
 }
-inline auto convertMapToList(YAML::Node map, std::string const& mapSubject, std::string const& mapPredicate) {
+inline auto convertMapToList(YAML::Node map, std::string const& mapSubject,
+                             std::string const& mapPredicate) {
     if (mapSubject.empty()) return map;
     if (!map.IsDefined()) return map;
     if (!map.IsMap()) return map;

--- a/schema_salad/tests/cpp_tests/02_two_records.h
+++ b/schema_salad/tests/cpp_tests/02_two_records.h
@@ -391,8 +391,9 @@ struct MyRecordTwo {
 };
 }
 
-template <typename T>
-example_com::heap_object<T>::~heap_object() = default;
+namespace example_com {
+template <typename T> heap_object<T>::~heap_object() = default;
+}
 
 inline auto example_com::MyRecordOne::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
     using ::example_com::toYaml;
@@ -415,12 +416,13 @@ inline void example_com::MyRecordOne::fromYaml([[maybe_unused]] YAML::Node const
         fromYaml(expandedNode, *name);
     }
 }
+namespace example_com {
 template <>
-struct example_com::DetectAndExtractFromYaml<example_com::MyRecordOne> {
-    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordOne> {
+struct DetectAndExtractFromYaml<::example_com::MyRecordOne> {
+    auto operator()(YAML::Node const& n) const -> std::optional<::example_com::MyRecordOne> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = example_com::MyRecordOne{};
+        auto res = ::example_com::MyRecordOne{};
 
         if constexpr (::example_com::IsConstant<decltype(res.name)::value_t>::value) try {
             fromYaml(n["name"], *res.name);
@@ -431,6 +433,7 @@ struct example_com::DetectAndExtractFromYaml<example_com::MyRecordOne> {
         return std::nullopt;
     }
 };
+}
 inline auto example_com::MyRecordTwo::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
     using ::example_com::toYaml;
     auto n = YAML::Node{};
@@ -452,12 +455,13 @@ inline void example_com::MyRecordTwo::fromYaml([[maybe_unused]] YAML::Node const
         fromYaml(expandedNode, *value);
     }
 }
+namespace example_com {
 template <>
-struct example_com::DetectAndExtractFromYaml<example_com::MyRecordTwo> {
-    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordTwo> {
+struct DetectAndExtractFromYaml<::example_com::MyRecordTwo> {
+    auto operator()(YAML::Node const& n) const -> std::optional<::example_com::MyRecordTwo> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = example_com::MyRecordTwo{};
+        auto res = ::example_com::MyRecordTwo{};
 
         if constexpr (::example_com::IsConstant<decltype(res.value)::value_t>::value) try {
             fromYaml(n["value"], *res.value);
@@ -468,6 +472,7 @@ struct example_com::DetectAndExtractFromYaml<example_com::MyRecordTwo> {
         return std::nullopt;
     }
 };
+}
 namespace example_com {
 
 template <typename T>
@@ -572,7 +577,7 @@ auto load_document_from_string(std::string document) -> DocumentRootType {
     return load_document_from_yaml(YAML::Load(document));
 }
 auto load_document(std::filesystem::path path) -> DocumentRootType {
-    return load_document_from_yaml(YAML::LoadFile(path));
+    return load_document_from_yaml(YAML::LoadFile(path.string()));
 }
 void store_document(DocumentRootType const& root, std::ostream& ostream, store_config config={}) {
     auto y = toYaml(root, config);

--- a/schema_salad/tests/cpp_tests/02_two_records.h
+++ b/schema_salad/tests/cpp_tests/02_two_records.h
@@ -9,6 +9,8 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <map>
 #include <optional>
 #include <string>
@@ -17,45 +19,123 @@
 #include <vector>
 #include <yaml-cpp/yaml.h>
 
-inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
-    for (auto const& e : n1) {
-        n2[e.first.as<std::string>()] = e.second;
+namespace example_com {
+
+struct store_config {
+    bool simplifyTypes = true;
+    bool transformListsToMaps = true;
+    bool generateTags = false;
+};
+
+inline auto simplifyType(YAML::Node type, store_config const& config) -> YAML::Node {
+    if (!config.simplifyTypes) return type;
+    auto is_optional = [](YAML::Node const & node) {
+        return node.IsSequence() && node.size() == 2u && node[0].Scalar() == "null";
+    };
+
+    auto is_array = [](YAML::Node const & node) {
+        return node.IsMap() && node["type"].Scalar() == "array" && node["items"].IsScalar();
+    };
+
+    // 1. Collapsing optional scalar types into one option
+    if (is_optional(type) && type[1].IsScalar()) {
+        type = type[1].as<std::string>() + "?";
     }
-    return n2;
+
+    // 2. Collapsing array types into one option
+    if (is_array(type)) {
+        type = type["items"].as<std::string>() + "[]";
+    }
+
+    // 3. Collapsing optional array types into one option
+    if (is_optional(type) && is_array(type[1])) {
+        type = type[1]["items"].as<std::string>() + "[]?";
+    }
+
+    return type;
+}
+
+inline auto expandType(YAML::Node type) -> YAML::Node {
+    auto ends_with = [](std::string str, std::string suffix) {
+        if (str.size() < suffix.size()) return false;
+        auto str_suffix = str.substr(str.size()-suffix.size(), suffix.size());
+        return str_suffix == suffix;
+    };
+
+    // 0. If not a scalar type, nothing to do
+    if (!type.IsDefined() || !type.IsScalar()) {
+        return type;
+    }
+
+    auto str = type.as<std::string>();
+    // 1. Check if optional array type and expand
+    if (ends_with(str, "[]?")) {
+        auto result = YAML::Node{};
+        result.push_back(YAML::Node{"null"});
+        auto array = YAML::Node{};
+        array["type"] = "array";
+        array["items"] = expandType(YAML::Node(str.substr(0, str.size()-3)));
+        result.push_back(array);
+        return result;
+    }
+
+    // 2. Expand array
+    if (ends_with(str, "[]")) {
+        auto array = YAML::Node{};
+        array["type"] = "array";
+        array["items"] = expandType(YAML::Node(str.substr(0, str.size()-2)));
+        return array;
+    }
+
+    // 3. Expand optional scalar type
+    if (ends_with(str, "?")) {
+        auto result = YAML::Node{};
+        result.push_back(YAML::Node{"null"});
+        result.push_back(expandType(YAML::Node(str.substr(0, str.size()-1))));
+        return result;
+    }
+    return type;
+}
+
+inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
+    for (auto const& e : n2) {
+        n1[e.first.as<std::string>()] = e.second;
+    }
+    return n1;
 }
 
 // declaring toYaml
-inline auto toYaml(bool v) { return YAML::Node{v}; }
-inline auto toYaml(float v) { return YAML::Node{v}; }
-inline auto toYaml(double v) { return YAML::Node{v}; }
-inline auto toYaml(char v) { return YAML::Node{v}; }
-inline auto toYaml(int8_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint8_t v) { return YAML::Node{v}; }
-inline auto toYaml(int16_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint16_t v) { return YAML::Node{v}; }
-inline auto toYaml(int32_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint32_t v) { return YAML::Node{v}; }
-inline auto toYaml(int64_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint64_t v) { return YAML::Node{v}; }
-inline auto toYaml(std::monostate const&) {
+inline auto toYaml(bool v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(float v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(double v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(char v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int8_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint8_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int16_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint16_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int32_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint32_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int64_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint64_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(std::monostate const&, [[maybe_unused]] store_config const&) {
     return YAML::Node(YAML::NodeType::Undefined);
 }
-inline auto toYaml(std::string const& v) {
+inline auto toYaml(std::string const& v, [[maybe_unused]] store_config const&) {
     return YAML::Node{v};
 }
 
 template <typename T, typename ...Args>
-auto anyToYaml_impl(std::any const& a) {
+auto anyToYaml_impl(std::any const& a, [[maybe_unused]] store_config const& config) {
     if (auto v = std::any_cast<T const>(&a)) {
-        return toYaml(*v);
+        return toYaml(*v, config);
     }
     if constexpr (sizeof...(Args) > 0) {
-        return anyToYaml_impl<Args...>(a);
+        return anyToYaml_impl<Args...>(a, config);
     }
-    return toYaml(std::monostate{});
+    return toYaml(std::monostate{}, config);
 }
 
-inline auto toYaml(std::any const& a) {
+inline auto toYaml(std::any const& a, [[maybe_unused]] store_config const& config) {
     return anyToYaml_impl<bool,
                           float,
                           double,
@@ -68,7 +148,7 @@ inline auto toYaml(std::any const& a) {
                           uint32_t,
                           int64_t,
                           uint64_t,
-                          std::string>(a);
+                          std::string>(a, config);
 }
 
 // declaring fromYaml
@@ -101,23 +181,37 @@ inline void addYamlField(YAML::Node& node, std::string const& key, YAML::Node va
     }
 }
 
-inline auto convertListToMap(YAML::Node list, std::string const& key_name) {
+inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std::string const& mapPredicate, store_config const& config) {
+    if (!config.transformListsToMaps) return list;
+    if (mapSubject.empty()) return list;
     if (list.size() == 0) return list;
     auto map = YAML::Node{};
     for (YAML::Node n : list) {
-        auto key = n[key_name].as<std::string>();
-        n.remove(key_name);
-        map[key] = n;
+        auto key = n[mapSubject].as<std::string>();
+        if (mapPredicate.empty() || n[mapPredicate].IsMap() || n.size() > 2) {
+            n.remove(mapSubject);
+            map[key] = n;
+        } else {
+            map[key] = n[mapPredicate];
+        }
     }
     return map;
 }
-inline auto convertMapToList(YAML::Node map, std::string const& key_name) {
+inline auto convertMapToList(YAML::Node map, std::string const& mapSubject, std::string const& mapPredicate) {
+    if (mapSubject.empty()) return map;
     if (!map.IsDefined()) return map;
     if (!map.IsMap()) return map;
     auto list = YAML::Node{};
     for (auto n : map) {
-        n.second[key_name] = n.first;
-        list.push_back(n.second);
+        if (mapPredicate.empty() || n.second.IsMap()) {
+            n.second[mapSubject] = n.first;
+            list.push_back(n.second);
+        } else {
+            auto n2 = YAML::Node{};
+            n2[mapSubject] = n.first;
+            n2[mapPredicate] = n.second;
+            list.push_back(n2);
+        }
     }
     return list;
 }
@@ -126,13 +220,13 @@ template <typename T> struct IsConstant : std::false_type {};
 
 // fwd declaring toYaml
 template <typename T>
-auto toYaml(std::vector<T> const& v) -> YAML::Node;
+auto toYaml(std::vector<T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename T>
-auto toYaml(std::map<std::string, T> const& v) -> YAML::Node;
+auto toYaml(std::map<std::string, T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename T>
-auto toYaml(T const& t) -> YAML::Node;
+auto toYaml(T const& t, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename ...Args>
-auto toYaml(std::variant<Args...> const& t) -> YAML::Node;
+auto toYaml(std::variant<Args...> const& t, [[maybe_unused]] store_config const& config) -> YAML::Node;
 
 // fwd declaring fromYaml
 template <typename T>
@@ -150,6 +244,23 @@ struct DetectAndExtractFromYaml {
         return std::nullopt;
     }
 };
+
+// special cwl expression string
+struct cwl_expression_string {
+    std::string s;
+
+    auto toYaml([[maybe_unused]] store_config const& config) const {
+        auto n = YAML::Node{s};
+        if (config.generateTags) {
+            n.SetTag("Expression");
+        }
+        return n;
+    }
+    void fromYaml(YAML::Node const& n) {
+        s = n.as<std::string>();
+    }
+};
+
 
 template <>
 struct DetectAndExtractFromYaml<std::monostate> {
@@ -257,48 +368,59 @@ public:
     }
 };
 
-namespace https___example_com_ { struct MyRecordOne; }
-namespace https___example_com_ { struct MyRecordTwo; }
-namespace https___example_com_ {
+}
+namespace example_com { struct MyRecordOne; }
+namespace example_com { struct MyRecordTwo; }
+namespace example_com {
 struct MyRecordOne {
     heap_object<std::string> name;
     virtual ~MyRecordOne() = default;
-    virtual auto toYaml() const -> YAML::Node;
+    virtual auto toYaml([[maybe_unused]] example_com::store_config const& config) const -> YAML::Node;
     virtual void fromYaml(YAML::Node const& n);
 };
 }
 
-namespace https___example_com_ {
+namespace example_com {
 struct MyRecordTwo {
     heap_object<int32_t> value;
     virtual ~MyRecordTwo() = default;
-    virtual auto toYaml() const -> YAML::Node;
+    virtual auto toYaml([[maybe_unused]] example_com::store_config const& config) const -> YAML::Node;
     virtual void fromYaml(YAML::Node const& n);
 };
 }
 
 template <typename T>
-heap_object<T>::~heap_object() = default;
+example_com::heap_object<T>::~heap_object() = default;
 
-inline auto https___example_com_::MyRecordOne::toYaml() const -> YAML::Node {
-    using ::toYaml;
+inline auto example_com::MyRecordOne::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
+    using ::example_com::toYaml;
     auto n = YAML::Node{};
-    addYamlField(n, "name", toYaml(*name));
+    if (config.generateTags) {
+        n.SetTag("MyRecordOne");
+    }
+    {
+         auto member = toYaml(*name, config);
+         member = convertListToMap(member, "", "", config);
+        addYamlField(n, "name", member);
+    }
     return n;
 }
-inline void https___example_com_::MyRecordOne::fromYaml([[maybe_unused]] YAML::Node const& n) {
-    using ::fromYaml;
-    fromYaml(n["name"], *name);
+inline void example_com::MyRecordOne::fromYaml([[maybe_unused]] YAML::Node const& n) {
+    using ::example_com::fromYaml;
+    {
+        auto nodeAsList = convertMapToList(n["name"], "", "");
+        auto expandedNode = (nodeAsList);
+        fromYaml(expandedNode, *name);
+    }
 }
-
 template <>
-struct DetectAndExtractFromYaml<https___example_com_::MyRecordOne> {
-    auto operator()(YAML::Node const& n) const -> std::optional<https___example_com_::MyRecordOne> {
+struct example_com::DetectAndExtractFromYaml<example_com::MyRecordOne> {
+    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordOne> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = https___example_com_::MyRecordOne{};
+        auto res = example_com::MyRecordOne{};
 
-        if constexpr (IsConstant<decltype(res.name)::value_t>::value) try {
+        if constexpr (::example_com::IsConstant<decltype(res.name)::value_t>::value) try {
             fromYaml(n["name"], *res.name);
             fromYaml(n, res);
             return res;
@@ -307,25 +429,35 @@ struct DetectAndExtractFromYaml<https___example_com_::MyRecordOne> {
         return std::nullopt;
     }
 };
-inline auto https___example_com_::MyRecordTwo::toYaml() const -> YAML::Node {
-    using ::toYaml;
+inline auto example_com::MyRecordTwo::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
+    using ::example_com::toYaml;
     auto n = YAML::Node{};
-    addYamlField(n, "value", toYaml(*value));
+    if (config.generateTags) {
+        n.SetTag("MyRecordTwo");
+    }
+    {
+         auto member = toYaml(*value, config);
+         member = convertListToMap(member, "", "", config);
+        addYamlField(n, "value", member);
+    }
     return n;
 }
-inline void https___example_com_::MyRecordTwo::fromYaml([[maybe_unused]] YAML::Node const& n) {
-    using ::fromYaml;
-    fromYaml(n["value"], *value);
+inline void example_com::MyRecordTwo::fromYaml([[maybe_unused]] YAML::Node const& n) {
+    using ::example_com::fromYaml;
+    {
+        auto nodeAsList = convertMapToList(n["value"], "", "");
+        auto expandedNode = (nodeAsList);
+        fromYaml(expandedNode, *value);
+    }
 }
-
 template <>
-struct DetectAndExtractFromYaml<https___example_com_::MyRecordTwo> {
-    auto operator()(YAML::Node const& n) const -> std::optional<https___example_com_::MyRecordTwo> {
+struct example_com::DetectAndExtractFromYaml<example_com::MyRecordTwo> {
+    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordTwo> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = https___example_com_::MyRecordTwo{};
+        auto res = example_com::MyRecordTwo{};
 
-        if constexpr (IsConstant<decltype(res.value)::value_t>::value) try {
+        if constexpr (::example_com::IsConstant<decltype(res.value)::value_t>::value) try {
             fromYaml(n["value"], *res.value);
             fromYaml(n, res);
             return res;
@@ -334,38 +466,39 @@ struct DetectAndExtractFromYaml<https___example_com_::MyRecordTwo> {
         return std::nullopt;
     }
 };
+namespace example_com {
 
 template <typename T>
-auto toYaml(std::vector<T> const& v) -> YAML::Node {
+auto toYaml(std::vector<T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node {
     auto n = YAML::Node(YAML::NodeType::Sequence);
     for (auto const& e : v) {
-        n.push_back(toYaml(e));
+        n.push_back(toYaml(e, config));
     }
     return n;
 }
 
 template <typename T>
-auto toYaml(std::map<std::string, T> const& v) -> YAML::Node {
+auto toYaml(std::map<std::string, T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node {
     auto n = YAML::Node(YAML::NodeType::Map);
     for (auto const& [key, value] : v) {
-        n[key] = toYaml(value);
+        n[key] = toYaml(value, config);
     }
     return n;
 }
 
 template <typename T>
-auto toYaml(T const& t) -> YAML::Node {
+auto toYaml(T const& t, [[maybe_unused]] store_config const& config) -> YAML::Node {
     if constexpr (std::is_enum_v<T>) {
-        return toYaml(t);
+        return toYaml(t, config);
     } else {
-        return t.toYaml();
+        return t.toYaml(config);
     }
 }
 
 template <typename ...Args>
-auto toYaml(std::variant<Args...> const& t) -> YAML::Node {
-    return std::visit([](auto const& e) {
-        return toYaml(e);
+auto toYaml(std::variant<Args...> const& t, store_config const& config) -> YAML::Node {
+    return std::visit([config](auto const& e) {
+        return toYaml(e, config);
     }, t);
 }
 
@@ -426,4 +559,34 @@ template <typename ...Args>
 void fromYaml(YAML::Node const& n, std::variant<Args...>& v){
     bool found = detectAndExtractFromYaml<std::variant<Args...>, Args...>(n, v);
     if (!found) throw std::runtime_error{"didn't find any overload"};
+}
+using DocumentRootType = std::variant<>;
+auto load_document_from_yaml(YAML::Node n) -> DocumentRootType {
+    DocumentRootType root;
+    fromYaml(n, root);
+    return root;
+}
+auto load_document_from_string(std::string document) -> DocumentRootType {
+    return load_document_from_yaml(YAML::Load(document));
+}
+auto load_document(std::filesystem::path path) -> DocumentRootType {
+    return load_document_from_yaml(YAML::LoadFile(path));
+}
+void store_document(DocumentRootType const& root, std::ostream& ostream, store_config config={}) {
+    auto y = toYaml(root, config);
+
+    YAML::Emitter out;
+    out << y;
+    ostream << out.c_str() << std::endl;
+}
+void store_document(DocumentRootType const& root, std::filesystem::path const& path, store_config config={}) {
+    auto ofs = std::ofstream{path};
+    store_document(root, ofs, config);
+}
+auto store_document_as_string(DocumentRootType const& root, store_config config={}) -> std::string {
+    auto ss = std::stringstream{};
+    store_document(root, ss, config);
+    return ss.str();
+}
+
 }

--- a/schema_salad/tests/cpp_tests/03_simple_inheritance.h
+++ b/schema_salad/tests/cpp_tests/03_simple_inheritance.h
@@ -181,7 +181,8 @@ inline void addYamlField(YAML::Node& node, std::string const& key, YAML::Node va
     }
 }
 
-inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std::string const& mapPredicate, store_config const& config) {
+inline auto convertListToMap(YAML::Node list, std::string const& mapSubject,
+                             std::string const& mapPredicate, store_config const& config) {
     if (!config.transformListsToMaps) return list;
     if (mapSubject.empty()) return list;
     if (list.size() == 0) return list;
@@ -197,7 +198,8 @@ inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std
     }
     return map;
 }
-inline auto convertMapToList(YAML::Node map, std::string const& mapSubject, std::string const& mapPredicate) {
+inline auto convertMapToList(YAML::Node map, std::string const& mapSubject,
+                             std::string const& mapPredicate) {
     if (mapSubject.empty()) return map;
     if (!map.IsDefined()) return map;
     if (!map.IsMap()) return map;

--- a/schema_salad/tests/cpp_tests/03_simple_inheritance.h
+++ b/schema_salad/tests/cpp_tests/03_simple_inheritance.h
@@ -9,6 +9,8 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <map>
 #include <optional>
 #include <string>
@@ -17,45 +19,123 @@
 #include <vector>
 #include <yaml-cpp/yaml.h>
 
-inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
-    for (auto const& e : n1) {
-        n2[e.first.as<std::string>()] = e.second;
+namespace example_com {
+
+struct store_config {
+    bool simplifyTypes = true;
+    bool transformListsToMaps = true;
+    bool generateTags = false;
+};
+
+inline auto simplifyType(YAML::Node type, store_config const& config) -> YAML::Node {
+    if (!config.simplifyTypes) return type;
+    auto is_optional = [](YAML::Node const & node) {
+        return node.IsSequence() && node.size() == 2u && node[0].Scalar() == "null";
+    };
+
+    auto is_array = [](YAML::Node const & node) {
+        return node.IsMap() && node["type"].Scalar() == "array" && node["items"].IsScalar();
+    };
+
+    // 1. Collapsing optional scalar types into one option
+    if (is_optional(type) && type[1].IsScalar()) {
+        type = type[1].as<std::string>() + "?";
     }
-    return n2;
+
+    // 2. Collapsing array types into one option
+    if (is_array(type)) {
+        type = type["items"].as<std::string>() + "[]";
+    }
+
+    // 3. Collapsing optional array types into one option
+    if (is_optional(type) && is_array(type[1])) {
+        type = type[1]["items"].as<std::string>() + "[]?";
+    }
+
+    return type;
+}
+
+inline auto expandType(YAML::Node type) -> YAML::Node {
+    auto ends_with = [](std::string str, std::string suffix) {
+        if (str.size() < suffix.size()) return false;
+        auto str_suffix = str.substr(str.size()-suffix.size(), suffix.size());
+        return str_suffix == suffix;
+    };
+
+    // 0. If not a scalar type, nothing to do
+    if (!type.IsDefined() || !type.IsScalar()) {
+        return type;
+    }
+
+    auto str = type.as<std::string>();
+    // 1. Check if optional array type and expand
+    if (ends_with(str, "[]?")) {
+        auto result = YAML::Node{};
+        result.push_back(YAML::Node{"null"});
+        auto array = YAML::Node{};
+        array["type"] = "array";
+        array["items"] = expandType(YAML::Node(str.substr(0, str.size()-3)));
+        result.push_back(array);
+        return result;
+    }
+
+    // 2. Expand array
+    if (ends_with(str, "[]")) {
+        auto array = YAML::Node{};
+        array["type"] = "array";
+        array["items"] = expandType(YAML::Node(str.substr(0, str.size()-2)));
+        return array;
+    }
+
+    // 3. Expand optional scalar type
+    if (ends_with(str, "?")) {
+        auto result = YAML::Node{};
+        result.push_back(YAML::Node{"null"});
+        result.push_back(expandType(YAML::Node(str.substr(0, str.size()-1))));
+        return result;
+    }
+    return type;
+}
+
+inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
+    for (auto const& e : n2) {
+        n1[e.first.as<std::string>()] = e.second;
+    }
+    return n1;
 }
 
 // declaring toYaml
-inline auto toYaml(bool v) { return YAML::Node{v}; }
-inline auto toYaml(float v) { return YAML::Node{v}; }
-inline auto toYaml(double v) { return YAML::Node{v}; }
-inline auto toYaml(char v) { return YAML::Node{v}; }
-inline auto toYaml(int8_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint8_t v) { return YAML::Node{v}; }
-inline auto toYaml(int16_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint16_t v) { return YAML::Node{v}; }
-inline auto toYaml(int32_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint32_t v) { return YAML::Node{v}; }
-inline auto toYaml(int64_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint64_t v) { return YAML::Node{v}; }
-inline auto toYaml(std::monostate const&) {
+inline auto toYaml(bool v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(float v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(double v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(char v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int8_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint8_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int16_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint16_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int32_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint32_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int64_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint64_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(std::monostate const&, [[maybe_unused]] store_config const&) {
     return YAML::Node(YAML::NodeType::Undefined);
 }
-inline auto toYaml(std::string const& v) {
+inline auto toYaml(std::string const& v, [[maybe_unused]] store_config const&) {
     return YAML::Node{v};
 }
 
 template <typename T, typename ...Args>
-auto anyToYaml_impl(std::any const& a) {
+auto anyToYaml_impl(std::any const& a, [[maybe_unused]] store_config const& config) {
     if (auto v = std::any_cast<T const>(&a)) {
-        return toYaml(*v);
+        return toYaml(*v, config);
     }
     if constexpr (sizeof...(Args) > 0) {
-        return anyToYaml_impl<Args...>(a);
+        return anyToYaml_impl<Args...>(a, config);
     }
-    return toYaml(std::monostate{});
+    return toYaml(std::monostate{}, config);
 }
 
-inline auto toYaml(std::any const& a) {
+inline auto toYaml(std::any const& a, [[maybe_unused]] store_config const& config) {
     return anyToYaml_impl<bool,
                           float,
                           double,
@@ -68,7 +148,7 @@ inline auto toYaml(std::any const& a) {
                           uint32_t,
                           int64_t,
                           uint64_t,
-                          std::string>(a);
+                          std::string>(a, config);
 }
 
 // declaring fromYaml
@@ -101,23 +181,37 @@ inline void addYamlField(YAML::Node& node, std::string const& key, YAML::Node va
     }
 }
 
-inline auto convertListToMap(YAML::Node list, std::string const& key_name) {
+inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std::string const& mapPredicate, store_config const& config) {
+    if (!config.transformListsToMaps) return list;
+    if (mapSubject.empty()) return list;
     if (list.size() == 0) return list;
     auto map = YAML::Node{};
     for (YAML::Node n : list) {
-        auto key = n[key_name].as<std::string>();
-        n.remove(key_name);
-        map[key] = n;
+        auto key = n[mapSubject].as<std::string>();
+        if (mapPredicate.empty() || n[mapPredicate].IsMap() || n.size() > 2) {
+            n.remove(mapSubject);
+            map[key] = n;
+        } else {
+            map[key] = n[mapPredicate];
+        }
     }
     return map;
 }
-inline auto convertMapToList(YAML::Node map, std::string const& key_name) {
+inline auto convertMapToList(YAML::Node map, std::string const& mapSubject, std::string const& mapPredicate) {
+    if (mapSubject.empty()) return map;
     if (!map.IsDefined()) return map;
     if (!map.IsMap()) return map;
     auto list = YAML::Node{};
     for (auto n : map) {
-        n.second[key_name] = n.first;
-        list.push_back(n.second);
+        if (mapPredicate.empty() || n.second.IsMap()) {
+            n.second[mapSubject] = n.first;
+            list.push_back(n.second);
+        } else {
+            auto n2 = YAML::Node{};
+            n2[mapSubject] = n.first;
+            n2[mapPredicate] = n.second;
+            list.push_back(n2);
+        }
     }
     return list;
 }
@@ -126,13 +220,13 @@ template <typename T> struct IsConstant : std::false_type {};
 
 // fwd declaring toYaml
 template <typename T>
-auto toYaml(std::vector<T> const& v) -> YAML::Node;
+auto toYaml(std::vector<T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename T>
-auto toYaml(std::map<std::string, T> const& v) -> YAML::Node;
+auto toYaml(std::map<std::string, T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename T>
-auto toYaml(T const& t) -> YAML::Node;
+auto toYaml(T const& t, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename ...Args>
-auto toYaml(std::variant<Args...> const& t) -> YAML::Node;
+auto toYaml(std::variant<Args...> const& t, [[maybe_unused]] store_config const& config) -> YAML::Node;
 
 // fwd declaring fromYaml
 template <typename T>
@@ -150,6 +244,23 @@ struct DetectAndExtractFromYaml {
         return std::nullopt;
     }
 };
+
+// special cwl expression string
+struct cwl_expression_string {
+    std::string s;
+
+    auto toYaml([[maybe_unused]] store_config const& config) const {
+        auto n = YAML::Node{s};
+        if (config.generateTags) {
+            n.SetTag("Expression");
+        }
+        return n;
+    }
+    void fromYaml(YAML::Node const& n) {
+        s = n.as<std::string>();
+    }
+};
+
 
 template <>
 struct DetectAndExtractFromYaml<std::monostate> {
@@ -257,49 +368,60 @@ public:
     }
 };
 
-namespace https___example_com_ { struct MyRecordOne; }
-namespace https___example_com_ { struct MyRecordTwo; }
-namespace https___example_com_ {
+}
+namespace example_com { struct MyRecordOne; }
+namespace example_com { struct MyRecordTwo; }
+namespace example_com {
 struct MyRecordOne {
     heap_object<std::string> name;
     virtual ~MyRecordOne() = default;
-    virtual auto toYaml() const -> YAML::Node;
+    virtual auto toYaml([[maybe_unused]] example_com::store_config const& config) const -> YAML::Node;
     virtual void fromYaml(YAML::Node const& n);
 };
 }
 
-namespace https___example_com_ {
+namespace example_com {
 struct MyRecordTwo
-    : https___example_com_::MyRecordOne {
+    : example_com::MyRecordOne {
     heap_object<int32_t> value;
     ~MyRecordTwo() override = default;
-    auto toYaml() const -> YAML::Node override;
+    auto toYaml([[maybe_unused]] example_com::store_config const& config) const -> YAML::Node override;
     void fromYaml(YAML::Node const& n) override;
 };
 }
 
 template <typename T>
-heap_object<T>::~heap_object() = default;
+example_com::heap_object<T>::~heap_object() = default;
 
-inline auto https___example_com_::MyRecordOne::toYaml() const -> YAML::Node {
-    using ::toYaml;
+inline auto example_com::MyRecordOne::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
+    using ::example_com::toYaml;
     auto n = YAML::Node{};
-    addYamlField(n, "name", toYaml(*name));
+    if (config.generateTags) {
+        n.SetTag("MyRecordOne");
+    }
+    {
+         auto member = toYaml(*name, config);
+         member = convertListToMap(member, "", "", config);
+        addYamlField(n, "name", member);
+    }
     return n;
 }
-inline void https___example_com_::MyRecordOne::fromYaml([[maybe_unused]] YAML::Node const& n) {
-    using ::fromYaml;
-    fromYaml(n["name"], *name);
+inline void example_com::MyRecordOne::fromYaml([[maybe_unused]] YAML::Node const& n) {
+    using ::example_com::fromYaml;
+    {
+        auto nodeAsList = convertMapToList(n["name"], "", "");
+        auto expandedNode = (nodeAsList);
+        fromYaml(expandedNode, *name);
+    }
 }
-
 template <>
-struct DetectAndExtractFromYaml<https___example_com_::MyRecordOne> {
-    auto operator()(YAML::Node const& n) const -> std::optional<https___example_com_::MyRecordOne> {
+struct example_com::DetectAndExtractFromYaml<example_com::MyRecordOne> {
+    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordOne> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = https___example_com_::MyRecordOne{};
+        auto res = example_com::MyRecordOne{};
 
-        if constexpr (IsConstant<decltype(res.name)::value_t>::value) try {
+        if constexpr (::example_com::IsConstant<decltype(res.name)::value_t>::value) try {
             fromYaml(n["name"], *res.name);
             fromYaml(n, res);
             return res;
@@ -308,27 +430,37 @@ struct DetectAndExtractFromYaml<https___example_com_::MyRecordOne> {
         return std::nullopt;
     }
 };
-inline auto https___example_com_::MyRecordTwo::toYaml() const -> YAML::Node {
-    using ::toYaml;
+inline auto example_com::MyRecordTwo::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
+    using ::example_com::toYaml;
     auto n = YAML::Node{};
-    n = mergeYaml(n, https___example_com_::MyRecordOne::toYaml());
-    addYamlField(n, "value", toYaml(*value));
+    if (config.generateTags) {
+        n.SetTag("MyRecordTwo");
+    }
+    n = mergeYaml(n, example_com::MyRecordOne::toYaml(config));
+    {
+         auto member = toYaml(*value, config);
+         member = convertListToMap(member, "", "", config);
+        addYamlField(n, "value", member);
+    }
     return n;
 }
-inline void https___example_com_::MyRecordTwo::fromYaml([[maybe_unused]] YAML::Node const& n) {
-    using ::fromYaml;
-    https___example_com_::MyRecordOne::fromYaml(n);
-    fromYaml(n["value"], *value);
+inline void example_com::MyRecordTwo::fromYaml([[maybe_unused]] YAML::Node const& n) {
+    using ::example_com::fromYaml;
+    example_com::MyRecordOne::fromYaml(n);
+    {
+        auto nodeAsList = convertMapToList(n["value"], "", "");
+        auto expandedNode = (nodeAsList);
+        fromYaml(expandedNode, *value);
+    }
 }
-
 template <>
-struct DetectAndExtractFromYaml<https___example_com_::MyRecordTwo> {
-    auto operator()(YAML::Node const& n) const -> std::optional<https___example_com_::MyRecordTwo> {
+struct example_com::DetectAndExtractFromYaml<example_com::MyRecordTwo> {
+    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordTwo> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = https___example_com_::MyRecordTwo{};
+        auto res = example_com::MyRecordTwo{};
 
-        if constexpr (IsConstant<decltype(res.value)::value_t>::value) try {
+        if constexpr (::example_com::IsConstant<decltype(res.value)::value_t>::value) try {
             fromYaml(n["value"], *res.value);
             fromYaml(n, res);
             return res;
@@ -337,38 +469,39 @@ struct DetectAndExtractFromYaml<https___example_com_::MyRecordTwo> {
         return std::nullopt;
     }
 };
+namespace example_com {
 
 template <typename T>
-auto toYaml(std::vector<T> const& v) -> YAML::Node {
+auto toYaml(std::vector<T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node {
     auto n = YAML::Node(YAML::NodeType::Sequence);
     for (auto const& e : v) {
-        n.push_back(toYaml(e));
+        n.push_back(toYaml(e, config));
     }
     return n;
 }
 
 template <typename T>
-auto toYaml(std::map<std::string, T> const& v) -> YAML::Node {
+auto toYaml(std::map<std::string, T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node {
     auto n = YAML::Node(YAML::NodeType::Map);
     for (auto const& [key, value] : v) {
-        n[key] = toYaml(value);
+        n[key] = toYaml(value, config);
     }
     return n;
 }
 
 template <typename T>
-auto toYaml(T const& t) -> YAML::Node {
+auto toYaml(T const& t, [[maybe_unused]] store_config const& config) -> YAML::Node {
     if constexpr (std::is_enum_v<T>) {
-        return toYaml(t);
+        return toYaml(t, config);
     } else {
-        return t.toYaml();
+        return t.toYaml(config);
     }
 }
 
 template <typename ...Args>
-auto toYaml(std::variant<Args...> const& t) -> YAML::Node {
-    return std::visit([](auto const& e) {
-        return toYaml(e);
+auto toYaml(std::variant<Args...> const& t, store_config const& config) -> YAML::Node {
+    return std::visit([config](auto const& e) {
+        return toYaml(e, config);
     }, t);
 }
 
@@ -429,4 +562,34 @@ template <typename ...Args>
 void fromYaml(YAML::Node const& n, std::variant<Args...>& v){
     bool found = detectAndExtractFromYaml<std::variant<Args...>, Args...>(n, v);
     if (!found) throw std::runtime_error{"didn't find any overload"};
+}
+using DocumentRootType = std::variant<>;
+auto load_document_from_yaml(YAML::Node n) -> DocumentRootType {
+    DocumentRootType root;
+    fromYaml(n, root);
+    return root;
+}
+auto load_document_from_string(std::string document) -> DocumentRootType {
+    return load_document_from_yaml(YAML::Load(document));
+}
+auto load_document(std::filesystem::path path) -> DocumentRootType {
+    return load_document_from_yaml(YAML::LoadFile(path));
+}
+void store_document(DocumentRootType const& root, std::ostream& ostream, store_config config={}) {
+    auto y = toYaml(root, config);
+
+    YAML::Emitter out;
+    out << y;
+    ostream << out.c_str() << std::endl;
+}
+void store_document(DocumentRootType const& root, std::filesystem::path const& path, store_config config={}) {
+    auto ofs = std::ofstream{path};
+    store_document(root, ofs, config);
+}
+auto store_document_as_string(DocumentRootType const& root, store_config config={}) -> std::string {
+    auto ss = std::stringstream{};
+    store_document(root, ss, config);
+    return ss.str();
+}
+
 }

--- a/schema_salad/tests/cpp_tests/03_simple_inheritance.h
+++ b/schema_salad/tests/cpp_tests/03_simple_inheritance.h
@@ -392,8 +392,9 @@ struct MyRecordTwo
 };
 }
 
-template <typename T>
-example_com::heap_object<T>::~heap_object() = default;
+namespace example_com {
+template <typename T> heap_object<T>::~heap_object() = default;
+}
 
 inline auto example_com::MyRecordOne::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
     using ::example_com::toYaml;
@@ -416,12 +417,13 @@ inline void example_com::MyRecordOne::fromYaml([[maybe_unused]] YAML::Node const
         fromYaml(expandedNode, *name);
     }
 }
+namespace example_com {
 template <>
-struct example_com::DetectAndExtractFromYaml<example_com::MyRecordOne> {
-    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordOne> {
+struct DetectAndExtractFromYaml<::example_com::MyRecordOne> {
+    auto operator()(YAML::Node const& n) const -> std::optional<::example_com::MyRecordOne> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = example_com::MyRecordOne{};
+        auto res = ::example_com::MyRecordOne{};
 
         if constexpr (::example_com::IsConstant<decltype(res.name)::value_t>::value) try {
             fromYaml(n["name"], *res.name);
@@ -432,6 +434,7 @@ struct example_com::DetectAndExtractFromYaml<example_com::MyRecordOne> {
         return std::nullopt;
     }
 };
+}
 inline auto example_com::MyRecordTwo::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
     using ::example_com::toYaml;
     auto n = YAML::Node{};
@@ -455,12 +458,13 @@ inline void example_com::MyRecordTwo::fromYaml([[maybe_unused]] YAML::Node const
         fromYaml(expandedNode, *value);
     }
 }
+namespace example_com {
 template <>
-struct example_com::DetectAndExtractFromYaml<example_com::MyRecordTwo> {
-    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordTwo> {
+struct DetectAndExtractFromYaml<::example_com::MyRecordTwo> {
+    auto operator()(YAML::Node const& n) const -> std::optional<::example_com::MyRecordTwo> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = example_com::MyRecordTwo{};
+        auto res = ::example_com::MyRecordTwo{};
 
         if constexpr (::example_com::IsConstant<decltype(res.value)::value_t>::value) try {
             fromYaml(n["value"], *res.value);
@@ -471,6 +475,7 @@ struct example_com::DetectAndExtractFromYaml<example_com::MyRecordTwo> {
         return std::nullopt;
     }
 };
+}
 namespace example_com {
 
 template <typename T>
@@ -575,7 +580,7 @@ auto load_document_from_string(std::string document) -> DocumentRootType {
     return load_document_from_yaml(YAML::Load(document));
 }
 auto load_document(std::filesystem::path path) -> DocumentRootType {
-    return load_document_from_yaml(YAML::LoadFile(path));
+    return load_document_from_yaml(YAML::LoadFile(path.string()));
 }
 void store_document(DocumentRootType const& root, std::ostream& ostream, store_config config={}) {
     auto y = toYaml(root, config);

--- a/schema_salad/tests/cpp_tests/04_abstract_inheritance.h
+++ b/schema_salad/tests/cpp_tests/04_abstract_inheritance.h
@@ -181,7 +181,8 @@ inline void addYamlField(YAML::Node& node, std::string const& key, YAML::Node va
     }
 }
 
-inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std::string const& mapPredicate, store_config const& config) {
+inline auto convertListToMap(YAML::Node list, std::string const& mapSubject,
+                             std::string const& mapPredicate, store_config const& config) {
     if (!config.transformListsToMaps) return list;
     if (mapSubject.empty()) return list;
     if (list.size() == 0) return list;
@@ -197,7 +198,8 @@ inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std
     }
     return map;
 }
-inline auto convertMapToList(YAML::Node map, std::string const& mapSubject, std::string const& mapPredicate) {
+inline auto convertMapToList(YAML::Node map, std::string const& mapSubject,
+                             std::string const& mapPredicate) {
     if (mapSubject.empty()) return map;
     if (!map.IsDefined()) return map;
     if (!map.IsMap()) return map;

--- a/schema_salad/tests/cpp_tests/04_abstract_inheritance.h
+++ b/schema_salad/tests/cpp_tests/04_abstract_inheritance.h
@@ -9,6 +9,8 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <map>
 #include <optional>
 #include <string>
@@ -17,45 +19,123 @@
 #include <vector>
 #include <yaml-cpp/yaml.h>
 
-inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
-    for (auto const& e : n1) {
-        n2[e.first.as<std::string>()] = e.second;
+namespace example_com {
+
+struct store_config {
+    bool simplifyTypes = true;
+    bool transformListsToMaps = true;
+    bool generateTags = false;
+};
+
+inline auto simplifyType(YAML::Node type, store_config const& config) -> YAML::Node {
+    if (!config.simplifyTypes) return type;
+    auto is_optional = [](YAML::Node const & node) {
+        return node.IsSequence() && node.size() == 2u && node[0].Scalar() == "null";
+    };
+
+    auto is_array = [](YAML::Node const & node) {
+        return node.IsMap() && node["type"].Scalar() == "array" && node["items"].IsScalar();
+    };
+
+    // 1. Collapsing optional scalar types into one option
+    if (is_optional(type) && type[1].IsScalar()) {
+        type = type[1].as<std::string>() + "?";
     }
-    return n2;
+
+    // 2. Collapsing array types into one option
+    if (is_array(type)) {
+        type = type["items"].as<std::string>() + "[]";
+    }
+
+    // 3. Collapsing optional array types into one option
+    if (is_optional(type) && is_array(type[1])) {
+        type = type[1]["items"].as<std::string>() + "[]?";
+    }
+
+    return type;
+}
+
+inline auto expandType(YAML::Node type) -> YAML::Node {
+    auto ends_with = [](std::string str, std::string suffix) {
+        if (str.size() < suffix.size()) return false;
+        auto str_suffix = str.substr(str.size()-suffix.size(), suffix.size());
+        return str_suffix == suffix;
+    };
+
+    // 0. If not a scalar type, nothing to do
+    if (!type.IsDefined() || !type.IsScalar()) {
+        return type;
+    }
+
+    auto str = type.as<std::string>();
+    // 1. Check if optional array type and expand
+    if (ends_with(str, "[]?")) {
+        auto result = YAML::Node{};
+        result.push_back(YAML::Node{"null"});
+        auto array = YAML::Node{};
+        array["type"] = "array";
+        array["items"] = expandType(YAML::Node(str.substr(0, str.size()-3)));
+        result.push_back(array);
+        return result;
+    }
+
+    // 2. Expand array
+    if (ends_with(str, "[]")) {
+        auto array = YAML::Node{};
+        array["type"] = "array";
+        array["items"] = expandType(YAML::Node(str.substr(0, str.size()-2)));
+        return array;
+    }
+
+    // 3. Expand optional scalar type
+    if (ends_with(str, "?")) {
+        auto result = YAML::Node{};
+        result.push_back(YAML::Node{"null"});
+        result.push_back(expandType(YAML::Node(str.substr(0, str.size()-1))));
+        return result;
+    }
+    return type;
+}
+
+inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
+    for (auto const& e : n2) {
+        n1[e.first.as<std::string>()] = e.second;
+    }
+    return n1;
 }
 
 // declaring toYaml
-inline auto toYaml(bool v) { return YAML::Node{v}; }
-inline auto toYaml(float v) { return YAML::Node{v}; }
-inline auto toYaml(double v) { return YAML::Node{v}; }
-inline auto toYaml(char v) { return YAML::Node{v}; }
-inline auto toYaml(int8_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint8_t v) { return YAML::Node{v}; }
-inline auto toYaml(int16_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint16_t v) { return YAML::Node{v}; }
-inline auto toYaml(int32_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint32_t v) { return YAML::Node{v}; }
-inline auto toYaml(int64_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint64_t v) { return YAML::Node{v}; }
-inline auto toYaml(std::monostate const&) {
+inline auto toYaml(bool v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(float v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(double v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(char v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int8_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint8_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int16_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint16_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int32_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint32_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int64_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint64_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(std::monostate const&, [[maybe_unused]] store_config const&) {
     return YAML::Node(YAML::NodeType::Undefined);
 }
-inline auto toYaml(std::string const& v) {
+inline auto toYaml(std::string const& v, [[maybe_unused]] store_config const&) {
     return YAML::Node{v};
 }
 
 template <typename T, typename ...Args>
-auto anyToYaml_impl(std::any const& a) {
+auto anyToYaml_impl(std::any const& a, [[maybe_unused]] store_config const& config) {
     if (auto v = std::any_cast<T const>(&a)) {
-        return toYaml(*v);
+        return toYaml(*v, config);
     }
     if constexpr (sizeof...(Args) > 0) {
-        return anyToYaml_impl<Args...>(a);
+        return anyToYaml_impl<Args...>(a, config);
     }
-    return toYaml(std::monostate{});
+    return toYaml(std::monostate{}, config);
 }
 
-inline auto toYaml(std::any const& a) {
+inline auto toYaml(std::any const& a, [[maybe_unused]] store_config const& config) {
     return anyToYaml_impl<bool,
                           float,
                           double,
@@ -68,7 +148,7 @@ inline auto toYaml(std::any const& a) {
                           uint32_t,
                           int64_t,
                           uint64_t,
-                          std::string>(a);
+                          std::string>(a, config);
 }
 
 // declaring fromYaml
@@ -101,23 +181,37 @@ inline void addYamlField(YAML::Node& node, std::string const& key, YAML::Node va
     }
 }
 
-inline auto convertListToMap(YAML::Node list, std::string const& key_name) {
+inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std::string const& mapPredicate, store_config const& config) {
+    if (!config.transformListsToMaps) return list;
+    if (mapSubject.empty()) return list;
     if (list.size() == 0) return list;
     auto map = YAML::Node{};
     for (YAML::Node n : list) {
-        auto key = n[key_name].as<std::string>();
-        n.remove(key_name);
-        map[key] = n;
+        auto key = n[mapSubject].as<std::string>();
+        if (mapPredicate.empty() || n[mapPredicate].IsMap() || n.size() > 2) {
+            n.remove(mapSubject);
+            map[key] = n;
+        } else {
+            map[key] = n[mapPredicate];
+        }
     }
     return map;
 }
-inline auto convertMapToList(YAML::Node map, std::string const& key_name) {
+inline auto convertMapToList(YAML::Node map, std::string const& mapSubject, std::string const& mapPredicate) {
+    if (mapSubject.empty()) return map;
     if (!map.IsDefined()) return map;
     if (!map.IsMap()) return map;
     auto list = YAML::Node{};
     for (auto n : map) {
-        n.second[key_name] = n.first;
-        list.push_back(n.second);
+        if (mapPredicate.empty() || n.second.IsMap()) {
+            n.second[mapSubject] = n.first;
+            list.push_back(n.second);
+        } else {
+            auto n2 = YAML::Node{};
+            n2[mapSubject] = n.first;
+            n2[mapPredicate] = n.second;
+            list.push_back(n2);
+        }
     }
     return list;
 }
@@ -126,13 +220,13 @@ template <typename T> struct IsConstant : std::false_type {};
 
 // fwd declaring toYaml
 template <typename T>
-auto toYaml(std::vector<T> const& v) -> YAML::Node;
+auto toYaml(std::vector<T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename T>
-auto toYaml(std::map<std::string, T> const& v) -> YAML::Node;
+auto toYaml(std::map<std::string, T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename T>
-auto toYaml(T const& t) -> YAML::Node;
+auto toYaml(T const& t, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename ...Args>
-auto toYaml(std::variant<Args...> const& t) -> YAML::Node;
+auto toYaml(std::variant<Args...> const& t, [[maybe_unused]] store_config const& config) -> YAML::Node;
 
 // fwd declaring fromYaml
 template <typename T>
@@ -150,6 +244,23 @@ struct DetectAndExtractFromYaml {
         return std::nullopt;
     }
 };
+
+// special cwl expression string
+struct cwl_expression_string {
+    std::string s;
+
+    auto toYaml([[maybe_unused]] store_config const& config) const {
+        auto n = YAML::Node{s};
+        if (config.generateTags) {
+            n.SetTag("Expression");
+        }
+        return n;
+    }
+    void fromYaml(YAML::Node const& n) {
+        s = n.as<std::string>();
+    }
+};
+
 
 template <>
 struct DetectAndExtractFromYaml<std::monostate> {
@@ -257,62 +368,84 @@ public:
     }
 };
 
-namespace https___example_com_ { struct MyRecordOne; }
-namespace https___example_com_ { struct MyRecordTwo; }
-namespace https___example_com_ {
+}
+namespace example_com { struct MyRecordOne; }
+namespace example_com { struct MyRecordTwo; }
+namespace example_com {
 struct MyRecordOne {
     heap_object<std::string> name;
     virtual ~MyRecordOne() = 0;
-    virtual auto toYaml() const -> YAML::Node;
+    virtual auto toYaml([[maybe_unused]] example_com::store_config const& config) const -> YAML::Node;
     virtual void fromYaml(YAML::Node const& n);
 };
 }
 
-namespace https___example_com_ {
+namespace example_com {
 struct MyRecordTwo
-    : https___example_com_::MyRecordOne {
+    : example_com::MyRecordOne {
     heap_object<int32_t> value;
     ~MyRecordTwo() override = default;
-    auto toYaml() const -> YAML::Node override;
+    auto toYaml([[maybe_unused]] example_com::store_config const& config) const -> YAML::Node override;
     void fromYaml(YAML::Node const& n) override;
 };
 }
 
 template <typename T>
-heap_object<T>::~heap_object() = default;
+example_com::heap_object<T>::~heap_object() = default;
 
-inline https___example_com_::MyRecordOne::~MyRecordOne() = default;
-inline auto https___example_com_::MyRecordOne::toYaml() const -> YAML::Node {
-    using ::toYaml;
+inline example_com::MyRecordOne::~MyRecordOne() = default;
+inline auto example_com::MyRecordOne::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
+    using ::example_com::toYaml;
     auto n = YAML::Node{};
-    addYamlField(n, "name", toYaml(*name));
+    if (config.generateTags) {
+        n.SetTag("MyRecordOne");
+    }
+    {
+         auto member = toYaml(*name, config);
+         member = convertListToMap(member, "", "", config);
+        addYamlField(n, "name", member);
+    }
     return n;
 }
-inline void https___example_com_::MyRecordOne::fromYaml([[maybe_unused]] YAML::Node const& n) {
-    using ::fromYaml;
-    fromYaml(n["name"], *name);
+inline void example_com::MyRecordOne::fromYaml([[maybe_unused]] YAML::Node const& n) {
+    using ::example_com::fromYaml;
+    {
+        auto nodeAsList = convertMapToList(n["name"], "", "");
+        auto expandedNode = (nodeAsList);
+        fromYaml(expandedNode, *name);
+    }
 }
-inline auto https___example_com_::MyRecordTwo::toYaml() const -> YAML::Node {
-    using ::toYaml;
+inline auto example_com::MyRecordTwo::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
+    using ::example_com::toYaml;
     auto n = YAML::Node{};
-    n = mergeYaml(n, https___example_com_::MyRecordOne::toYaml());
-    addYamlField(n, "value", toYaml(*value));
+    if (config.generateTags) {
+        n.SetTag("MyRecordTwo");
+    }
+    n = mergeYaml(n, example_com::MyRecordOne::toYaml(config));
+    {
+         auto member = toYaml(*value, config);
+         member = convertListToMap(member, "", "", config);
+        addYamlField(n, "value", member);
+    }
     return n;
 }
-inline void https___example_com_::MyRecordTwo::fromYaml([[maybe_unused]] YAML::Node const& n) {
-    using ::fromYaml;
-    https___example_com_::MyRecordOne::fromYaml(n);
-    fromYaml(n["value"], *value);
+inline void example_com::MyRecordTwo::fromYaml([[maybe_unused]] YAML::Node const& n) {
+    using ::example_com::fromYaml;
+    example_com::MyRecordOne::fromYaml(n);
+    {
+        auto nodeAsList = convertMapToList(n["value"], "", "");
+        auto expandedNode = (nodeAsList);
+        fromYaml(expandedNode, *value);
+    }
 }
-
 template <>
-struct DetectAndExtractFromYaml<https___example_com_::MyRecordTwo> {
-    auto operator()(YAML::Node const& n) const -> std::optional<https___example_com_::MyRecordTwo> {
+struct example_com::DetectAndExtractFromYaml<example_com::MyRecordTwo> {
+    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordTwo> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = https___example_com_::MyRecordTwo{};
+        auto res = example_com::MyRecordTwo{};
 
-        if constexpr (IsConstant<decltype(res.value)::value_t>::value) try {
+        if constexpr (::example_com::IsConstant<decltype(res.value)::value_t>::value) try {
             fromYaml(n["value"], *res.value);
             fromYaml(n, res);
             return res;
@@ -321,38 +454,39 @@ struct DetectAndExtractFromYaml<https___example_com_::MyRecordTwo> {
         return std::nullopt;
     }
 };
+namespace example_com {
 
 template <typename T>
-auto toYaml(std::vector<T> const& v) -> YAML::Node {
+auto toYaml(std::vector<T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node {
     auto n = YAML::Node(YAML::NodeType::Sequence);
     for (auto const& e : v) {
-        n.push_back(toYaml(e));
+        n.push_back(toYaml(e, config));
     }
     return n;
 }
 
 template <typename T>
-auto toYaml(std::map<std::string, T> const& v) -> YAML::Node {
+auto toYaml(std::map<std::string, T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node {
     auto n = YAML::Node(YAML::NodeType::Map);
     for (auto const& [key, value] : v) {
-        n[key] = toYaml(value);
+        n[key] = toYaml(value, config);
     }
     return n;
 }
 
 template <typename T>
-auto toYaml(T const& t) -> YAML::Node {
+auto toYaml(T const& t, [[maybe_unused]] store_config const& config) -> YAML::Node {
     if constexpr (std::is_enum_v<T>) {
-        return toYaml(t);
+        return toYaml(t, config);
     } else {
-        return t.toYaml();
+        return t.toYaml(config);
     }
 }
 
 template <typename ...Args>
-auto toYaml(std::variant<Args...> const& t) -> YAML::Node {
-    return std::visit([](auto const& e) {
-        return toYaml(e);
+auto toYaml(std::variant<Args...> const& t, store_config const& config) -> YAML::Node {
+    return std::visit([config](auto const& e) {
+        return toYaml(e, config);
     }, t);
 }
 
@@ -413,4 +547,34 @@ template <typename ...Args>
 void fromYaml(YAML::Node const& n, std::variant<Args...>& v){
     bool found = detectAndExtractFromYaml<std::variant<Args...>, Args...>(n, v);
     if (!found) throw std::runtime_error{"didn't find any overload"};
+}
+using DocumentRootType = std::variant<>;
+auto load_document_from_yaml(YAML::Node n) -> DocumentRootType {
+    DocumentRootType root;
+    fromYaml(n, root);
+    return root;
+}
+auto load_document_from_string(std::string document) -> DocumentRootType {
+    return load_document_from_yaml(YAML::Load(document));
+}
+auto load_document(std::filesystem::path path) -> DocumentRootType {
+    return load_document_from_yaml(YAML::LoadFile(path));
+}
+void store_document(DocumentRootType const& root, std::ostream& ostream, store_config config={}) {
+    auto y = toYaml(root, config);
+
+    YAML::Emitter out;
+    out << y;
+    ostream << out.c_str() << std::endl;
+}
+void store_document(DocumentRootType const& root, std::filesystem::path const& path, store_config config={}) {
+    auto ofs = std::ofstream{path};
+    store_document(root, ofs, config);
+}
+auto store_document_as_string(DocumentRootType const& root, store_config config={}) -> std::string {
+    auto ss = std::stringstream{};
+    store_document(root, ss, config);
+    return ss.str();
+}
+
 }

--- a/schema_salad/tests/cpp_tests/04_abstract_inheritance.h
+++ b/schema_salad/tests/cpp_tests/04_abstract_inheritance.h
@@ -392,8 +392,9 @@ struct MyRecordTwo
 };
 }
 
-template <typename T>
-example_com::heap_object<T>::~heap_object() = default;
+namespace example_com {
+template <typename T> heap_object<T>::~heap_object() = default;
+}
 
 inline example_com::MyRecordOne::~MyRecordOne() = default;
 inline auto example_com::MyRecordOne::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
@@ -440,12 +441,13 @@ inline void example_com::MyRecordTwo::fromYaml([[maybe_unused]] YAML::Node const
         fromYaml(expandedNode, *value);
     }
 }
+namespace example_com {
 template <>
-struct example_com::DetectAndExtractFromYaml<example_com::MyRecordTwo> {
-    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordTwo> {
+struct DetectAndExtractFromYaml<::example_com::MyRecordTwo> {
+    auto operator()(YAML::Node const& n) const -> std::optional<::example_com::MyRecordTwo> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = example_com::MyRecordTwo{};
+        auto res = ::example_com::MyRecordTwo{};
 
         if constexpr (::example_com::IsConstant<decltype(res.value)::value_t>::value) try {
             fromYaml(n["value"], *res.value);
@@ -456,6 +458,7 @@ struct example_com::DetectAndExtractFromYaml<example_com::MyRecordTwo> {
         return std::nullopt;
     }
 };
+}
 namespace example_com {
 
 template <typename T>
@@ -560,7 +563,7 @@ auto load_document_from_string(std::string document) -> DocumentRootType {
     return load_document_from_yaml(YAML::Load(document));
 }
 auto load_document(std::filesystem::path path) -> DocumentRootType {
-    return load_document_from_yaml(YAML::LoadFile(path));
+    return load_document_from_yaml(YAML::LoadFile(path.string()));
 }
 void store_document(DocumentRootType const& root, std::ostream& ostream, store_config config={}) {
     auto y = toYaml(root, config);

--- a/schema_salad/tests/cpp_tests/05_specialization.h
+++ b/schema_salad/tests/cpp_tests/05_specialization.h
@@ -181,7 +181,8 @@ inline void addYamlField(YAML::Node& node, std::string const& key, YAML::Node va
     }
 }
 
-inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std::string const& mapPredicate, store_config const& config) {
+inline auto convertListToMap(YAML::Node list, std::string const& mapSubject,
+                             std::string const& mapPredicate, store_config const& config) {
     if (!config.transformListsToMaps) return list;
     if (mapSubject.empty()) return list;
     if (list.size() == 0) return list;
@@ -197,7 +198,8 @@ inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std
     }
     return map;
 }
-inline auto convertMapToList(YAML::Node map, std::string const& mapSubject, std::string const& mapPredicate) {
+inline auto convertMapToList(YAML::Node map, std::string const& mapSubject,
+                             std::string const& mapPredicate) {
     if (mapSubject.empty()) return map;
     if (!map.IsDefined()) return map;
     if (!map.IsMap()) return map;

--- a/schema_salad/tests/cpp_tests/05_specialization.h
+++ b/schema_salad/tests/cpp_tests/05_specialization.h
@@ -410,8 +410,9 @@ struct MyRecordTwo {
 };
 }
 
-template <typename T>
-example_com::heap_object<T>::~heap_object() = default;
+namespace example_com {
+template <typename T> heap_object<T>::~heap_object() = default;
+}
 
 inline auto example_com::FieldRecordA::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
     using ::example_com::toYaml;
@@ -424,16 +425,18 @@ inline auto example_com::FieldRecordA::toYaml([[maybe_unused]] ::example_com::st
 inline void example_com::FieldRecordA::fromYaml([[maybe_unused]] YAML::Node const& n) {
     using ::example_com::fromYaml;
 }
+namespace example_com {
 template <>
-struct example_com::DetectAndExtractFromYaml<example_com::FieldRecordA> {
-    auto operator()(YAML::Node const& n) const -> std::optional<example_com::FieldRecordA> {
+struct DetectAndExtractFromYaml<::example_com::FieldRecordA> {
+    auto operator()(YAML::Node const& n) const -> std::optional<::example_com::FieldRecordA> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = example_com::FieldRecordA{};
+        auto res = ::example_com::FieldRecordA{};
 
         return std::nullopt;
     }
 };
+}
 inline auto example_com::FieldRecordB::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
     using ::example_com::toYaml;
     auto n = YAML::Node{};
@@ -445,16 +448,18 @@ inline auto example_com::FieldRecordB::toYaml([[maybe_unused]] ::example_com::st
 inline void example_com::FieldRecordB::fromYaml([[maybe_unused]] YAML::Node const& n) {
     using ::example_com::fromYaml;
 }
+namespace example_com {
 template <>
-struct example_com::DetectAndExtractFromYaml<example_com::FieldRecordB> {
-    auto operator()(YAML::Node const& n) const -> std::optional<example_com::FieldRecordB> {
+struct DetectAndExtractFromYaml<::example_com::FieldRecordB> {
+    auto operator()(YAML::Node const& n) const -> std::optional<::example_com::FieldRecordB> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = example_com::FieldRecordB{};
+        auto res = ::example_com::FieldRecordB{};
 
         return std::nullopt;
     }
 };
+}
 inline auto example_com::MyRecordOne::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
     using ::example_com::toYaml;
     auto n = YAML::Node{};
@@ -476,12 +481,13 @@ inline void example_com::MyRecordOne::fromYaml([[maybe_unused]] YAML::Node const
         fromYaml(expandedNode, *name);
     }
 }
+namespace example_com {
 template <>
-struct example_com::DetectAndExtractFromYaml<example_com::MyRecordOne> {
-    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordOne> {
+struct DetectAndExtractFromYaml<::example_com::MyRecordOne> {
+    auto operator()(YAML::Node const& n) const -> std::optional<::example_com::MyRecordOne> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = example_com::MyRecordOne{};
+        auto res = ::example_com::MyRecordOne{};
 
         if constexpr (::example_com::IsConstant<decltype(res.name)::value_t>::value) try {
             fromYaml(n["name"], *res.name);
@@ -492,6 +498,7 @@ struct example_com::DetectAndExtractFromYaml<example_com::MyRecordOne> {
         return std::nullopt;
     }
 };
+}
 inline auto example_com::MyRecordTwo::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
     using ::example_com::toYaml;
     auto n = YAML::Node{};
@@ -523,12 +530,13 @@ inline void example_com::MyRecordTwo::fromYaml([[maybe_unused]] YAML::Node const
         fromYaml(expandedNode, *value);
     }
 }
+namespace example_com {
 template <>
-struct example_com::DetectAndExtractFromYaml<example_com::MyRecordTwo> {
-    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordTwo> {
+struct DetectAndExtractFromYaml<::example_com::MyRecordTwo> {
+    auto operator()(YAML::Node const& n) const -> std::optional<::example_com::MyRecordTwo> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = example_com::MyRecordTwo{};
+        auto res = ::example_com::MyRecordTwo{};
 
         if constexpr (::example_com::IsConstant<decltype(res.name)::value_t>::value) try {
             fromYaml(n["name"], *res.name);
@@ -545,6 +553,7 @@ struct example_com::DetectAndExtractFromYaml<example_com::MyRecordTwo> {
         return std::nullopt;
     }
 };
+}
 namespace example_com {
 
 template <typename T>
@@ -649,7 +658,7 @@ auto load_document_from_string(std::string document) -> DocumentRootType {
     return load_document_from_yaml(YAML::Load(document));
 }
 auto load_document(std::filesystem::path path) -> DocumentRootType {
-    return load_document_from_yaml(YAML::LoadFile(path));
+    return load_document_from_yaml(YAML::LoadFile(path.string()));
 }
 void store_document(DocumentRootType const& root, std::ostream& ostream, store_config config={}) {
     auto y = toYaml(root, config);

--- a/schema_salad/tests/cpp_tests/05_specialization.h
+++ b/schema_salad/tests/cpp_tests/05_specialization.h
@@ -9,6 +9,8 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <map>
 #include <optional>
 #include <string>
@@ -17,45 +19,123 @@
 #include <vector>
 #include <yaml-cpp/yaml.h>
 
-inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
-    for (auto const& e : n1) {
-        n2[e.first.as<std::string>()] = e.second;
+namespace example_com {
+
+struct store_config {
+    bool simplifyTypes = true;
+    bool transformListsToMaps = true;
+    bool generateTags = false;
+};
+
+inline auto simplifyType(YAML::Node type, store_config const& config) -> YAML::Node {
+    if (!config.simplifyTypes) return type;
+    auto is_optional = [](YAML::Node const & node) {
+        return node.IsSequence() && node.size() == 2u && node[0].Scalar() == "null";
+    };
+
+    auto is_array = [](YAML::Node const & node) {
+        return node.IsMap() && node["type"].Scalar() == "array" && node["items"].IsScalar();
+    };
+
+    // 1. Collapsing optional scalar types into one option
+    if (is_optional(type) && type[1].IsScalar()) {
+        type = type[1].as<std::string>() + "?";
     }
-    return n2;
+
+    // 2. Collapsing array types into one option
+    if (is_array(type)) {
+        type = type["items"].as<std::string>() + "[]";
+    }
+
+    // 3. Collapsing optional array types into one option
+    if (is_optional(type) && is_array(type[1])) {
+        type = type[1]["items"].as<std::string>() + "[]?";
+    }
+
+    return type;
+}
+
+inline auto expandType(YAML::Node type) -> YAML::Node {
+    auto ends_with = [](std::string str, std::string suffix) {
+        if (str.size() < suffix.size()) return false;
+        auto str_suffix = str.substr(str.size()-suffix.size(), suffix.size());
+        return str_suffix == suffix;
+    };
+
+    // 0. If not a scalar type, nothing to do
+    if (!type.IsDefined() || !type.IsScalar()) {
+        return type;
+    }
+
+    auto str = type.as<std::string>();
+    // 1. Check if optional array type and expand
+    if (ends_with(str, "[]?")) {
+        auto result = YAML::Node{};
+        result.push_back(YAML::Node{"null"});
+        auto array = YAML::Node{};
+        array["type"] = "array";
+        array["items"] = expandType(YAML::Node(str.substr(0, str.size()-3)));
+        result.push_back(array);
+        return result;
+    }
+
+    // 2. Expand array
+    if (ends_with(str, "[]")) {
+        auto array = YAML::Node{};
+        array["type"] = "array";
+        array["items"] = expandType(YAML::Node(str.substr(0, str.size()-2)));
+        return array;
+    }
+
+    // 3. Expand optional scalar type
+    if (ends_with(str, "?")) {
+        auto result = YAML::Node{};
+        result.push_back(YAML::Node{"null"});
+        result.push_back(expandType(YAML::Node(str.substr(0, str.size()-1))));
+        return result;
+    }
+    return type;
+}
+
+inline auto mergeYaml(YAML::Node n1, YAML::Node n2) {
+    for (auto const& e : n2) {
+        n1[e.first.as<std::string>()] = e.second;
+    }
+    return n1;
 }
 
 // declaring toYaml
-inline auto toYaml(bool v) { return YAML::Node{v}; }
-inline auto toYaml(float v) { return YAML::Node{v}; }
-inline auto toYaml(double v) { return YAML::Node{v}; }
-inline auto toYaml(char v) { return YAML::Node{v}; }
-inline auto toYaml(int8_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint8_t v) { return YAML::Node{v}; }
-inline auto toYaml(int16_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint16_t v) { return YAML::Node{v}; }
-inline auto toYaml(int32_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint32_t v) { return YAML::Node{v}; }
-inline auto toYaml(int64_t v) { return YAML::Node{v}; }
-inline auto toYaml(uint64_t v) { return YAML::Node{v}; }
-inline auto toYaml(std::monostate const&) {
+inline auto toYaml(bool v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(float v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(double v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(char v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int8_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint8_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int16_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint16_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int32_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint32_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(int64_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(uint64_t v, [[maybe_unused]] store_config const&) { return YAML::Node{v}; }
+inline auto toYaml(std::monostate const&, [[maybe_unused]] store_config const&) {
     return YAML::Node(YAML::NodeType::Undefined);
 }
-inline auto toYaml(std::string const& v) {
+inline auto toYaml(std::string const& v, [[maybe_unused]] store_config const&) {
     return YAML::Node{v};
 }
 
 template <typename T, typename ...Args>
-auto anyToYaml_impl(std::any const& a) {
+auto anyToYaml_impl(std::any const& a, [[maybe_unused]] store_config const& config) {
     if (auto v = std::any_cast<T const>(&a)) {
-        return toYaml(*v);
+        return toYaml(*v, config);
     }
     if constexpr (sizeof...(Args) > 0) {
-        return anyToYaml_impl<Args...>(a);
+        return anyToYaml_impl<Args...>(a, config);
     }
-    return toYaml(std::monostate{});
+    return toYaml(std::monostate{}, config);
 }
 
-inline auto toYaml(std::any const& a) {
+inline auto toYaml(std::any const& a, [[maybe_unused]] store_config const& config) {
     return anyToYaml_impl<bool,
                           float,
                           double,
@@ -68,7 +148,7 @@ inline auto toYaml(std::any const& a) {
                           uint32_t,
                           int64_t,
                           uint64_t,
-                          std::string>(a);
+                          std::string>(a, config);
 }
 
 // declaring fromYaml
@@ -101,23 +181,37 @@ inline void addYamlField(YAML::Node& node, std::string const& key, YAML::Node va
     }
 }
 
-inline auto convertListToMap(YAML::Node list, std::string const& key_name) {
+inline auto convertListToMap(YAML::Node list, std::string const& mapSubject, std::string const& mapPredicate, store_config const& config) {
+    if (!config.transformListsToMaps) return list;
+    if (mapSubject.empty()) return list;
     if (list.size() == 0) return list;
     auto map = YAML::Node{};
     for (YAML::Node n : list) {
-        auto key = n[key_name].as<std::string>();
-        n.remove(key_name);
-        map[key] = n;
+        auto key = n[mapSubject].as<std::string>();
+        if (mapPredicate.empty() || n[mapPredicate].IsMap() || n.size() > 2) {
+            n.remove(mapSubject);
+            map[key] = n;
+        } else {
+            map[key] = n[mapPredicate];
+        }
     }
     return map;
 }
-inline auto convertMapToList(YAML::Node map, std::string const& key_name) {
+inline auto convertMapToList(YAML::Node map, std::string const& mapSubject, std::string const& mapPredicate) {
+    if (mapSubject.empty()) return map;
     if (!map.IsDefined()) return map;
     if (!map.IsMap()) return map;
     auto list = YAML::Node{};
     for (auto n : map) {
-        n.second[key_name] = n.first;
-        list.push_back(n.second);
+        if (mapPredicate.empty() || n.second.IsMap()) {
+            n.second[mapSubject] = n.first;
+            list.push_back(n.second);
+        } else {
+            auto n2 = YAML::Node{};
+            n2[mapSubject] = n.first;
+            n2[mapPredicate] = n.second;
+            list.push_back(n2);
+        }
     }
     return list;
 }
@@ -126,13 +220,13 @@ template <typename T> struct IsConstant : std::false_type {};
 
 // fwd declaring toYaml
 template <typename T>
-auto toYaml(std::vector<T> const& v) -> YAML::Node;
+auto toYaml(std::vector<T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename T>
-auto toYaml(std::map<std::string, T> const& v) -> YAML::Node;
+auto toYaml(std::map<std::string, T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename T>
-auto toYaml(T const& t) -> YAML::Node;
+auto toYaml(T const& t, [[maybe_unused]] store_config const& config) -> YAML::Node;
 template <typename ...Args>
-auto toYaml(std::variant<Args...> const& t) -> YAML::Node;
+auto toYaml(std::variant<Args...> const& t, [[maybe_unused]] store_config const& config) -> YAML::Node;
 
 // fwd declaring fromYaml
 template <typename T>
@@ -150,6 +244,23 @@ struct DetectAndExtractFromYaml {
         return std::nullopt;
     }
 };
+
+// special cwl expression string
+struct cwl_expression_string {
+    std::string s;
+
+    auto toYaml([[maybe_unused]] store_config const& config) const {
+        auto n = YAML::Node{s};
+        if (config.generateTags) {
+            n.SetTag("Expression");
+        }
+        return n;
+    }
+    void fromYaml(YAML::Node const& n) {
+        s = n.as<std::string>();
+    }
+};
+
 
 template <>
 struct DetectAndExtractFromYaml<std::monostate> {
@@ -257,105 +368,120 @@ public:
     }
 };
 
-namespace https___example_com_ { struct FieldRecordA; }
-namespace https___example_com_ { struct FieldRecordB; }
-namespace https___example_com_ { struct MyRecordOne; }
-namespace https___example_com_ { struct MyRecordTwo; }
-namespace https___example_com_ {
+}
+namespace example_com { struct FieldRecordA; }
+namespace example_com { struct FieldRecordB; }
+namespace example_com { struct MyRecordOne; }
+namespace example_com { struct MyRecordTwo; }
+namespace example_com {
 struct FieldRecordA {
     virtual ~FieldRecordA() = default;
-    virtual auto toYaml() const -> YAML::Node;
+    virtual auto toYaml([[maybe_unused]] example_com::store_config const& config) const -> YAML::Node;
     virtual void fromYaml(YAML::Node const& n);
 };
 }
 
-namespace https___example_com_ {
+namespace example_com {
 struct FieldRecordB {
     virtual ~FieldRecordB() = default;
-    virtual auto toYaml() const -> YAML::Node;
+    virtual auto toYaml([[maybe_unused]] example_com::store_config const& config) const -> YAML::Node;
     virtual void fromYaml(YAML::Node const& n);
 };
 }
 
-namespace https___example_com_ {
+namespace example_com {
 struct MyRecordOne {
     heap_object<FieldRecordA> name;
     virtual ~MyRecordOne() = default;
-    virtual auto toYaml() const -> YAML::Node;
+    virtual auto toYaml([[maybe_unused]] example_com::store_config const& config) const -> YAML::Node;
     virtual void fromYaml(YAML::Node const& n);
 };
 }
 
-namespace https___example_com_ {
+namespace example_com {
 struct MyRecordTwo {
     heap_object<FieldRecordB> name;
     heap_object<int32_t> value;
     virtual ~MyRecordTwo() = default;
-    virtual auto toYaml() const -> YAML::Node;
+    virtual auto toYaml([[maybe_unused]] example_com::store_config const& config) const -> YAML::Node;
     virtual void fromYaml(YAML::Node const& n);
 };
 }
 
 template <typename T>
-heap_object<T>::~heap_object() = default;
+example_com::heap_object<T>::~heap_object() = default;
 
-inline auto https___example_com_::FieldRecordA::toYaml() const -> YAML::Node {
-    using ::toYaml;
+inline auto example_com::FieldRecordA::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
+    using ::example_com::toYaml;
     auto n = YAML::Node{};
+    if (config.generateTags) {
+        n.SetTag("FieldRecordA");
+    }
     return n;
 }
-inline void https___example_com_::FieldRecordA::fromYaml([[maybe_unused]] YAML::Node const& n) {
-    using ::fromYaml;
+inline void example_com::FieldRecordA::fromYaml([[maybe_unused]] YAML::Node const& n) {
+    using ::example_com::fromYaml;
 }
-
 template <>
-struct DetectAndExtractFromYaml<https___example_com_::FieldRecordA> {
-    auto operator()(YAML::Node const& n) const -> std::optional<https___example_com_::FieldRecordA> {
+struct example_com::DetectAndExtractFromYaml<example_com::FieldRecordA> {
+    auto operator()(YAML::Node const& n) const -> std::optional<example_com::FieldRecordA> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = https___example_com_::FieldRecordA{};
+        auto res = example_com::FieldRecordA{};
 
         return std::nullopt;
     }
 };
-inline auto https___example_com_::FieldRecordB::toYaml() const -> YAML::Node {
-    using ::toYaml;
+inline auto example_com::FieldRecordB::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
+    using ::example_com::toYaml;
     auto n = YAML::Node{};
+    if (config.generateTags) {
+        n.SetTag("FieldRecordB");
+    }
     return n;
 }
-inline void https___example_com_::FieldRecordB::fromYaml([[maybe_unused]] YAML::Node const& n) {
-    using ::fromYaml;
+inline void example_com::FieldRecordB::fromYaml([[maybe_unused]] YAML::Node const& n) {
+    using ::example_com::fromYaml;
 }
-
 template <>
-struct DetectAndExtractFromYaml<https___example_com_::FieldRecordB> {
-    auto operator()(YAML::Node const& n) const -> std::optional<https___example_com_::FieldRecordB> {
+struct example_com::DetectAndExtractFromYaml<example_com::FieldRecordB> {
+    auto operator()(YAML::Node const& n) const -> std::optional<example_com::FieldRecordB> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = https___example_com_::FieldRecordB{};
+        auto res = example_com::FieldRecordB{};
 
         return std::nullopt;
     }
 };
-inline auto https___example_com_::MyRecordOne::toYaml() const -> YAML::Node {
-    using ::toYaml;
+inline auto example_com::MyRecordOne::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
+    using ::example_com::toYaml;
     auto n = YAML::Node{};
-    addYamlField(n, "name", toYaml(*name));
+    if (config.generateTags) {
+        n.SetTag("MyRecordOne");
+    }
+    {
+         auto member = toYaml(*name, config);
+         member = convertListToMap(member, "", "", config);
+        addYamlField(n, "name", member);
+    }
     return n;
 }
-inline void https___example_com_::MyRecordOne::fromYaml([[maybe_unused]] YAML::Node const& n) {
-    using ::fromYaml;
-    fromYaml(n["name"], *name);
+inline void example_com::MyRecordOne::fromYaml([[maybe_unused]] YAML::Node const& n) {
+    using ::example_com::fromYaml;
+    {
+        auto nodeAsList = convertMapToList(n["name"], "", "");
+        auto expandedNode = (nodeAsList);
+        fromYaml(expandedNode, *name);
+    }
 }
-
 template <>
-struct DetectAndExtractFromYaml<https___example_com_::MyRecordOne> {
-    auto operator()(YAML::Node const& n) const -> std::optional<https___example_com_::MyRecordOne> {
+struct example_com::DetectAndExtractFromYaml<example_com::MyRecordOne> {
+    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordOne> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = https___example_com_::MyRecordOne{};
+        auto res = example_com::MyRecordOne{};
 
-        if constexpr (IsConstant<decltype(res.name)::value_t>::value) try {
+        if constexpr (::example_com::IsConstant<decltype(res.name)::value_t>::value) try {
             fromYaml(n["name"], *res.name);
             fromYaml(n, res);
             return res;
@@ -364,33 +490,51 @@ struct DetectAndExtractFromYaml<https___example_com_::MyRecordOne> {
         return std::nullopt;
     }
 };
-inline auto https___example_com_::MyRecordTwo::toYaml() const -> YAML::Node {
-    using ::toYaml;
+inline auto example_com::MyRecordTwo::toYaml([[maybe_unused]] ::example_com::store_config const& config) const -> YAML::Node {
+    using ::example_com::toYaml;
     auto n = YAML::Node{};
-    addYamlField(n, "name", toYaml(*name));
-    addYamlField(n, "value", toYaml(*value));
+    if (config.generateTags) {
+        n.SetTag("MyRecordTwo");
+    }
+    {
+         auto member = toYaml(*name, config);
+         member = convertListToMap(member, "", "", config);
+        addYamlField(n, "name", member);
+    }
+    {
+         auto member = toYaml(*value, config);
+         member = convertListToMap(member, "", "", config);
+        addYamlField(n, "value", member);
+    }
     return n;
 }
-inline void https___example_com_::MyRecordTwo::fromYaml([[maybe_unused]] YAML::Node const& n) {
-    using ::fromYaml;
-    fromYaml(n["name"], *name);
-    fromYaml(n["value"], *value);
+inline void example_com::MyRecordTwo::fromYaml([[maybe_unused]] YAML::Node const& n) {
+    using ::example_com::fromYaml;
+    {
+        auto nodeAsList = convertMapToList(n["name"], "", "");
+        auto expandedNode = (nodeAsList);
+        fromYaml(expandedNode, *name);
+    }
+    {
+        auto nodeAsList = convertMapToList(n["value"], "", "");
+        auto expandedNode = (nodeAsList);
+        fromYaml(expandedNode, *value);
+    }
 }
-
 template <>
-struct DetectAndExtractFromYaml<https___example_com_::MyRecordTwo> {
-    auto operator()(YAML::Node const& n) const -> std::optional<https___example_com_::MyRecordTwo> {
+struct example_com::DetectAndExtractFromYaml<example_com::MyRecordTwo> {
+    auto operator()(YAML::Node const& n) const -> std::optional<example_com::MyRecordTwo> {
         if (!n.IsDefined()) return std::nullopt;
         if (!n.IsMap()) return std::nullopt;
-        auto res = https___example_com_::MyRecordTwo{};
+        auto res = example_com::MyRecordTwo{};
 
-        if constexpr (IsConstant<decltype(res.name)::value_t>::value) try {
+        if constexpr (::example_com::IsConstant<decltype(res.name)::value_t>::value) try {
             fromYaml(n["name"], *res.name);
             fromYaml(n, res);
             return res;
         } catch(...) {}
 
-        if constexpr (IsConstant<decltype(res.value)::value_t>::value) try {
+        if constexpr (::example_com::IsConstant<decltype(res.value)::value_t>::value) try {
             fromYaml(n["value"], *res.value);
             fromYaml(n, res);
             return res;
@@ -399,38 +543,39 @@ struct DetectAndExtractFromYaml<https___example_com_::MyRecordTwo> {
         return std::nullopt;
     }
 };
+namespace example_com {
 
 template <typename T>
-auto toYaml(std::vector<T> const& v) -> YAML::Node {
+auto toYaml(std::vector<T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node {
     auto n = YAML::Node(YAML::NodeType::Sequence);
     for (auto const& e : v) {
-        n.push_back(toYaml(e));
+        n.push_back(toYaml(e, config));
     }
     return n;
 }
 
 template <typename T>
-auto toYaml(std::map<std::string, T> const& v) -> YAML::Node {
+auto toYaml(std::map<std::string, T> const& v, [[maybe_unused]] store_config const& config) -> YAML::Node {
     auto n = YAML::Node(YAML::NodeType::Map);
     for (auto const& [key, value] : v) {
-        n[key] = toYaml(value);
+        n[key] = toYaml(value, config);
     }
     return n;
 }
 
 template <typename T>
-auto toYaml(T const& t) -> YAML::Node {
+auto toYaml(T const& t, [[maybe_unused]] store_config const& config) -> YAML::Node {
     if constexpr (std::is_enum_v<T>) {
-        return toYaml(t);
+        return toYaml(t, config);
     } else {
-        return t.toYaml();
+        return t.toYaml(config);
     }
 }
 
 template <typename ...Args>
-auto toYaml(std::variant<Args...> const& t) -> YAML::Node {
-    return std::visit([](auto const& e) {
-        return toYaml(e);
+auto toYaml(std::variant<Args...> const& t, store_config const& config) -> YAML::Node {
+    return std::visit([config](auto const& e) {
+        return toYaml(e, config);
     }, t);
 }
 
@@ -491,4 +636,34 @@ template <typename ...Args>
 void fromYaml(YAML::Node const& n, std::variant<Args...>& v){
     bool found = detectAndExtractFromYaml<std::variant<Args...>, Args...>(n, v);
     if (!found) throw std::runtime_error{"didn't find any overload"};
+}
+using DocumentRootType = std::variant<>;
+auto load_document_from_yaml(YAML::Node n) -> DocumentRootType {
+    DocumentRootType root;
+    fromYaml(n, root);
+    return root;
+}
+auto load_document_from_string(std::string document) -> DocumentRootType {
+    return load_document_from_yaml(YAML::Load(document));
+}
+auto load_document(std::filesystem::path path) -> DocumentRootType {
+    return load_document_from_yaml(YAML::LoadFile(path));
+}
+void store_document(DocumentRootType const& root, std::ostream& ostream, store_config config={}) {
+    auto y = toYaml(root, config);
+
+    YAML::Emitter out;
+    out << y;
+    ostream << out.c_str() << std::endl;
+}
+void store_document(DocumentRootType const& root, std::filesystem::path const& path, store_config config={}) {
+    auto ofs = std::ofstream{path};
+    store_document(root, ofs, config);
+}
+auto store_document_as_string(DocumentRootType const& root, store_config config={}) -> std::string {
+    auto ss = std::stringstream{};
+    store_document(root, ss, config);
+    return ss.str();
+}
+
 }


### PR DESCRIPTION
This PR addresses multiple concerns at once:

1. It adds special handling of [CWL Expression type](https://www.commonwl.org/v1.2/CommandLineTool.html#Expression)
2. It now handles simplification of types by respecting the [`typeDSL` option](https://www.commonwl.org/v1.2/SchemaSalad.html#Domain_Specific_Language_for_types)
3. It also handles `mapPredicate` when doing [map ⇔ list conversions](https://www.commonwl.org/v1.2/SchemaSalad.html#Identifier_maps). (and not only `mapSubject`)
4. added a `DocumentRootType` type and `load_document` and `store_document` functions.
5. Added a `store_config` object, which allows to control simplification of types, list to map conversion and partial YAML-tag output (all very helpful when debugging).
6. It wraps the generated code into a `cpp_gen` namespace to avoid symbol spilling into other parts of c++ programs.

A basic program that can load and save(print) CWL tool description files (or any `DocumentRootType` type):
```c++
#include "cwl_v1_2.h"

#include <iostream>

namespace cwl = w3id_org::cwl;
int main(int argc, char** argv) {
    if (argc != 2) return 1;

    auto tool = cwl::load_document(argv[1]);
    cwl::store_document(tool, std::cout);
    return 0;
}
```


