### PR TITLE
Update rpmfind package versions for cibuildwheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-verbosity = 1
 environment = { SCHEMA_SALAD_USE_MYPYC="1", MYPYPATH="$(pwd)/mypy-stubs", CCACHE_SLOPPINESS="include_file_ctime,include_file_mtime,locale,time_macros", CCACHE_NOHASHDIR="true" }
 
 [tool.cibuildwheel.linux]
-before-all = "apk add ccache || yum install -y ccache || dnf --nogpg -y install https://www.rpmfind.net/linux/opensuse/ports/riscv/tumbleweed/repo/oss/riscv64/ccache-4.11.3-2.6.riscv64.rpm https://www.rpmfind.net/linux/opensuse/ports/riscv/tumbleweed/repo/oss/riscv64/libcpp-httplib0_42-0.42.0-4.1.riscv64.rpm https://www.rpmfind.net/linux/opensuse/ports/riscv/tumbleweed/repo/oss/riscv64/libfmt12-12.1.0-1.1.riscv64.rpm https://www.rpmfind.net/linux/opensuse/ports/riscv/tumbleweed/repo/oss/riscv64/libhiredis1_3_0-1.3.0-1.1.riscv64.rpm https://www.rpmfind.net/linux/opensuse/ports/riscv/tumbleweed/repo/oss/riscv64/libxxhash0-0.8.3-4.2.riscv64.rpm || apt-get install -y --no-install-recommends ccache"
+before-all = "apk add ccache || yum install -y ccache || dnf --nogpg -y install https://www.rpmfind.net/linux/opensuse/ports/riscv/tumbleweed/repo/oss/riscv64/ccache-4.13.6-1.3.riscv64.rpm https://www.rpmfind.net/linux/opensuse/ports/riscv/tumbleweed/repo/oss/riscv64/libcpp-httplib0_49-0.49.0-4.1.riscv64.rpm https://www.rpmfind.net/linux/opensuse/ports/riscv/tumbleweed/repo/oss/riscv64/libfmt12-12.1.0-1.1.riscv64.rpm https://www.rpmfind.net/linux/opensuse/ports/riscv/tumbleweed/repo/oss/riscv64/libhiredis1_3_0-1.3.0-1.1.riscv64.rpm https://www.rpmfind.net/linux/opensuse/ports/riscv/tumbleweed/repo/oss/riscv64/libxxhash0-0.8.3-4.2.riscv64.rpm || apt-get install -y --no-install-recommends ccache"
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Bump ccache to 4.13.6 and libcpp-httplib to 0.49.0 in the riscv64 rpmfind .rpm URLs used for cibuildwheel builds on Linux.