### PR TITLE
Fixes for Java codegen

### DIFF
--- a/schema_salad/java/main_utils/UnionLoader.java
+++ b/schema_salad/java/main_utils/UnionLoader.java
@@ -5,10 +5,10 @@ import java.util.Arrays;
 import java.util.List;
 
 public class UnionLoader implements Loader<Object> {
-  private final List<Loader> alternates;
+  private final ArrayList<Loader> alternates;
 
   public UnionLoader(List<Loader> alternates) {
-    this.alternates = alternates;
+    this.alternates = new ArrayList<Loader>(alternates);
   }
 
   public UnionLoader(Loader[] alternates) {
@@ -19,7 +19,7 @@ public class UnionLoader implements Loader<Object> {
     this.alternates.addAll(loaders);
   }
 
-   public void addLoaders(Loader[] loaders) {
+  public void addLoaders(Loader[] loaders) {
     this.addLoaders(Arrays.asList(loaders));
   }
 

--- a/schema_salad/java_codegen.py
+++ b/schema_salad/java_codegen.py
@@ -464,7 +464,7 @@ public class {cls}Impl extends SaveableImpl implements {cls} {{
                         init="new MapLoader({}, {}, {})".format(
                             i.name,
                             (
-                                f"'{container}'" if container is not None else self.to_java(None)
+                                f'"{container}"' if container is not None else self.to_java(None)
                             ),  # noqa: B907
                             self.to_java(no_link_check),
                         ),
@@ -488,7 +488,7 @@ public class {cls}Impl extends SaveableImpl implements {cls} {{
                             clazz=fqclass,
                             ext="Impl" if not is_abstract else "",
                             container=(
-                                f"'{container}'"
+                                f'"{container}"'
                                 if container is not None
                                 else self.to_java(None)  # noqa: B907
                             ),


### PR DESCRIPTION
- java codegen: use double quotes for string literals in generated code.
- java codegen: UnionLoader.alternates needs a concrete collection type.
