### PR TITLE
Preserve original type in `extend_and_specialize`

### DIFF
--- a/src/schema_salad/metaschema.py
+++ b/src/schema_salad/metaschema.py
@@ -44,7 +44,7 @@ from schema_salad.runtime import (
 from schema_salad.sourceline import SourceLine, add_lc_filename
 from schema_salad.utils import yaml_no_ts  # requires schema-salad v8.2+
 
-_loaders: Final[dict[str, Loader]] = {}
+_loaders: Final[dict[str, Loader | None]] = {}
 _vocab: Final[dict[str, str]] = {}
 _rvocab: Final[dict[str, str]] = {}
 
@@ -305,9 +305,7 @@ class _RecordLoader(Loader, Generic[SaveableType]):
             loadingOptions = LoadingOptions(
                 copyfrom=loadingOptions, container=self.container, no_link_check=self.no_link_check
             )
-        return self.classtype.fromDoc(
-            doc, baseuri, loadingOptions, docRoot=docRoot, loaders=_loaders
-        )
+        return self.classtype.fromDoc(doc, baseuri, loadingOptions, docRoot=docRoot)
 
     def __repr__(self) -> str:
         return str(self.classtype.__name__)
@@ -628,6 +626,29 @@ class _IdMapLoader(Loader):
         return self.inner.load(doc, baseuri, loadingOptions, lc=lc)
 
 
+class _ProxyLoader(Loader):
+    def __init__(self, name: str) -> None:
+        self.name: Final = name
+
+    def load(
+        self,
+        doc: Any,
+        baseuri: str,
+        loadingOptions: LoadingOptions,
+        docRoot: str | None = None,
+        lc: Any | None = None,
+    ) -> Any | None:
+        if (
+            self.name in loadingOptions.loaders
+            and (loader := loadingOptions.loaders.get(self.name)) is not None
+        ):
+            return loader.load(doc, baseuri, loadingOptions, lc=lc)
+        elif self.name in _loaders and (loader := _loaders.get(self.name)) is not None:
+            return loader.load(doc, baseuri, loadingOptions, lc=lc)
+        else:
+            raise ValidationException(f"No Loader instance available for {self.name}")
+
+
 def _document_load(
     loader: Loader,
     doc: str | MutableMapping[str, Any] | MutableSequence[Any],
@@ -660,6 +681,7 @@ def _document_load(
             schemas=doc.get("$schemas", None),
             baseuri=doc.get("$base", None),
             addl_metadata=addl_metadata,
+            loaders=_loaders | loadingOptions.loaders,
         )
 
         doc2: Final = copy.copy(doc)
@@ -881,7 +903,6 @@ class RecordField(Documented):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -894,7 +915,7 @@ class RecordField(Documented):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["uri_strtype_True_False_None_None"],
+                    uri_strtype_True_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -950,7 +971,7 @@ class RecordField(Documented):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
+                    union_of_None_type_or_strtype_or_array_of_strtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -998,7 +1019,7 @@ class RecordField(Documented):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2"],
+                typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -1142,7 +1163,6 @@ class RecordSchema(Saveable):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -1155,7 +1175,7 @@ class RecordSchema(Saveable):
             try:
                 fields = _load_field(
                     _doc.get("fields"),
-                    loaders["idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader"],
+                    idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("fields")
@@ -1203,7 +1223,7 @@ class RecordSchema(Saveable):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["typedsl_Record_nameLoader_2"],
+                typedsl_Record_nameLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -1355,7 +1375,6 @@ class EnumSchema(Saveable):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -1368,7 +1387,7 @@ class EnumSchema(Saveable):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["uri_union_of_None_type_or_strtype_True_False_None_None"],
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -1425,7 +1444,7 @@ class EnumSchema(Saveable):
 
             symbols = _load_field(
                 _doc.get("symbols"),
-                loaders["uri_array_of_strtype_True_False_None_None"],
+                uri_array_of_strtype_True_False_None_None,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("symbols")
@@ -1473,7 +1492,7 @@ class EnumSchema(Saveable):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["typedsl_Enum_nameLoader_2"],
+                typedsl_Enum_nameLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -1616,7 +1635,6 @@ class ArraySchema(Saveable):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -1630,7 +1648,7 @@ class ArraySchema(Saveable):
 
             items = _load_field(
                 _doc.get("items"),
-                loaders["uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None"],
+                uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("items")
@@ -1678,7 +1696,7 @@ class ArraySchema(Saveable):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["typedsl_Array_nameLoader_2"],
+                typedsl_Array_nameLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -1816,7 +1834,6 @@ class MapSchema(Saveable):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -1830,7 +1847,7 @@ class MapSchema(Saveable):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["typedsl_Map_nameLoader_2"],
+                typedsl_Map_nameLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -1878,7 +1895,7 @@ class MapSchema(Saveable):
 
             values = _load_field(
                 _doc.get("values"),
-                loaders["uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None"],
+                uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("values")
@@ -2016,7 +2033,6 @@ class UnionSchema(Saveable):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -2030,7 +2046,7 @@ class UnionSchema(Saveable):
 
             names = _load_field(
                 _doc.get("names"),
-                loaders["uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None"],
+                uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("names")
@@ -2078,7 +2094,7 @@ class UnionSchema(Saveable):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["typedsl_Union_nameLoader_2"],
+                typedsl_Union_nameLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -2265,7 +2281,6 @@ class JsonldPredicate(Saveable):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -2278,7 +2293,7 @@ class JsonldPredicate(Saveable):
             try:
                 _id = _load_field(
                     _doc.get("_id"),
-                    loaders["uri_union_of_None_type_or_strtype_True_False_None_None"],
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("_id")
@@ -2325,7 +2340,7 @@ class JsonldPredicate(Saveable):
             try:
                 _type = _load_field(
                     _doc.get("_type"),
-                    loaders["union_of_None_type_or_strtype"],
+                    union_of_None_type_or_strtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("_type")
@@ -2372,7 +2387,7 @@ class JsonldPredicate(Saveable):
             try:
                 _container = _load_field(
                     _doc.get("_container"),
-                    loaders["union_of_None_type_or_strtype"],
+                    union_of_None_type_or_strtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("_container")
@@ -2419,7 +2434,7 @@ class JsonldPredicate(Saveable):
             try:
                 identity = _load_field(
                     _doc.get("identity"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("identity")
@@ -2466,7 +2481,7 @@ class JsonldPredicate(Saveable):
             try:
                 noLinkCheck = _load_field(
                     _doc.get("noLinkCheck"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("noLinkCheck")
@@ -2513,7 +2528,7 @@ class JsonldPredicate(Saveable):
             try:
                 mapSubject = _load_field(
                     _doc.get("mapSubject"),
-                    loaders["union_of_None_type_or_strtype"],
+                    union_of_None_type_or_strtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("mapSubject")
@@ -2560,7 +2575,7 @@ class JsonldPredicate(Saveable):
             try:
                 mapPredicate = _load_field(
                     _doc.get("mapPredicate"),
-                    loaders["union_of_None_type_or_strtype"],
+                    union_of_None_type_or_strtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("mapPredicate")
@@ -2607,7 +2622,7 @@ class JsonldPredicate(Saveable):
             try:
                 refScope = _load_field(
                     _doc.get("refScope"),
-                    loaders["union_of_None_type_or_inttype"],
+                    union_of_None_type_or_inttype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("refScope")
@@ -2654,7 +2669,7 @@ class JsonldPredicate(Saveable):
             try:
                 typeDSL = _load_field(
                     _doc.get("typeDSL"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("typeDSL")
@@ -2701,7 +2716,7 @@ class JsonldPredicate(Saveable):
             try:
                 secondaryFilesDSL = _load_field(
                     _doc.get("secondaryFilesDSL"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("secondaryFilesDSL")
@@ -2748,7 +2763,7 @@ class JsonldPredicate(Saveable):
             try:
                 subscope = _load_field(
                     _doc.get("subscope"),
-                    loaders["union_of_None_type_or_strtype"],
+                    union_of_None_type_or_strtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("subscope")
@@ -2963,7 +2978,6 @@ class SpecializeDef(Saveable):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -2977,7 +2991,7 @@ class SpecializeDef(Saveable):
 
             specializeFrom = _load_field(
                 _doc.get("specializeFrom"),
-                loaders["uri_strtype_False_False_1_None"],
+                uri_strtype_False_False_1_None,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("specializeFrom")
@@ -3025,7 +3039,7 @@ class SpecializeDef(Saveable):
 
             specializeTo = _load_field(
                 _doc.get("specializeTo"),
-                loaders["uri_strtype_False_False_1_None"],
+                uri_strtype_False_False_1_None,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("specializeTo")
@@ -3202,7 +3216,6 @@ class SaladRecordField(RecordField):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -3215,7 +3228,7 @@ class SaladRecordField(RecordField):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["uri_strtype_True_False_None_None"],
+                    uri_strtype_True_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -3271,7 +3284,7 @@ class SaladRecordField(RecordField):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
+                    union_of_None_type_or_strtype_or_array_of_strtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -3319,7 +3332,7 @@ class SaladRecordField(RecordField):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2"],
+                typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -3366,7 +3379,7 @@ class SaladRecordField(RecordField):
             try:
                 jsonldPredicate = _load_field(
                     _doc.get("jsonldPredicate"),
-                    loaders["union_of_None_type_or_strtype_or_JsonldPredicateLoader"],
+                    union_of_None_type_or_strtype_or_JsonldPredicateLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("jsonldPredicate")
@@ -3413,7 +3426,7 @@ class SaladRecordField(RecordField):
             try:
                 default = _load_field(
                     _doc.get("default"),
-                    loaders["union_of_None_type_or_Any_type"],
+                    union_of_None_type_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("default")
@@ -3626,7 +3639,6 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -3639,7 +3651,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["uri_strtype_True_False_None_None"],
+                    uri_strtype_True_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -3695,7 +3707,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 inVocab = _load_field(
                     _doc.get("inVocab"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inVocab")
@@ -3742,7 +3754,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 fields = _load_field(
                     _doc.get("fields"),
-                    loaders["idmap_fields_union_of_None_type_or_array_of_SaladRecordFieldLoader"],
+                    idmap_fields_union_of_None_type_or_array_of_SaladRecordFieldLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("fields")
@@ -3790,7 +3802,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["typedsl_Record_nameLoader_2"],
+                typedsl_Record_nameLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -3837,7 +3849,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
+                    union_of_None_type_or_strtype_or_array_of_strtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -3884,7 +3896,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 docParent = _load_field(
                     _doc.get("docParent"),
-                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docParent")
@@ -3931,7 +3943,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 docChild = _load_field(
                     _doc.get("docChild"),
-                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docChild")
@@ -3978,7 +3990,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 docAfter = _load_field(
                     _doc.get("docAfter"),
-                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docAfter")
@@ -4025,7 +4037,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 jsonldPredicate = _load_field(
                     _doc.get("jsonldPredicate"),
-                    loaders["union_of_None_type_or_strtype_or_JsonldPredicateLoader"],
+                    union_of_None_type_or_strtype_or_JsonldPredicateLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("jsonldPredicate")
@@ -4072,7 +4084,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 documentRoot = _load_field(
                     _doc.get("documentRoot"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("documentRoot")
@@ -4119,7 +4131,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 abstract = _load_field(
                     _doc.get("abstract"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("abstract")
@@ -4166,7 +4178,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 extends = _load_field(
                     _doc.get("extends"),
-                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None"],
+                    uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("extends")
@@ -4213,7 +4225,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 specialize = _load_field(
                     _doc.get("specialize"),
-                    loaders["idmap_specialize_union_of_None_type_or_array_of_SpecializeDefLoader"],
+                    idmap_specialize_union_of_None_type_or_array_of_SpecializeDefLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("specialize")
@@ -4482,7 +4494,6 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -4495,7 +4506,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["uri_union_of_None_type_or_strtype_True_False_None_None"],
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -4551,7 +4562,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 inVocab = _load_field(
                     _doc.get("inVocab"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inVocab")
@@ -4599,7 +4610,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
 
             symbols = _load_field(
                 _doc.get("symbols"),
-                loaders["uri_array_of_strtype_True_False_None_None"],
+                uri_array_of_strtype_True_False_None_None,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("symbols")
@@ -4647,7 +4658,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["typedsl_Enum_nameLoader_2"],
+                typedsl_Enum_nameLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -4694,7 +4705,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
+                    union_of_None_type_or_strtype_or_array_of_strtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -4741,7 +4752,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 docParent = _load_field(
                     _doc.get("docParent"),
-                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docParent")
@@ -4788,7 +4799,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 docChild = _load_field(
                     _doc.get("docChild"),
-                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docChild")
@@ -4835,7 +4846,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 docAfter = _load_field(
                     _doc.get("docAfter"),
-                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docAfter")
@@ -4882,7 +4893,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 jsonldPredicate = _load_field(
                     _doc.get("jsonldPredicate"),
-                    loaders["union_of_None_type_or_strtype_or_JsonldPredicateLoader"],
+                    union_of_None_type_or_strtype_or_JsonldPredicateLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("jsonldPredicate")
@@ -4929,7 +4940,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 documentRoot = _load_field(
                     _doc.get("documentRoot"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("documentRoot")
@@ -4976,7 +4987,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 extends = _load_field(
                     _doc.get("extends"),
-                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None"],
+                    uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("extends")
@@ -5222,7 +5233,6 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -5235,7 +5245,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["uri_strtype_True_False_None_None"],
+                    uri_strtype_True_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -5291,7 +5301,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 inVocab = _load_field(
                     _doc.get("inVocab"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inVocab")
@@ -5339,7 +5349,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["typedsl_Map_nameLoader_2"],
+                typedsl_Map_nameLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -5387,7 +5397,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
 
             values = _load_field(
                 _doc.get("values"),
-                loaders["uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None"],
+                uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("values")
@@ -5434,7 +5444,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
+                    union_of_None_type_or_strtype_or_array_of_strtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -5481,7 +5491,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 docParent = _load_field(
                     _doc.get("docParent"),
-                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docParent")
@@ -5528,7 +5538,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 docChild = _load_field(
                     _doc.get("docChild"),
-                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docChild")
@@ -5575,7 +5585,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 docAfter = _load_field(
                     _doc.get("docAfter"),
-                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docAfter")
@@ -5622,7 +5632,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 jsonldPredicate = _load_field(
                     _doc.get("jsonldPredicate"),
-                    loaders["union_of_None_type_or_strtype_or_JsonldPredicateLoader"],
+                    union_of_None_type_or_strtype_or_JsonldPredicateLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("jsonldPredicate")
@@ -5669,7 +5679,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 documentRoot = _load_field(
                     _doc.get("documentRoot"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("documentRoot")
@@ -5906,7 +5916,6 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -5919,7 +5928,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["uri_strtype_True_False_None_None"],
+                    uri_strtype_True_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -5975,7 +5984,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 inVocab = _load_field(
                     _doc.get("inVocab"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inVocab")
@@ -6023,7 +6032,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
 
             names = _load_field(
                 _doc.get("names"),
-                loaders["uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None"],
+                uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("names")
@@ -6071,7 +6080,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["typedsl_Union_nameLoader_2"],
+                typedsl_Union_nameLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -6118,7 +6127,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
+                    union_of_None_type_or_strtype_or_array_of_strtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -6165,7 +6174,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 docParent = _load_field(
                     _doc.get("docParent"),
-                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docParent")
@@ -6212,7 +6221,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 docChild = _load_field(
                     _doc.get("docChild"),
-                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docChild")
@@ -6259,7 +6268,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 docAfter = _load_field(
                     _doc.get("docAfter"),
-                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docAfter")
@@ -6306,7 +6315,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 documentRoot = _load_field(
                     _doc.get("documentRoot"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("documentRoot")
@@ -6526,7 +6535,6 @@ class Documentation(NamedType, DocType):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -6539,7 +6547,7 @@ class Documentation(NamedType, DocType):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["uri_strtype_True_False_None_None"],
+                    uri_strtype_True_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -6595,7 +6603,7 @@ class Documentation(NamedType, DocType):
             try:
                 inVocab = _load_field(
                     _doc.get("inVocab"),
-                    loaders["union_of_None_type_or_booltype"],
+                    union_of_None_type_or_booltype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inVocab")
@@ -6642,7 +6650,7 @@ class Documentation(NamedType, DocType):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
+                    union_of_None_type_or_strtype_or_array_of_strtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -6689,7 +6697,7 @@ class Documentation(NamedType, DocType):
             try:
                 docParent = _load_field(
                     _doc.get("docParent"),
-                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docParent")
@@ -6736,7 +6744,7 @@ class Documentation(NamedType, DocType):
             try:
                 docChild = _load_field(
                     _doc.get("docChild"),
-                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docChild")
@@ -6783,7 +6791,7 @@ class Documentation(NamedType, DocType):
             try:
                 docAfter = _load_field(
                     _doc.get("docAfter"),
-                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
+                    uri_union_of_None_type_or_strtype_False_False_None_None,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docAfter")
@@ -6831,7 +6839,7 @@ class Documentation(NamedType, DocType):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["typedsl_Documentation_nameLoader_2"],
+                typedsl_Documentation_nameLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -7037,6 +7045,7 @@ floattype: Final = _PrimitiveLoader(float)
 booltype: Final = _PrimitiveLoader(bool)
 None_type: Final = _PrimitiveLoader(type(None))
 Any_type: Final = _AnyLoader()
+DocumentedProxyLoader: Final = _ProxyLoader("DocumentedLoader")
 PrimitiveTypeLoader: Final = _EnumLoader(
     (
         "null",
@@ -7080,6 +7089,9 @@ MapSchemaLoader: Final = _RecordLoader(MapSchema, None, None)
 UnionSchemaLoader: Final = _RecordLoader(UnionSchema, None, None)
 JsonldPredicateLoader: Final = _RecordLoader(JsonldPredicate, None, None)
 SpecializeDefLoader: Final = _RecordLoader(SpecializeDef, None, None)
+NamedTypeProxyLoader: Final = _ProxyLoader("NamedTypeLoader")
+DocTypeProxyLoader: Final = _ProxyLoader("DocTypeLoader")
+SchemaDefinedTypeProxyLoader: Final = _ProxyLoader("SchemaDefinedTypeLoader")
 SaladRecordFieldLoader: Final = _RecordLoader(SaladRecordField, None, None)
 SaladRecordSchemaLoader: Final = _RecordLoader(SaladRecordSchema, None, None)
 SaladEnumSchemaLoader: Final = _RecordLoader(SaladEnumSchema, None, None)
@@ -7270,71 +7282,10 @@ union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoade
 )
 
 _loaders.update({
-    "strtype": strtype,
-    "inttype": inttype,
-    "floattype": floattype,
-    "booltype": booltype,
-    "None_type": None_type,
-    "Any_type": Any_type,
-    "PrimitiveTypeLoader": PrimitiveTypeLoader,
-    "AnyLoader": AnyLoader,
-    "RecordFieldLoader": RecordFieldLoader,
-    "RecordSchemaLoader": RecordSchemaLoader,
-    "EnumSchemaLoader": EnumSchemaLoader,
-    "ArraySchemaLoader": ArraySchemaLoader,
-    "MapSchemaLoader": MapSchemaLoader,
-    "UnionSchemaLoader": UnionSchemaLoader,
-    "JsonldPredicateLoader": JsonldPredicateLoader,
-    "SpecializeDefLoader": SpecializeDefLoader,
-    "SaladRecordFieldLoader": SaladRecordFieldLoader,
-    "SaladRecordSchemaLoader": SaladRecordSchemaLoader,
-    "SaladEnumSchemaLoader": SaladEnumSchemaLoader,
-    "SaladMapSchemaLoader": SaladMapSchemaLoader,
-    "SaladUnionSchemaLoader": SaladUnionSchemaLoader,
-    "DocumentationLoader": DocumentationLoader,
-    "array_of_strtype": array_of_strtype,
-    "union_of_None_type_or_strtype_or_array_of_strtype": union_of_None_type_or_strtype_or_array_of_strtype,
-    "uri_strtype_True_False_None_None": uri_strtype_True_False_None_None,
-    "union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype": union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
-    "array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype": array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
-    "union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype": union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
-    "typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2": typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2,
-    "array_of_RecordFieldLoader": array_of_RecordFieldLoader,
-    "union_of_None_type_or_array_of_RecordFieldLoader": union_of_None_type_or_array_of_RecordFieldLoader,
-    "idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader": idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader,
-    "Record_nameLoader": Record_nameLoader,
-    "typedsl_Record_nameLoader_2": typedsl_Record_nameLoader_2,
-    "union_of_None_type_or_strtype": union_of_None_type_or_strtype,
-    "uri_union_of_None_type_or_strtype_True_False_None_None": uri_union_of_None_type_or_strtype_True_False_None_None,
-    "uri_array_of_strtype_True_False_None_None": uri_array_of_strtype_True_False_None_None,
-    "Enum_nameLoader": Enum_nameLoader,
-    "typedsl_Enum_nameLoader_2": typedsl_Enum_nameLoader_2,
-    "uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None": uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None,
-    "Array_nameLoader": Array_nameLoader,
-    "typedsl_Array_nameLoader_2": typedsl_Array_nameLoader_2,
-    "Map_nameLoader": Map_nameLoader,
-    "typedsl_Map_nameLoader_2": typedsl_Map_nameLoader_2,
-    "Union_nameLoader": Union_nameLoader,
-    "typedsl_Union_nameLoader_2": typedsl_Union_nameLoader_2,
-    "union_of_None_type_or_booltype": union_of_None_type_or_booltype,
-    "union_of_None_type_or_inttype": union_of_None_type_or_inttype,
-    "uri_strtype_False_False_1_None": uri_strtype_False_False_1_None,
-    "uri_union_of_None_type_or_strtype_False_False_None_None": uri_union_of_None_type_or_strtype_False_False_None_None,
-    "uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None": uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None,
-    "union_of_None_type_or_strtype_or_JsonldPredicateLoader": union_of_None_type_or_strtype_or_JsonldPredicateLoader,
-    "union_of_None_type_or_Any_type": union_of_None_type_or_Any_type,
-    "array_of_SaladRecordFieldLoader": array_of_SaladRecordFieldLoader,
-    "union_of_None_type_or_array_of_SaladRecordFieldLoader": union_of_None_type_or_array_of_SaladRecordFieldLoader,
-    "idmap_fields_union_of_None_type_or_array_of_SaladRecordFieldLoader": idmap_fields_union_of_None_type_or_array_of_SaladRecordFieldLoader,
-    "uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None": uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None,
-    "array_of_SpecializeDefLoader": array_of_SpecializeDefLoader,
-    "union_of_None_type_or_array_of_SpecializeDefLoader": union_of_None_type_or_array_of_SpecializeDefLoader,
-    "idmap_specialize_union_of_None_type_or_array_of_SpecializeDefLoader": idmap_specialize_union_of_None_type_or_array_of_SpecializeDefLoader,
-    "Documentation_nameLoader": Documentation_nameLoader,
-    "typedsl_Documentation_nameLoader_2": typedsl_Documentation_nameLoader_2,
-    "union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader": union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader,
-    "array_of_union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader": array_of_union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader,
-    "union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader_or_array_of_union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader": union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader_or_array_of_union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader,
+    "DocumentedLoader": None,
+    "NamedTypeLoader": None,
+    "DocTypeLoader": None,
+    "SchemaDefinedTypeLoader": None,
 })
 
 

--- a/src/schema_salad/metaschema.py
+++ b/src/schema_salad/metaschema.py
@@ -25,7 +25,7 @@ else:
     from typing_extensions import Self
 
 import copy
-from collections.abc import MutableSequence, Sequence, MutableMapping, Mapping
+from collections.abc import MutableSequence, Sequence, MutableMapping
 from io import StringIO
 from itertools import chain
 from typing import Any, Final, cast, Generic
@@ -44,6 +44,7 @@ from schema_salad.runtime import (
 from schema_salad.sourceline import SourceLine, add_lc_filename
 from schema_salad.utils import yaml_no_ts  # requires schema-salad v8.2+
 
+_loaders: Final[dict[str, Loader]] = {}
 _vocab: Final[dict[str, str]] = {}
 _rvocab: Final[dict[str, str]] = {}
 
@@ -280,12 +281,10 @@ class _RecordLoader(Loader, Generic[SaveableType]):
     def __init__(
         self,
         classtype: type[SaveableType],
-        loaders: Mapping[str, Loader],
         container: str | None = None,
         no_link_check: bool | None = None,
     ) -> None:
         self.classtype: Final = classtype
-        self.loaders: Final = loaders
         self.container: Final = container
         self.no_link_check: Final = no_link_check
 
@@ -306,7 +305,9 @@ class _RecordLoader(Loader, Generic[SaveableType]):
             loadingOptions = LoadingOptions(
                 copyfrom=loadingOptions, container=self.container, no_link_check=self.no_link_check
             )
-        return self.classtype.fromDoc(doc, baseuri, loadingOptions, self.loaders, docRoot=docRoot)
+        return self.classtype.fromDoc(
+            doc, baseuri, loadingOptions, docRoot=docRoot, loaders=_loaders
+        )
 
     def __repr__(self) -> str:
         return str(self.classtype.__name__)
@@ -879,8 +880,8 @@ class RecordField(Documented):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -893,7 +894,7 @@ class RecordField(Documented):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["name"],
+                    loaders["uri_strtype_True_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -949,7 +950,7 @@ class RecordField(Documented):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["doc"],
+                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -997,7 +998,7 @@ class RecordField(Documented):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["type"],
+                loaders["typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -1140,8 +1141,8 @@ class RecordSchema(Saveable):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -1154,7 +1155,7 @@ class RecordSchema(Saveable):
             try:
                 fields = _load_field(
                     _doc.get("fields"),
-                    loaders["fields"],
+                    loaders["idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("fields")
@@ -1202,7 +1203,7 @@ class RecordSchema(Saveable):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["type"],
+                loaders["typedsl_Record_nameLoader_2"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -1353,8 +1354,8 @@ class EnumSchema(Saveable):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -1367,7 +1368,7 @@ class EnumSchema(Saveable):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["name"],
+                    loaders["uri_union_of_None_type_or_strtype_True_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -1424,7 +1425,7 @@ class EnumSchema(Saveable):
 
             symbols = _load_field(
                 _doc.get("symbols"),
-                loaders["symbols"],
+                loaders["uri_array_of_strtype_True_False_None_None"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("symbols")
@@ -1472,7 +1473,7 @@ class EnumSchema(Saveable):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["type"],
+                loaders["typedsl_Enum_nameLoader_2"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -1614,8 +1615,8 @@ class ArraySchema(Saveable):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -1629,7 +1630,7 @@ class ArraySchema(Saveable):
 
             items = _load_field(
                 _doc.get("items"),
-                loaders["items"],
+                loaders["uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("items")
@@ -1677,7 +1678,7 @@ class ArraySchema(Saveable):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["type"],
+                loaders["typedsl_Array_nameLoader_2"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -1814,8 +1815,8 @@ class MapSchema(Saveable):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -1829,7 +1830,7 @@ class MapSchema(Saveable):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["type"],
+                loaders["typedsl_Map_nameLoader_2"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -1877,7 +1878,7 @@ class MapSchema(Saveable):
 
             values = _load_field(
                 _doc.get("values"),
-                loaders["values"],
+                loaders["uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("values")
@@ -2014,8 +2015,8 @@ class UnionSchema(Saveable):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -2029,7 +2030,7 @@ class UnionSchema(Saveable):
 
             names = _load_field(
                 _doc.get("names"),
-                loaders["names"],
+                loaders["uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("names")
@@ -2077,7 +2078,7 @@ class UnionSchema(Saveable):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["type"],
+                loaders["typedsl_Union_nameLoader_2"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -2263,8 +2264,8 @@ class JsonldPredicate(Saveable):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -2277,7 +2278,7 @@ class JsonldPredicate(Saveable):
             try:
                 _id = _load_field(
                     _doc.get("_id"),
-                    loaders["_id"],
+                    loaders["uri_union_of_None_type_or_strtype_True_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("_id")
@@ -2324,7 +2325,7 @@ class JsonldPredicate(Saveable):
             try:
                 _type = _load_field(
                     _doc.get("_type"),
-                    loaders["_type"],
+                    loaders["union_of_None_type_or_strtype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("_type")
@@ -2371,7 +2372,7 @@ class JsonldPredicate(Saveable):
             try:
                 _container = _load_field(
                     _doc.get("_container"),
-                    loaders["_container"],
+                    loaders["union_of_None_type_or_strtype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("_container")
@@ -2418,7 +2419,7 @@ class JsonldPredicate(Saveable):
             try:
                 identity = _load_field(
                     _doc.get("identity"),
-                    loaders["identity"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("identity")
@@ -2465,7 +2466,7 @@ class JsonldPredicate(Saveable):
             try:
                 noLinkCheck = _load_field(
                     _doc.get("noLinkCheck"),
-                    loaders["noLinkCheck"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("noLinkCheck")
@@ -2512,7 +2513,7 @@ class JsonldPredicate(Saveable):
             try:
                 mapSubject = _load_field(
                     _doc.get("mapSubject"),
-                    loaders["mapSubject"],
+                    loaders["union_of_None_type_or_strtype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("mapSubject")
@@ -2559,7 +2560,7 @@ class JsonldPredicate(Saveable):
             try:
                 mapPredicate = _load_field(
                     _doc.get("mapPredicate"),
-                    loaders["mapPredicate"],
+                    loaders["union_of_None_type_or_strtype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("mapPredicate")
@@ -2606,7 +2607,7 @@ class JsonldPredicate(Saveable):
             try:
                 refScope = _load_field(
                     _doc.get("refScope"),
-                    loaders["refScope"],
+                    loaders["union_of_None_type_or_inttype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("refScope")
@@ -2653,7 +2654,7 @@ class JsonldPredicate(Saveable):
             try:
                 typeDSL = _load_field(
                     _doc.get("typeDSL"),
-                    loaders["typeDSL"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("typeDSL")
@@ -2700,7 +2701,7 @@ class JsonldPredicate(Saveable):
             try:
                 secondaryFilesDSL = _load_field(
                     _doc.get("secondaryFilesDSL"),
-                    loaders["secondaryFilesDSL"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("secondaryFilesDSL")
@@ -2747,7 +2748,7 @@ class JsonldPredicate(Saveable):
             try:
                 subscope = _load_field(
                     _doc.get("subscope"),
-                    loaders["subscope"],
+                    loaders["union_of_None_type_or_strtype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("subscope")
@@ -2961,8 +2962,8 @@ class SpecializeDef(Saveable):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -2976,7 +2977,7 @@ class SpecializeDef(Saveable):
 
             specializeFrom = _load_field(
                 _doc.get("specializeFrom"),
-                loaders["specializeFrom"],
+                loaders["uri_strtype_False_False_1_None"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("specializeFrom")
@@ -3024,7 +3025,7 @@ class SpecializeDef(Saveable):
 
             specializeTo = _load_field(
                 _doc.get("specializeTo"),
-                loaders["specializeTo"],
+                loaders["uri_strtype_False_False_1_None"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("specializeTo")
@@ -3200,8 +3201,8 @@ class SaladRecordField(RecordField):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -3214,7 +3215,7 @@ class SaladRecordField(RecordField):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["name"],
+                    loaders["uri_strtype_True_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -3270,7 +3271,7 @@ class SaladRecordField(RecordField):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["doc"],
+                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -3318,7 +3319,7 @@ class SaladRecordField(RecordField):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["type"],
+                loaders["typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -3365,7 +3366,7 @@ class SaladRecordField(RecordField):
             try:
                 jsonldPredicate = _load_field(
                     _doc.get("jsonldPredicate"),
-                    loaders["jsonldPredicate"],
+                    loaders["union_of_None_type_or_strtype_or_JsonldPredicateLoader"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("jsonldPredicate")
@@ -3412,7 +3413,7 @@ class SaladRecordField(RecordField):
             try:
                 default = _load_field(
                     _doc.get("default"),
-                    loaders["default"],
+                    loaders["union_of_None_type_or_Any_type"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("default")
@@ -3624,8 +3625,8 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -3638,7 +3639,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["name"],
+                    loaders["uri_strtype_True_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -3694,7 +3695,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 inVocab = _load_field(
                     _doc.get("inVocab"),
-                    loaders["inVocab"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inVocab")
@@ -3741,7 +3742,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 fields = _load_field(
                     _doc.get("fields"),
-                    loaders["fields"],
+                    loaders["idmap_fields_union_of_None_type_or_array_of_SaladRecordFieldLoader"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("fields")
@@ -3789,7 +3790,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["type"],
+                loaders["typedsl_Record_nameLoader_2"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -3836,7 +3837,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["doc"],
+                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -3883,7 +3884,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 docParent = _load_field(
                     _doc.get("docParent"),
-                    loaders["docParent"],
+                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docParent")
@@ -3930,7 +3931,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 docChild = _load_field(
                     _doc.get("docChild"),
-                    loaders["docChild"],
+                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docChild")
@@ -3977,7 +3978,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 docAfter = _load_field(
                     _doc.get("docAfter"),
-                    loaders["docAfter"],
+                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docAfter")
@@ -4024,7 +4025,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 jsonldPredicate = _load_field(
                     _doc.get("jsonldPredicate"),
-                    loaders["jsonldPredicate"],
+                    loaders["union_of_None_type_or_strtype_or_JsonldPredicateLoader"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("jsonldPredicate")
@@ -4071,7 +4072,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 documentRoot = _load_field(
                     _doc.get("documentRoot"),
-                    loaders["documentRoot"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("documentRoot")
@@ -4118,7 +4119,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 abstract = _load_field(
                     _doc.get("abstract"),
-                    loaders["abstract"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("abstract")
@@ -4165,7 +4166,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 extends = _load_field(
                     _doc.get("extends"),
-                    loaders["extends"],
+                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("extends")
@@ -4212,7 +4213,7 @@ class SaladRecordSchema(NamedType, RecordSchema, SchemaDefinedType):
             try:
                 specialize = _load_field(
                     _doc.get("specialize"),
-                    loaders["specialize"],
+                    loaders["idmap_specialize_union_of_None_type_or_array_of_SpecializeDefLoader"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("specialize")
@@ -4480,8 +4481,8 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -4494,7 +4495,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["name"],
+                    loaders["uri_union_of_None_type_or_strtype_True_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -4550,7 +4551,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 inVocab = _load_field(
                     _doc.get("inVocab"),
-                    loaders["inVocab"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inVocab")
@@ -4598,7 +4599,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
 
             symbols = _load_field(
                 _doc.get("symbols"),
-                loaders["symbols"],
+                loaders["uri_array_of_strtype_True_False_None_None"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("symbols")
@@ -4646,7 +4647,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["type"],
+                loaders["typedsl_Enum_nameLoader_2"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -4693,7 +4694,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["doc"],
+                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -4740,7 +4741,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 docParent = _load_field(
                     _doc.get("docParent"),
-                    loaders["docParent"],
+                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docParent")
@@ -4787,7 +4788,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 docChild = _load_field(
                     _doc.get("docChild"),
-                    loaders["docChild"],
+                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docChild")
@@ -4834,7 +4835,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 docAfter = _load_field(
                     _doc.get("docAfter"),
-                    loaders["docAfter"],
+                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docAfter")
@@ -4881,7 +4882,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 jsonldPredicate = _load_field(
                     _doc.get("jsonldPredicate"),
-                    loaders["jsonldPredicate"],
+                    loaders["union_of_None_type_or_strtype_or_JsonldPredicateLoader"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("jsonldPredicate")
@@ -4928,7 +4929,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 documentRoot = _load_field(
                     _doc.get("documentRoot"),
-                    loaders["documentRoot"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("documentRoot")
@@ -4975,7 +4976,7 @@ class SaladEnumSchema(NamedType, EnumSchema, SchemaDefinedType):
             try:
                 extends = _load_field(
                     _doc.get("extends"),
-                    loaders["extends"],
+                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("extends")
@@ -5220,8 +5221,8 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -5234,7 +5235,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["name"],
+                    loaders["uri_strtype_True_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -5290,7 +5291,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 inVocab = _load_field(
                     _doc.get("inVocab"),
-                    loaders["inVocab"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inVocab")
@@ -5338,7 +5339,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["type"],
+                loaders["typedsl_Map_nameLoader_2"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -5386,7 +5387,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
 
             values = _load_field(
                 _doc.get("values"),
-                loaders["values"],
+                loaders["uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("values")
@@ -5433,7 +5434,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["doc"],
+                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -5480,7 +5481,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 docParent = _load_field(
                     _doc.get("docParent"),
-                    loaders["docParent"],
+                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docParent")
@@ -5527,7 +5528,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 docChild = _load_field(
                     _doc.get("docChild"),
-                    loaders["docChild"],
+                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docChild")
@@ -5574,7 +5575,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 docAfter = _load_field(
                     _doc.get("docAfter"),
-                    loaders["docAfter"],
+                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docAfter")
@@ -5621,7 +5622,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 jsonldPredicate = _load_field(
                     _doc.get("jsonldPredicate"),
-                    loaders["jsonldPredicate"],
+                    loaders["union_of_None_type_or_strtype_or_JsonldPredicateLoader"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("jsonldPredicate")
@@ -5668,7 +5669,7 @@ class SaladMapSchema(NamedType, MapSchema, SchemaDefinedType):
             try:
                 documentRoot = _load_field(
                     _doc.get("documentRoot"),
-                    loaders["documentRoot"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("documentRoot")
@@ -5904,8 +5905,8 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -5918,7 +5919,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["name"],
+                    loaders["uri_strtype_True_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -5974,7 +5975,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 inVocab = _load_field(
                     _doc.get("inVocab"),
-                    loaders["inVocab"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inVocab")
@@ -6022,7 +6023,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
 
             names = _load_field(
                 _doc.get("names"),
-                loaders["names"],
+                loaders["uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("names")
@@ -6070,7 +6071,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["type"],
+                loaders["typedsl_Union_nameLoader_2"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -6117,7 +6118,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["doc"],
+                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -6164,7 +6165,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 docParent = _load_field(
                     _doc.get("docParent"),
-                    loaders["docParent"],
+                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docParent")
@@ -6211,7 +6212,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 docChild = _load_field(
                     _doc.get("docChild"),
-                    loaders["docChild"],
+                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docChild")
@@ -6258,7 +6259,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 docAfter = _load_field(
                     _doc.get("docAfter"),
-                    loaders["docAfter"],
+                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docAfter")
@@ -6305,7 +6306,7 @@ class SaladUnionSchema(NamedType, UnionSchema, DocType):
             try:
                 documentRoot = _load_field(
                     _doc.get("documentRoot"),
-                    loaders["documentRoot"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("documentRoot")
@@ -6524,8 +6525,8 @@ class Documentation(NamedType, DocType):
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -6538,7 +6539,7 @@ class Documentation(NamedType, DocType):
             try:
                 name = _load_field(
                     _doc.get("name"),
-                    loaders["name"],
+                    loaders["uri_strtype_True_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("name")
@@ -6594,7 +6595,7 @@ class Documentation(NamedType, DocType):
             try:
                 inVocab = _load_field(
                     _doc.get("inVocab"),
-                    loaders["inVocab"],
+                    loaders["union_of_None_type_or_booltype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inVocab")
@@ -6641,7 +6642,7 @@ class Documentation(NamedType, DocType):
             try:
                 doc = _load_field(
                     _doc.get("doc"),
-                    loaders["doc"],
+                    loaders["union_of_None_type_or_strtype_or_array_of_strtype"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("doc")
@@ -6688,7 +6689,7 @@ class Documentation(NamedType, DocType):
             try:
                 docParent = _load_field(
                     _doc.get("docParent"),
-                    loaders["docParent"],
+                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docParent")
@@ -6735,7 +6736,7 @@ class Documentation(NamedType, DocType):
             try:
                 docChild = _load_field(
                     _doc.get("docChild"),
-                    loaders["docChild"],
+                    loaders["uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docChild")
@@ -6782,7 +6783,7 @@ class Documentation(NamedType, DocType):
             try:
                 docAfter = _load_field(
                     _doc.get("docAfter"),
-                    loaders["docAfter"],
+                    loaders["uri_union_of_None_type_or_strtype_False_False_None_None"],
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("docAfter")
@@ -6830,7 +6831,7 @@ class Documentation(NamedType, DocType):
 
             type_ = _load_field(
                 _doc.get("type"),
-                loaders["type"],
+                loaders["typedsl_Documentation_nameLoader_2"],
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -7036,7 +7037,6 @@ floattype: Final = _PrimitiveLoader(float)
 booltype: Final = _PrimitiveLoader(bool)
 None_type: Final = _PrimitiveLoader(type(None))
 Any_type: Final = _AnyLoader()
-DocumentedFieldLoaders: Final[MutableMapping[str, Loader]] = {}
 PrimitiveTypeLoader: Final = _EnumLoader(
     (
         "null",
@@ -7072,61 +7072,20 @@ AnyLoader: Final = _EnumLoader(("Any",), "Any")
 """
 The **Any** type validates for any non-null value.
 """
-RecordFieldFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-RecordFieldLoader: Final = _RecordLoader(
-    RecordField, RecordFieldFieldLoaders, None, None
-)
-RecordSchemaFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-RecordSchemaLoader: Final = _RecordLoader(
-    RecordSchema, RecordSchemaFieldLoaders, None, None
-)
-EnumSchemaFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-EnumSchemaLoader: Final = _RecordLoader(EnumSchema, EnumSchemaFieldLoaders, None, None)
-ArraySchemaFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-ArraySchemaLoader: Final = _RecordLoader(
-    ArraySchema, ArraySchemaFieldLoaders, None, None
-)
-MapSchemaFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-MapSchemaLoader: Final = _RecordLoader(MapSchema, MapSchemaFieldLoaders, None, None)
-UnionSchemaFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-UnionSchemaLoader: Final = _RecordLoader(
-    UnionSchema, UnionSchemaFieldLoaders, None, None
-)
-JsonldPredicateFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-JsonldPredicateLoader: Final = _RecordLoader(
-    JsonldPredicate, JsonldPredicateFieldLoaders, None, None
-)
-SpecializeDefFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-SpecializeDefLoader: Final = _RecordLoader(
-    SpecializeDef, SpecializeDefFieldLoaders, None, None
-)
-NamedTypeFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-DocTypeFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-SchemaDefinedTypeFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-SaladRecordFieldFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-SaladRecordFieldLoader: Final = _RecordLoader(
-    SaladRecordField, SaladRecordFieldFieldLoaders, None, None
-)
-SaladRecordSchemaFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-SaladRecordSchemaLoader: Final = _RecordLoader(
-    SaladRecordSchema, SaladRecordSchemaFieldLoaders, None, None
-)
-SaladEnumSchemaFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-SaladEnumSchemaLoader: Final = _RecordLoader(
-    SaladEnumSchema, SaladEnumSchemaFieldLoaders, None, None
-)
-SaladMapSchemaFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-SaladMapSchemaLoader: Final = _RecordLoader(
-    SaladMapSchema, SaladMapSchemaFieldLoaders, None, None
-)
-SaladUnionSchemaFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-SaladUnionSchemaLoader: Final = _RecordLoader(
-    SaladUnionSchema, SaladUnionSchemaFieldLoaders, None, None
-)
-DocumentationFieldLoaders: Final[MutableMapping[str, Loader]] = {}
-DocumentationLoader: Final = _RecordLoader(
-    Documentation, DocumentationFieldLoaders, None, None
-)
+RecordFieldLoader: Final = _RecordLoader(RecordField, None, None)
+RecordSchemaLoader: Final = _RecordLoader(RecordSchema, None, None)
+EnumSchemaLoader: Final = _RecordLoader(EnumSchema, None, None)
+ArraySchemaLoader: Final = _RecordLoader(ArraySchema, None, None)
+MapSchemaLoader: Final = _RecordLoader(MapSchema, None, None)
+UnionSchemaLoader: Final = _RecordLoader(UnionSchema, None, None)
+JsonldPredicateLoader: Final = _RecordLoader(JsonldPredicate, None, None)
+SpecializeDefLoader: Final = _RecordLoader(SpecializeDef, None, None)
+SaladRecordFieldLoader: Final = _RecordLoader(SaladRecordField, None, None)
+SaladRecordSchemaLoader: Final = _RecordLoader(SaladRecordSchema, None, None)
+SaladEnumSchemaLoader: Final = _RecordLoader(SaladEnumSchema, None, None)
+SaladMapSchemaLoader: Final = _RecordLoader(SaladMapSchema, None, None)
+SaladUnionSchemaLoader: Final = _RecordLoader(SaladUnionSchema, None, None)
+DocumentationLoader: Final = _RecordLoader(Documentation, None, None)
 array_of_strtype: Final = _ArrayLoader(strtype)
 union_of_None_type_or_strtype_or_array_of_strtype: Final = _UnionLoader(
     (
@@ -7310,144 +7269,73 @@ union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoade
     )
 )
 
-RecordFieldFieldLoaders.update(
-    {
-        "name": uri_strtype_True_False_None_None,
-        "doc": union_of_None_type_or_strtype_or_array_of_strtype,
-        "type": typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2,
-    }
-)
-RecordSchemaFieldLoaders.update(
-    {
-        "fields": idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader,
-        "type": typedsl_Record_nameLoader_2,
-    }
-)
-EnumSchemaFieldLoaders.update(
-    {
-        "name": uri_union_of_None_type_or_strtype_True_False_None_None,
-        "symbols": uri_array_of_strtype_True_False_None_None,
-        "type": typedsl_Enum_nameLoader_2,
-    }
-)
-ArraySchemaFieldLoaders.update(
-    {
-        "items": uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None,
-        "type": typedsl_Array_nameLoader_2,
-    }
-)
-MapSchemaFieldLoaders.update(
-    {
-        "type": typedsl_Map_nameLoader_2,
-        "values": uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None,
-    }
-)
-UnionSchemaFieldLoaders.update(
-    {
-        "names": uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None,
-        "type": typedsl_Union_nameLoader_2,
-    }
-)
-JsonldPredicateFieldLoaders.update(
-    {
-        "_id": uri_union_of_None_type_or_strtype_True_False_None_None,
-        "_type": union_of_None_type_or_strtype,
-        "_container": union_of_None_type_or_strtype,
-        "identity": union_of_None_type_or_booltype,
-        "noLinkCheck": union_of_None_type_or_booltype,
-        "mapSubject": union_of_None_type_or_strtype,
-        "mapPredicate": union_of_None_type_or_strtype,
-        "refScope": union_of_None_type_or_inttype,
-        "typeDSL": union_of_None_type_or_booltype,
-        "secondaryFilesDSL": union_of_None_type_or_booltype,
-        "subscope": union_of_None_type_or_strtype,
-    }
-)
-SpecializeDefFieldLoaders.update(
-    {
-        "specializeFrom": uri_strtype_False_False_1_None,
-        "specializeTo": uri_strtype_False_False_1_None,
-    }
-)
-SaladRecordFieldFieldLoaders.update(
-    {
-        "name": uri_strtype_True_False_None_None,
-        "doc": union_of_None_type_or_strtype_or_array_of_strtype,
-        "type": typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2,
-        "jsonldPredicate": union_of_None_type_or_strtype_or_JsonldPredicateLoader,
-        "default": union_of_None_type_or_Any_type,
-    }
-)
-SaladRecordSchemaFieldLoaders.update(
-    {
-        "name": uri_strtype_True_False_None_None,
-        "inVocab": union_of_None_type_or_booltype,
-        "fields": idmap_fields_union_of_None_type_or_array_of_SaladRecordFieldLoader,
-        "type": typedsl_Record_nameLoader_2,
-        "doc": union_of_None_type_or_strtype_or_array_of_strtype,
-        "docParent": uri_union_of_None_type_or_strtype_False_False_None_None,
-        "docChild": uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None,
-        "docAfter": uri_union_of_None_type_or_strtype_False_False_None_None,
-        "jsonldPredicate": union_of_None_type_or_strtype_or_JsonldPredicateLoader,
-        "documentRoot": union_of_None_type_or_booltype,
-        "abstract": union_of_None_type_or_booltype,
-        "extends": uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None,
-        "specialize": idmap_specialize_union_of_None_type_or_array_of_SpecializeDefLoader,
-    }
-)
-SaladEnumSchemaFieldLoaders.update(
-    {
-        "name": uri_union_of_None_type_or_strtype_True_False_None_None,
-        "inVocab": union_of_None_type_or_booltype,
-        "symbols": uri_array_of_strtype_True_False_None_None,
-        "type": typedsl_Enum_nameLoader_2,
-        "doc": union_of_None_type_or_strtype_or_array_of_strtype,
-        "docParent": uri_union_of_None_type_or_strtype_False_False_None_None,
-        "docChild": uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None,
-        "docAfter": uri_union_of_None_type_or_strtype_False_False_None_None,
-        "jsonldPredicate": union_of_None_type_or_strtype_or_JsonldPredicateLoader,
-        "documentRoot": union_of_None_type_or_booltype,
-        "extends": uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None,
-    }
-)
-SaladMapSchemaFieldLoaders.update(
-    {
-        "name": uri_strtype_True_False_None_None,
-        "inVocab": union_of_None_type_or_booltype,
-        "type": typedsl_Map_nameLoader_2,
-        "values": uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None,
-        "doc": union_of_None_type_or_strtype_or_array_of_strtype,
-        "docParent": uri_union_of_None_type_or_strtype_False_False_None_None,
-        "docChild": uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None,
-        "docAfter": uri_union_of_None_type_or_strtype_False_False_None_None,
-        "jsonldPredicate": union_of_None_type_or_strtype_or_JsonldPredicateLoader,
-        "documentRoot": union_of_None_type_or_booltype,
-    }
-)
-SaladUnionSchemaFieldLoaders.update(
-    {
-        "name": uri_strtype_True_False_None_None,
-        "inVocab": union_of_None_type_or_booltype,
-        "names": uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None,
-        "type": typedsl_Union_nameLoader_2,
-        "doc": union_of_None_type_or_strtype_or_array_of_strtype,
-        "docParent": uri_union_of_None_type_or_strtype_False_False_None_None,
-        "docChild": uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None,
-        "docAfter": uri_union_of_None_type_or_strtype_False_False_None_None,
-        "documentRoot": union_of_None_type_or_booltype,
-    }
-)
-DocumentationFieldLoaders.update(
-    {
-        "name": uri_strtype_True_False_None_None,
-        "inVocab": union_of_None_type_or_booltype,
-        "doc": union_of_None_type_or_strtype_or_array_of_strtype,
-        "docParent": uri_union_of_None_type_or_strtype_False_False_None_None,
-        "docChild": uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None,
-        "docAfter": uri_union_of_None_type_or_strtype_False_False_None_None,
-        "type": typedsl_Documentation_nameLoader_2,
-    }
-)
+_loaders.update({
+    "strtype": strtype,
+    "inttype": inttype,
+    "floattype": floattype,
+    "booltype": booltype,
+    "None_type": None_type,
+    "Any_type": Any_type,
+    "PrimitiveTypeLoader": PrimitiveTypeLoader,
+    "AnyLoader": AnyLoader,
+    "RecordFieldLoader": RecordFieldLoader,
+    "RecordSchemaLoader": RecordSchemaLoader,
+    "EnumSchemaLoader": EnumSchemaLoader,
+    "ArraySchemaLoader": ArraySchemaLoader,
+    "MapSchemaLoader": MapSchemaLoader,
+    "UnionSchemaLoader": UnionSchemaLoader,
+    "JsonldPredicateLoader": JsonldPredicateLoader,
+    "SpecializeDefLoader": SpecializeDefLoader,
+    "SaladRecordFieldLoader": SaladRecordFieldLoader,
+    "SaladRecordSchemaLoader": SaladRecordSchemaLoader,
+    "SaladEnumSchemaLoader": SaladEnumSchemaLoader,
+    "SaladMapSchemaLoader": SaladMapSchemaLoader,
+    "SaladUnionSchemaLoader": SaladUnionSchemaLoader,
+    "DocumentationLoader": DocumentationLoader,
+    "array_of_strtype": array_of_strtype,
+    "union_of_None_type_or_strtype_or_array_of_strtype": union_of_None_type_or_strtype_or_array_of_strtype,
+    "uri_strtype_True_False_None_None": uri_strtype_True_False_None_None,
+    "union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype": union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
+    "array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype": array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
+    "union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype": union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
+    "typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2": typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2,
+    "array_of_RecordFieldLoader": array_of_RecordFieldLoader,
+    "union_of_None_type_or_array_of_RecordFieldLoader": union_of_None_type_or_array_of_RecordFieldLoader,
+    "idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader": idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader,
+    "Record_nameLoader": Record_nameLoader,
+    "typedsl_Record_nameLoader_2": typedsl_Record_nameLoader_2,
+    "union_of_None_type_or_strtype": union_of_None_type_or_strtype,
+    "uri_union_of_None_type_or_strtype_True_False_None_None": uri_union_of_None_type_or_strtype_True_False_None_None,
+    "uri_array_of_strtype_True_False_None_None": uri_array_of_strtype_True_False_None_None,
+    "Enum_nameLoader": Enum_nameLoader,
+    "typedsl_Enum_nameLoader_2": typedsl_Enum_nameLoader_2,
+    "uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None": uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None,
+    "Array_nameLoader": Array_nameLoader,
+    "typedsl_Array_nameLoader_2": typedsl_Array_nameLoader_2,
+    "Map_nameLoader": Map_nameLoader,
+    "typedsl_Map_nameLoader_2": typedsl_Map_nameLoader_2,
+    "Union_nameLoader": Union_nameLoader,
+    "typedsl_Union_nameLoader_2": typedsl_Union_nameLoader_2,
+    "union_of_None_type_or_booltype": union_of_None_type_or_booltype,
+    "union_of_None_type_or_inttype": union_of_None_type_or_inttype,
+    "uri_strtype_False_False_1_None": uri_strtype_False_False_1_None,
+    "uri_union_of_None_type_or_strtype_False_False_None_None": uri_union_of_None_type_or_strtype_False_False_None_None,
+    "uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None": uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_None_None,
+    "union_of_None_type_or_strtype_or_JsonldPredicateLoader": union_of_None_type_or_strtype_or_JsonldPredicateLoader,
+    "union_of_None_type_or_Any_type": union_of_None_type_or_Any_type,
+    "array_of_SaladRecordFieldLoader": array_of_SaladRecordFieldLoader,
+    "union_of_None_type_or_array_of_SaladRecordFieldLoader": union_of_None_type_or_array_of_SaladRecordFieldLoader,
+    "idmap_fields_union_of_None_type_or_array_of_SaladRecordFieldLoader": idmap_fields_union_of_None_type_or_array_of_SaladRecordFieldLoader,
+    "uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None": uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None,
+    "array_of_SpecializeDefLoader": array_of_SpecializeDefLoader,
+    "union_of_None_type_or_array_of_SpecializeDefLoader": union_of_None_type_or_array_of_SpecializeDefLoader,
+    "idmap_specialize_union_of_None_type_or_array_of_SpecializeDefLoader": idmap_specialize_union_of_None_type_or_array_of_SpecializeDefLoader,
+    "Documentation_nameLoader": Documentation_nameLoader,
+    "typedsl_Documentation_nameLoader_2": typedsl_Documentation_nameLoader_2,
+    "union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader": union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader,
+    "array_of_union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader": array_of_union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader,
+    "union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader_or_array_of_union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader": union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader_or_array_of_union_of_SaladRecordSchemaLoader_or_SaladEnumSchemaLoader_or_SaladMapSchemaLoader_or_SaladUnionSchemaLoader_or_DocumentationLoader,
+})
 
 
 def load_document(

--- a/src/schema_salad/python_codegen.py
+++ b/src/schema_salad/python_codegen.py
@@ -5,7 +5,7 @@ from collections.abc import MutableSequence
 from importlib.resources import files
 from io import StringIO
 from types import ModuleType
-from typing import Final, Any, IO
+from typing import Final, Any, IO, cast
 
 try:
     black: ModuleType | None
@@ -95,8 +95,6 @@ class PythonCodeGen(CodeGenBase):
         super().__init__()
         self.out: Final = out
         self.current_class_is_abstract = False
-        self.current_class_is_inherited = False
-        self.current_field_loaders: dict[str, str] = {}
         self.serializer = StringIO()
         self.idfield = ""
         self.copyright: Final = copyright
@@ -189,12 +187,9 @@ else:
         idfield: str,
         optional_fields: set[str],
     ) -> None:
-        self.current_field_loaders = {}
         if (classname := self.safe_name(classname)) in self.inherited_classes:
-            self.current_class_is_inherited = True
+            self.current_class_is_abstract = True
             return
-        else:
-            self.current_class_is_inherited = False
         self.current_class_is_abstract = abstract
 
         if extends:
@@ -304,8 +299,8 @@ else:
         doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
-        docRoot: str | None = None
+        docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -334,19 +329,6 @@ else:
     def end_class(self, classname: str, field_names: list[str]) -> None:
         """Signal that we are done with this class."""
         if self.current_class_is_abstract:
-            return
-
-        self.add_lazy_init(
-            LazyInitDef(
-                self.safe_name(classname) + "FieldLoaders",
-                "{}.update({{{}}})".format(
-                    self.safe_name(classname) + "FieldLoaders",
-                    ", ".join(f'"{k}": {v}' for k, v in self.current_field_loaders.items()),
-                ),
-            )
-        )
-
-        if self.current_class_is_inherited:
             return
 
         self.out.write(
@@ -444,14 +426,28 @@ if _errors__:
                         "_UnionLoader(({},))".format(", ".join(sub_names1)),
                     )
                 )
-            case {"type": "array" | "https://w3id.org/cwl/salad#array", "items": items}:
+            case {"type": "array" | "https://w3id.org/cwl/salad#array", "items": items, **rest}:
                 i1: Final = self.type_loader(items)
-                return self.declare_type(
-                    TypeDef(
-                        f"array_of_{i1.name}",
-                        f"_ArrayLoader({i1.name})",
+                if "original_items" in rest:
+                    self.declare_type(
+                        TypeDef(
+                            f"array_of_{i1.name}",
+                            f"_ArrayLoader({i1.name})",
+                        )
                     )
-                )
+                    return self.declare_type(
+                        TypeDef(
+                            f"array_of_{self.safe_name(shortname(cast(str, rest['original_items'])))}",
+                            f"array_of_{i1.name}",
+                        )
+                    )
+                else:
+                    return self.declare_type(
+                        TypeDef(
+                            f"array_of_{i1.name}",
+                            f"_ArrayLoader({i1.name})",
+                        )
+                    )
             case {"type": "map" | "https://w3id.org/cwl/salad#map", "values": values, **rest}:
                 i2: Final = self.type_loader(values)
                 name = self.safe_name(str(rest["name"])) if "name" in rest else None
@@ -466,6 +462,13 @@ if _errors__:
                         ),
                     )
                 )
+                if "original_values" in rest:
+                    anon_type = self.declare_type(
+                        TypeDef(
+                            f"map_of_{self.safe_name(shortname(cast(str, rest['original_values'])))}",
+                            anon_type.name,
+                        )
+                    )
                 if "name" in rest:
                     return self.declare_type(
                         TypeDef(self.safe_name(str(rest["name"])) + "Loader", anon_type.name)
@@ -504,19 +507,11 @@ if _errors__:
                 classname = self.safe_name(name)
                 if (prefix := name.split("#")[0]) in self.parents_map:
                     self.inherited_classes[classname] = f"{self.parents_map[prefix]}.{classname}"
-                self.declare_type(
-                    TypeDef(
-                        classname + "FieldLoaders",
-                        "{}",
-                        instance_type="MutableMapping[str, Loader]",
-                    )
-                )
                 return self.declare_type(
                     TypeDef(
                         classname + "Loader",
-                        "_RecordLoader({}, {}, {}, {})".format(
+                        "_RecordLoader({}, {}, {})".format(
                             self.inherited_classes.get(classname, classname),
-                            classname + "FieldLoaders",
                             f"'{container}'" if container is not None else None,  # noqa: B907
                             no_link_check,
                         ),
@@ -573,9 +568,6 @@ if _errors__:
 
         self.declare_field(name, fieldtype, doc, True, "")
 
-        if self.current_class_is_inherited:
-            return
-
         if optional:
             opt = """{safename} = "_:" + str(_uuid__.uuid4())""".format(
                 safename=self.safe_name(name)
@@ -605,11 +597,6 @@ if _errors__:
         subscope: str | None,
     ) -> None:
         if self.current_class_is_abstract:
-            return
-
-        self.current_field_loaders[shortname(name)] = fieldtype.name
-
-        if self.current_class_is_inherited:
             return
 
         if optional:
@@ -644,7 +631,7 @@ if _errors__:
         self.out.write(
             """{spc}            {safename} = _load_field(
 {spc}                _doc.get("{fieldname}"),
-{spc}                loaders["{fieldname}"],
+{spc}                loaders["{fieldtype}"],
 {spc}                {baseurivar},
 {spc}                loadingOptions,
 {spc}                lc=_doc.get("{fieldname}")
@@ -652,6 +639,7 @@ if _errors__:
 """.format(
                 safename=self.safe_name(name),
                 fieldname=shortname(name),
+                fieldtype=fieldtype.name,
                 baseurivar=baseurivar,
                 spc=spc,
             )
@@ -850,6 +838,12 @@ if self.{safename} is not None:
                 )
                 self.out.write(fmt(f"{collected_type.name}: {type_} = {collected_type.init}\n", 0))
         self.out.write("\n")
+
+        self.out.write("_loaders.update({\n")
+        for _, collected_type in self.collected_types.items():
+            if not collected_type.abstract:
+                self.out.write(f'    "{collected_type.name}": {collected_type.name},\n')
+        self.out.write("})\n\n")
 
         if self.lazy_inits:
             for lazy_init in self.lazy_inits.values():

--- a/src/schema_salad/python_codegen.py
+++ b/src/schema_salad/python_codegen.py
@@ -102,6 +102,7 @@ class PythonCodeGen(CodeGenBase):
         self.parser_info: Final = parser_info
         self.salad_version: Final = salad_version
         self.inherited_classes: dict[str, str] = {}
+        self.dynamic_loaders: set[str] = set()
 
     @staticmethod
     def safe_name(name: str) -> str:
@@ -300,7 +301,6 @@ else:
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         _doc = copy.copy(doc)
 
@@ -429,16 +429,24 @@ if _errors__:
             case {"type": "array" | "https://w3id.org/cwl/salad#array", "items": items, **rest}:
                 i1: Final = self.type_loader(items)
                 if "original_items" in rest:
+                    original_type = self.safe_name(shortname(cast(str, rest["original_items"])))
                     self.declare_type(
                         TypeDef(
-                            f"array_of_{i1.name}",
-                            f"_ArrayLoader({i1.name})",
+                            f"{original_type}Loader",
+                            i1.name,
+                            abstract=True,
+                        )
+                    )
+                    self.declare_type(
+                        TypeDef(
+                            f"{original_type}ProxyLoader",
+                            '_ProxyLoader("{}")'.format(original_type + "Loader"),
                         )
                     )
                     return self.declare_type(
                         TypeDef(
-                            f"array_of_{self.safe_name(shortname(cast(str, rest['original_items'])))}",
-                            f"array_of_{i1.name}",
+                            f"array_of_{original_type}",
+                            f"_ArrayLoader({original_type}ProxyLoader)",
                         )
                     )
                 else:
@@ -451,22 +459,42 @@ if _errors__:
             case {"type": "map" | "https://w3id.org/cwl/salad#map", "values": values, **rest}:
                 i2: Final = self.type_loader(values)
                 name = self.safe_name(str(rest["name"])) if "name" in rest else None
-                anon_type = self.declare_type(
-                    TypeDef(
-                        f"map_of_{i2.name}",
-                        "_MapLoader({}, {}, {}, {})".format(
-                            i2.name,
-                            f"'{name}'",  # noqa: B907
-                            f"'{container}'" if container is not None else None,  # noqa: B907
-                            no_link_check,
-                        ),
-                    )
-                )
                 if "original_values" in rest:
+                    original_type = self.safe_name(shortname(cast(str, rest["original_values"])))
+                    self.declare_type(
+                        TypeDef(
+                            original_type + "Loader",
+                            i2.name,
+                            abstract=True,
+                        )
+                    )
+                    self.declare_type(
+                        TypeDef(
+                            f"{original_type}ProxyLoader",
+                            '_ProxyLoader("{}")'.format(original_type + "Loader"),
+                        )
+                    )
                     anon_type = self.declare_type(
                         TypeDef(
-                            f"map_of_{self.safe_name(shortname(cast(str, rest['original_values'])))}",
-                            anon_type.name,
+                            f"map_of_{original_type}",
+                            "_MapLoader({}, {}, {}, {})".format(
+                                f"{original_type}ProxyLoader",
+                                f"'{name}'",  # noqa: B907
+                                f"'{container}'" if container is not None else None,  # noqa: B907
+                                no_link_check,
+                            ),
+                        )
+                    )
+                else:
+                    anon_type = self.declare_type(
+                        TypeDef(
+                            f"map_of_{i2.name}",
+                            "_MapLoader({}, {}, {}, {})".format(
+                                i2.name,
+                                f"'{name}'",  # noqa: B907
+                                f"'{container}'" if container is not None else None,  # noqa: B907
+                                no_link_check,
+                            ),
                         )
                     )
                 if "name" in rest:
@@ -507,17 +535,31 @@ if _errors__:
                 classname = self.safe_name(name)
                 if (prefix := name.split("#")[0]) in self.parents_map:
                     self.inherited_classes[classname] = f"{self.parents_map[prefix]}.{classname}"
-                return self.declare_type(
-                    TypeDef(
-                        classname + "Loader",
-                        "_RecordLoader({}, {}, {})".format(
-                            self.inherited_classes.get(classname, classname),
-                            f"'{container}'" if container is not None else None,  # noqa: B907
-                            no_link_check,
-                        ),
-                        abstract=bool(rest.get("abstract", False)),
+                if rest.get("abstract", False):
+                    self.declare_type(
+                        TypeDef(
+                            classname + "Loader",
+                            "None",
+                            abstract=True,
+                        )
                     )
-                )
+                    return self.declare_type(
+                        TypeDef(
+                            classname + "ProxyLoader",
+                            '_ProxyLoader("{}")'.format(classname + "Loader"),
+                        )
+                    )
+                else:
+                    return self.declare_type(
+                        TypeDef(
+                            classname + "Loader",
+                            "_RecordLoader({}, {}, {})".format(
+                                self.inherited_classes.get(classname, classname),
+                                f"'{container}'" if container is not None else None,  # noqa: B907
+                                no_link_check,
+                            ),
+                        )
+                    )
 
             case {
                 "type": "union" | "https://w3id.org/cwl/salad#union",
@@ -631,7 +673,7 @@ if _errors__:
         self.out.write(
             """{spc}            {safename} = _load_field(
 {spc}                _doc.get("{fieldname}"),
-{spc}                loaders["{fieldtype}"],
+{spc}                {fieldtype},
 {spc}                {baseurivar},
 {spc}                loadingOptions,
 {spc}                lc=_doc.get("{fieldname}")
@@ -841,8 +883,8 @@ if self.{safename} is not None:
 
         self.out.write("_loaders.update({\n")
         for _, collected_type in self.collected_types.items():
-            if not collected_type.abstract:
-                self.out.write(f'    "{collected_type.name}": {collected_type.name},\n')
+            if collected_type.abstract:
+                self.out.write(f'    "{collected_type.name}": {collected_type.init},\n')
         self.out.write("})\n\n")
 
         if self.lazy_inits:

--- a/src/schema_salad/python_codegen_support.py
+++ b/src/schema_salad/python_codegen_support.py
@@ -22,7 +22,7 @@ from schema_salad.runtime import (
 from schema_salad.sourceline import SourceLine, add_lc_filename
 from schema_salad.utils import yaml_no_ts  # requires schema-salad v8.2+
 
-_loaders: Final[dict[str, Loader]] = {}
+_loaders: Final[dict[str, Loader | None]] = {}
 _vocab: Final[dict[str, str]] = {}
 _rvocab: Final[dict[str, str]] = {}
 
@@ -283,9 +283,7 @@ class _RecordLoader(Loader, Generic[SaveableType]):
             loadingOptions = LoadingOptions(
                 copyfrom=loadingOptions, container=self.container, no_link_check=self.no_link_check
             )
-        return self.classtype.fromDoc(
-            doc, baseuri, loadingOptions, docRoot=docRoot, loaders=_loaders
-        )
+        return self.classtype.fromDoc(doc, baseuri, loadingOptions, docRoot=docRoot)
 
     def __repr__(self) -> str:
         return str(self.classtype.__name__)
@@ -606,6 +604,29 @@ class _IdMapLoader(Loader):
         return self.inner.load(doc, baseuri, loadingOptions, lc=lc)
 
 
+class _ProxyLoader(Loader):
+    def __init__(self, name: str) -> None:
+        self.name: Final = name
+
+    def load(
+        self,
+        doc: Any,
+        baseuri: str,
+        loadingOptions: LoadingOptions,
+        docRoot: str | None = None,
+        lc: Any | None = None,
+    ) -> Any | None:
+        if (
+            self.name in loadingOptions.loaders
+            and (loader := loadingOptions.loaders.get(self.name)) is not None
+        ):
+            return loader.load(doc, baseuri, loadingOptions, lc=lc)
+        elif self.name in _loaders and (loader := _loaders.get(self.name)) is not None:
+            return loader.load(doc, baseuri, loadingOptions, lc=lc)
+        else:
+            raise ValidationException(f"No Loader instance available for {self.name}")
+
+
 def _document_load(
     loader: Loader,
     doc: str | MutableMapping[str, Any] | MutableSequence[Any],
@@ -638,6 +659,7 @@ def _document_load(
             schemas=doc.get("$schemas", None),
             baseuri=doc.get("$base", None),
             addl_metadata=addl_metadata,
+            loaders=_loaders | loadingOptions.loaders,
         )
 
         doc2: Final = copy.copy(doc)

--- a/src/schema_salad/python_codegen_support.py
+++ b/src/schema_salad/python_codegen_support.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import MutableSequence, Sequence, MutableMapping, Mapping
+from collections.abc import MutableSequence, Sequence, MutableMapping
 from io import StringIO
 from itertools import chain
 from typing import Any, Final, cast, Generic
@@ -22,6 +22,7 @@ from schema_salad.runtime import (
 from schema_salad.sourceline import SourceLine, add_lc_filename
 from schema_salad.utils import yaml_no_ts  # requires schema-salad v8.2+
 
+_loaders: Final[dict[str, Loader]] = {}
 _vocab: Final[dict[str, str]] = {}
 _rvocab: Final[dict[str, str]] = {}
 
@@ -258,12 +259,10 @@ class _RecordLoader(Loader, Generic[SaveableType]):
     def __init__(
         self,
         classtype: type[SaveableType],
-        loaders: Mapping[str, Loader],
         container: str | None = None,
         no_link_check: bool | None = None,
     ) -> None:
         self.classtype: Final = classtype
-        self.loaders: Final = loaders
         self.container: Final = container
         self.no_link_check: Final = no_link_check
 
@@ -284,7 +283,9 @@ class _RecordLoader(Loader, Generic[SaveableType]):
             loadingOptions = LoadingOptions(
                 copyfrom=loadingOptions, container=self.container, no_link_check=self.no_link_check
             )
-        return self.classtype.fromDoc(doc, baseuri, loadingOptions, self.loaders, docRoot=docRoot)
+        return self.classtype.fromDoc(
+            doc, baseuri, loadingOptions, docRoot=docRoot, loaders=_loaders
+        )
 
     def __repr__(self) -> str:
         return str(self.classtype.__name__)

--- a/src/schema_salad/runtime.py
+++ b/src/schema_salad/runtime.py
@@ -13,7 +13,7 @@ import sys
 import tempfile
 import xml.sax  # nosec
 from abc import ABCMeta, abstractmethod
-from collections.abc import MutableMapping, MutableSequence, Mapping
+from collections.abc import MutableMapping, MutableSequence
 from typing import Any, Final, TypeAlias, cast, TypeVar
 from urllib.parse import quote, urlparse, urlsplit
 from urllib.request import pathname2url
@@ -206,6 +206,9 @@ class LoadingOptions:
         return graph
 
 
+_loaders: Final[dict[str, Loader]] = {}
+
+
 class Saveable(metaclass=ABCMeta):
     """Mark classes than have a save() and fromDoc() function."""
 
@@ -216,8 +219,8 @@ class Saveable(metaclass=ABCMeta):
         _doc: Any,
         baseuri: str,
         loadingOptions: LoadingOptions,
-        loaders: Mapping[str, Loader],
         docRoot: str | None = None,
+        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         """Construct this object from the result of yaml.load()."""
 

--- a/src/schema_salad/runtime.py
+++ b/src/schema_salad/runtime.py
@@ -67,6 +67,7 @@ class LoadingOptions:
     includes: Final[list[str]]
     no_link_check: Final[bool | None]
     container: Final[str | None]
+    loaders: Final[dict[str, Loader | None]]
 
     def __init__(
         self,
@@ -83,6 +84,7 @@ class LoadingOptions:
         includes: list[str] | None = None,
         no_link_check: bool | None = None,
         container: str | None = None,
+        loaders: dict[str, Loader | None] | None = None,
     ) -> None:
         """Create a LoadingOptions object."""
         self.original_doc = original_doc
@@ -147,6 +149,12 @@ class LoadingOptions:
             temp_container = copyfrom.container if copyfrom is not None else None
         self.container = temp_container
 
+        if loaders is not None:
+            loaders = loaders
+        else:
+            loaders = copyfrom.loaders if copyfrom is not None else {}
+        self.loaders = loaders
+
         if fetcher is not None:
             temp_fetcher = fetcher
         elif copyfrom is not None:
@@ -206,9 +214,6 @@ class LoadingOptions:
         return graph
 
 
-_loaders: Final[dict[str, Loader]] = {}
-
-
 class Saveable(metaclass=ABCMeta):
     """Mark classes than have a save() and fromDoc() function."""
 
@@ -220,7 +225,6 @@ class Saveable(metaclass=ABCMeta):
         baseuri: str,
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
-        loaders: dict[str, Loader] = _loaders,
     ) -> Self:
         """Construct this object from the result of yaml.load()."""
 

--- a/src/schema_salad/schema.py
+++ b/src/schema_salad/schema.py
@@ -466,7 +466,8 @@ def replace_type(
             items["name"] = get_anon_name(items)
         for name in ("type", "items", "fields", "values"):
             if name in items:
-                items[name] = replace_type(
+                old_type = items[name]
+                new_type = replace_type(
                     items[name],
                     spec,
                     loader,
@@ -474,6 +475,9 @@ def replace_type(
                     find_embeds=find_embeds,
                     deepen=find_embeds,
                 )
+                if isinstance(old_type, str) and not isinstance(new_type, str):
+                    items[f"original_{name}"] = old_type
+                items[name] = new_type
                 if isinstance(items[name], MutableSequence):
                     items[name] = flatten(items[name])
 

--- a/src/schema_salad/tests/test_cg.py
+++ b/src/schema_salad/tests/test_cg.py
@@ -21,7 +21,6 @@ def test_load() -> None:
         doc,
         "http://example.com/",
         LoadingOptions(no_link_check=True),
-        cg_metaschema.RecordSchemaFieldLoaders,
     )
     assert "record" == rs.type_
     assert rs.fields and "http://example.com/#hello" == rs.fields[0].name
@@ -43,7 +42,9 @@ def test_err() -> None:
     doc = {"doc": "Hello test case", "type": "string"}
     with pytest.raises(ValidationException):
         cg_metaschema.RecordField.fromDoc(
-            doc, "", LoadingOptions(), cg_metaschema.RecordFieldFieldLoaders
+            doc,
+            "",
+            LoadingOptions(),
         )
 
 
@@ -54,7 +55,6 @@ def test_include() -> None:
         doc,
         "http://example.com/",
         LoadingOptions(fileuri=path_uri, no_link_check=True),
-        cg_metaschema.DocumentationFieldLoaders,
     )
     assert "http://example.com/#hello" == rf.name
     assert ["hello world!\n"] == rf.doc
@@ -73,7 +73,6 @@ def test_import() -> None:
         doc,
         "http://example.com/",
         LoadingOptions(fileuri=lead + "/_"),
-        cg_metaschema.RecordSchemaFieldLoaders,
     )
     assert "record" == rs.type_
     assert rs.fields and lead + "/hellofield.yml#hello" == rs.fields[0].name
@@ -119,7 +118,9 @@ def test_err2() -> None:
     }
     with pytest.raises(ValidationException):
         cg_metaschema.RecordSchema.fromDoc(
-            doc, "", LoadingOptions(), cg_metaschema.RecordSchemaFieldLoaders
+            doc,
+            "",
+            LoadingOptions(),
         )
 
 
@@ -132,7 +133,6 @@ def test_idmap() -> None:
         doc,
         "http://example.com/",
         LoadingOptions(no_link_check=True),
-        cg_metaschema.RecordSchemaFieldLoaders,
     )
     assert "record" == rs.type_
     assert rs.fields and "http://example.com/#hello" == rs.fields[0].name
@@ -156,7 +156,6 @@ def test_idmap2() -> None:
         doc,
         "http://example.com/",
         LoadingOptions(no_link_check=True),
-        cg_metaschema.RecordSchemaFieldLoaders,
     )
     assert "record" == rs.type_
     assert rs.fields and "http://example.com/#hello" == rs.fields[0].name

--- a/src/schema_salad/tests/test_examples.py
+++ b/src/schema_salad/tests/test_examples.py
@@ -611,10 +611,8 @@ def test_python_codegen_parent(tmp_path: Path) -> None:
     assert "class ArraySchema(Saveable)" not in content
     assert "class CWLArraySchema(schema_salad.metaschema.ArraySchema)" in content
     assert "class Workflow(Process)" in content
+    assert "EnumSchemaLoader: Final = _RecordLoader(EnumSchema, None, None)" not in content
     assert (
-        "EnumSchemaLoader: Final = _RecordLoader(EnumSchema, EnumSchemaFieldLoaders, None, None)"
-        not in content
+        "EnumSchemaLoader: Final = _RecordLoader(schema_salad.metaschema.EnumSchema, None, None)"
+        in content
     )
-    assert """EnumSchemaLoader: Final = _RecordLoader(
-    schema_salad.metaschema.EnumSchema, EnumSchemaFieldLoaders, None, None
-)""" in content

--- a/src/schema_salad/tests/test_python_codegen.py
+++ b/src/schema_salad/tests/test_python_codegen.py
@@ -33,10 +33,7 @@ def test_cwl_gen(tmp_path: Path) -> None:
     assert "class ArraySchema(Saveable)" in content
     assert "class CWLArraySchema(ArraySchema)" in content
     assert "class Workflow(Process)" in content
-    assert (
-        "EnumSchemaLoader: Final = _RecordLoader(EnumSchema, EnumSchemaFieldLoaders, None, None)"
-        in content
-    )
+    assert "EnumSchemaLoader: Final = _RecordLoader(EnumSchema, None, None)" in content
 
 
 def test_cwl_gen_with_inheritance(tmp_path: Path) -> None:
@@ -53,13 +50,11 @@ def test_cwl_gen_with_inheritance(tmp_path: Path) -> None:
     assert "class ArraySchema(Saveable)" not in content
     assert "class CWLArraySchema(schema_salad.metaschema.ArraySchema)" in content
     assert "class Workflow(Process)" in content
+    assert "EnumSchemaLoader: Final = _RecordLoader(EnumSchema, None, None)" not in content
     assert (
-        "EnumSchemaLoader: Final = _RecordLoader(EnumSchema, EnumSchemaFieldLoaders, None, None)"
-        not in content
+        "EnumSchemaLoader: Final = _RecordLoader(schema_salad.metaschema.EnumSchema, None, None)"
+        in content
     )
-    assert ("""EnumSchemaLoader: Final = _RecordLoader(
-    schema_salad.metaschema.EnumSchema, EnumSchemaFieldLoaders, None, None
-)""") in content
 
 
 def test_meta_schema_gen(tmp_path: Path) -> None:

--- a/src/schema_salad/validate.py
+++ b/src/schema_salad/validate.py
@@ -328,6 +328,12 @@ def validate_ex(
                 avroname = None
                 if d in vocab:
                     avroname = avro_type_name(vocab[d])
+                elif ":" in d:
+                    prefix = d.split(":")[0]
+                    if prefix in vocab:
+                        d = vocab[prefix] + d[len(prefix) + 1 :]
+                        if d in vocab:
+                            avroname = avro_type_name(vocab[d])
                 if expected_schema.name not in (d, avroname):
                     if raise_ex:
                         raise ValidationException(


### PR DESCRIPTION
This commit forces the `ref_resolver` logic to retain the original type when applying the `extend` logic to Schema SALAD objects, in order to allow for inheritance-based typing in record fields. This update also allows for parent-based loader naming, allowing to implement the `_ProxyLoader` logic to correctly handle prefix-based inheritance.