### PR TITLE
allow for named custom array types

### DIFF
--- a/schema_salad/validate.py
+++ b/schema_salad/validate.py
@@ -92,7 +92,7 @@ def friendly(v: Any) -> Any:
     """Format an Avro schema into a pretty-printed representation."""
     if isinstance(v, avro.schema.NamedSchema):
         return avro_shortname(v.name)
-    if isinstance(v, avro.schema.ArraySchema):
+    if isinstance(v, (avro.schema.ArraySchema, avro.schema.NamedArraySchema)):
         return f"array of <{friendly(v.items)}>"
     if isinstance(v, (avro.schema.MapSchema, avro.schema.NamedMapSchema)):
         return f"map of <{friendly(v.values)}>"
@@ -207,7 +207,7 @@ def validate_ex(
                 )
             )
         return False
-    if isinstance(expected_schema, avro.schema.ArraySchema):
+    if isinstance(expected_schema, (avro.schema.ArraySchema, avro.schema.NamedArraySchema)):
         if isinstance(datum, MutableSequence):
             for i, d in enumerate(datum):
                 try:
@@ -258,7 +258,9 @@ def validate_ex(
         errors: list[SchemaSaladException] = []
         checked = []
         for s in expected_schema.schemas:
-            if isinstance(datum, MutableSequence) and not isinstance(s, avro.schema.ArraySchema):
+            if isinstance(datum, MutableSequence) and not isinstance(
+                s, (avro.schema.ArraySchema, avro.schema.NamedArraySchema)
+            ):
                 continue
             if isinstance(datum, MutableMapping) and not isinstance(
                 s, (avro.schema.RecordSchema, avro.schema.MapSchema, avro.schema.NamedMapSchema)
@@ -268,6 +270,7 @@ def validate_ex(
                 s,
                 (
                     avro.schema.ArraySchema,
+                    avro.schema.NamedArraySchema,
                     avro.schema.RecordSchema,
                     avro.schema.MapSchema,
                     avro.schema.NamedMapSchema,


### PR DESCRIPTION
Necessary for `cwltool` to be able to parse and run

https://github.com/rabix/sbpack/blob/ebd5fbca8c6aec03015228f3e35ab37f0e208c33/tests/remote-cwl/wf1.cwl

which includes

https://github.com/rabix/sbpack/blob/ebd5fbca8c6aec03015228f3e35ab37f0e208c33/tests/types/testtypes.yml#L1-L4

``` yaml
- name: my_boolean_array
  type: array
  items: boolean
  label: "A boolean array"
```

- [ ] tests, but it is unclear how to do so without running `cwltool`
