### PR TITLE
save_relative_uri: don't truncate ids sharing a name prefix with their scope

### DIFF
--- a/src/schema_salad/dotnet/util/Saveable.cs
+++ b/src/schema_salad/dotnet/util/Saveable.cs
@@ -135,6 +135,13 @@ public interface ISaveable
                     }
 
                     baseFrag = string.Join('/', sp);
+                    if (baseFrag.Length > 0 && !baseFrag.EndsWith("/"))
+                    {
+                        // Match only on a path-segment boundary, so that a sibling id
+                        // sharing a prefix (e.g. "step_1_input" vs "step_1") is not
+                        // truncated.
+                        baseFrag += "/";
+                    }
                 }
 
                 if (uriSplit.FragmentWithoutFragmentation().StartsWith(baseFrag))

--- a/src/schema_salad/runtime.py
+++ b/src/schema_salad/runtime.py
@@ -403,6 +403,11 @@ def save_relative_uri(
                     sp.pop()
                     i += 1
                 basefrag = "/".join(sp)
+                if basefrag:
+                    # Match only on a path-segment boundary, so that a sibling
+                    # id sharing a prefix (e.g. "step_1_input" vs "step_1")
+                    # is not truncated.
+                    basefrag += "/"
 
             if urisplit.fragment.startswith(basefrag):
                 return urisplit.fragment[len(basefrag) :]

--- a/src/schema_salad/tests/test_runtime.py
+++ b/src/schema_salad/tests/test_runtime.py
@@ -1,0 +1,66 @@
+"""Tests of the runtime support functions for generated parsers."""
+
+from schema_salad.runtime import save_relative_uri
+
+BASE = "file:///wf.cwl#second_step/input_2"
+
+
+def test_save_relative_uri_sibling_prefix() -> None:
+    """A sibling id sharing a name prefix with the scope must not be truncated.
+
+    E.g. in CWL, a step input sourced from a workflow input whose name
+    starts with the step's own name:
+
+        inputs:
+          second_step_input: string        # id: ...#second_step_input
+        steps:
+          second_step:
+            in:
+              input_2: second_step_input   # id: ...#second_step/input_2
+
+    Saving the `source` field (ref_scope=2) must yield "second_step_input",
+    not "_input".
+    """
+    uri = "file:///wf.cwl#second_step_input"
+    assert save_relative_uri(uri, BASE, False, 2, True) == "second_step_input"
+
+
+def test_save_relative_uri_sibling_prefix_ref_scope_1() -> None:
+    """Same as above for ref_scope=1 fields, e.g. a CWL Workflow outputSource.
+
+        outputs:
+          second:                          # id: ...#second
+            outputSource: second_step/log
+
+    must save as "second_step/log", not "_step/log".
+    """
+    uri = "file:///wf.cwl#second_step/log"
+    base = "file:///wf.cwl#second"
+    assert save_relative_uri(uri, base, False, 1, True) == "second_step/log"
+
+
+def test_save_relative_uri_sibling() -> None:
+    """An ordinary sibling reference is saved as its full fragment.
+
+    E.g. CWL's `source: first_input` or `source: first_step/log`.
+    """
+    uri = "file:///wf.cwl#first_input"
+    assert save_relative_uri(uri, BASE, False, 2, True) == "first_input"
+    uri = "file:///wf.cwl#first_step/log"
+    assert save_relative_uri(uri, BASE, False, 2, True) == "first_step/log"
+
+
+def test_save_relative_uri_inside_scope() -> None:
+    """A reference below the popped scope is relativized without a leading slash."""
+    uri = "file:///wf.cwl#second_step/log"
+    assert save_relative_uri(uri, BASE, False, 2, True) == "log"
+
+
+def test_save_relative_uri_no_ref_scope() -> None:
+    """Without ref_scope the base fragment already ends in a slash.
+
+    E.g. how CWL's `scatter: input_2` is saved relative to its step.
+    """
+    uri = "file:///wf.cwl#second_step/input_2"
+    base = "file:///wf.cwl#second_step"
+    assert save_relative_uri(uri, base, False, None, True) == "input_2"

--- a/src/schema_salad/typescript/util/Saveable.ts
+++ b/src/schema_salad/typescript/util/Saveable.ts
@@ -75,6 +75,12 @@ export function saveRelativeUri (uri: any, baseUrl: string='', scopedId: boolean
           i += 1
         }
         basefrag = sp.join('/')
+        if (basefrag !== '' && !basefrag.endsWith('/')) {
+          // Match only on a path-segment boundary, so that a sibling id
+          // sharing a prefix (e.g. "step_1_input" vs "step_1") is not
+          // truncated.
+          basefrag += '/'
+        }
       }
       if (uriSplit.fragment == null) {
         uriSplit.fragment = ''


### PR DESCRIPTION
Fixes common-workflow-language/cwl-utils#402 :crossed_fingers: 