### PR TITLE
codegen: Rework ProxyLoader generation

### DIFF
--- a/src/schema_salad/codegen.py
+++ b/src/schema_salad/codegen.py
@@ -37,7 +37,10 @@ def codegen(
     parser_info: str | None = None,
 ) -> None:
     """Generate classes with loaders for the given Schema Salad description."""
-    j = schema.extend_and_specialize(i, loader)
+    j = {
+        r["name"]: r
+        for r in schema.extend_and_specialize(i, loader, expand_subtypes=lang != "python")
+    }
 
     gen: CodeGenBase
     base = schema_metadata.get("$base", schema_metadata.get("id"))
@@ -72,7 +75,7 @@ def codegen(
                         spdx_copyright_text,
                         spdx_license_identifier,
                     )
-                    gen.parse(j)
+                    gen.parse(list(j.values()))
                     return
                 case "dlang":
                     gen = DlangCodeGen(
@@ -84,7 +87,7 @@ def codegen(
                         info,
                         salad_version,
                     )
-                    gen.parse(j)
+                    gen.parse(list(j.values()))
                     return
                 case "python":
                     gen = PythonCodeGen(
@@ -113,23 +116,27 @@ def codegen(
 
     document_roots = []
 
-    for rec in j:
+    for name, rec in j.items():
         if rec["type"] in ("enum", "map", "record", "union"):
             jld = rec.get("jsonldPredicate")
             if isinstance(jld, MutableMapping):
                 gen.type_loader(rec, jld.get("_container"), jld.get("noLinkCheck"))
             else:
                 gen.type_loader(rec)
-            gen.add_vocab(shortname(rec["name"]), rec["name"])
+            gen.add_vocab(shortname(name), name)
+        if rec["type"] == "record" and rec.get("extends"):
+            for t in aslist(rec.get("extends")):
+                if j[t]["type"] == "record" and j[t].get("abstract"):
+                    gen.add_extend(name, t)
 
-    for rec in j:
+    for name, rec in j.items():
         if rec["type"] == "enum":
             for symbol in rec["symbols"]:
                 gen.add_vocab(shortname(symbol), symbol)
 
         if rec["type"] == "record":
             if rec.get("documentRoot"):
-                document_roots.append(rec["name"])
+                document_roots.append(name)
 
             field_names = []
             optional_fields = set()
@@ -146,7 +153,7 @@ def codegen(
                     idfield = field.get("name")
 
             gen.begin_class(
-                rec["name"],
+                name,
                 aslist(rec.get("extends", [])),
                 rec.get("doc", ""),
                 rec.get("abstract", False),
@@ -154,13 +161,13 @@ def codegen(
                 idfield,
                 optional_fields,
             )
-            gen.add_vocab(shortname(rec["name"]), rec["name"])
+            gen.add_vocab(shortname(name), name)
 
             sorted_fields = sorted(
                 rec.get("fields", []),
-                key=lambda i: (
-                    FIELD_SORT_ORDER.index(i["name"].split("/")[-1])
-                    if i["name"].split("/")[-1] in FIELD_SORT_ORDER
+                key=lambda idx: (
+                    FIELD_SORT_ORDER.index(idx["name"].split("/")[-1])
+                    if idx["name"].split("/")[-1] in FIELD_SORT_ORDER
                     else 100
                 ),
             )
@@ -187,7 +194,9 @@ def codegen(
 
                 if isinstance(jld, MutableMapping):
                     type_loader = gen.type_loader(
-                        field["type"], jld.get("_container"), jld.get("noLinkCheck")
+                        field["type"],
+                        jld.get("_container"),
+                        jld.get("noLinkCheck"),
                     )
                     ref_scope = jld.get("refScope")
                     subscope = jld.get("subscope")
@@ -227,7 +236,7 @@ def codegen(
 
                 gen.declare_field(fieldpred, type_loader, field.get("doc"), optional, subscope)
 
-            gen.end_class(rec["name"], field_names)
+            gen.end_class(name, field_names)
 
     root_type = list(document_roots)
     root_type.append({"type": "array", "items": document_roots})

--- a/src/schema_salad/codegen_base.py
+++ b/src/schema_salad/codegen_base.py
@@ -30,6 +30,7 @@ class CodeGenBase:
 
     def __init__(self) -> None:
         self.collected_types: OrderedDict[str, TypeDef] = OrderedDict()
+        self.extended_by: dict[str, set[str]] = {}
         self.lazy_inits: OrderedDict[str, LazyInitDef] = OrderedDict()
         self.vocab: dict[str, str] = {}
 
@@ -38,6 +39,10 @@ class CodeGenBase:
         if declared_type not in self.collected_types.values():
             self.collected_types[declared_type.name] = declared_type
         return declared_type
+
+    def add_extend(self, subtype: str, supertype: str) -> None:
+        """Add type inheritance info."""
+        self.extended_by.setdefault(supertype, set()).add(subtype)
 
     def add_lazy_init(self, lazy_init: LazyInitDef) -> None:
         """Add lazy initialization logic for a given type."""

--- a/src/schema_salad/python_codegen.py
+++ b/src/schema_salad/python_codegen.py
@@ -5,7 +5,7 @@ from collections.abc import MutableSequence
 from importlib.resources import files
 from io import StringIO
 from types import ModuleType
-from typing import Final, Any, IO, cast
+from typing import Final, Any, IO
 
 try:
     black: ModuleType | None
@@ -102,7 +102,6 @@ class PythonCodeGen(CodeGenBase):
         self.parser_info: Final = parser_info
         self.salad_version: Final = salad_version
         self.inherited_classes: dict[str, str] = {}
-        self.dynamic_loaders: set[str] = set()
 
     @staticmethod
     def safe_name(name: str) -> str:
@@ -417,7 +416,7 @@ if _errors__:
         """Parse the given type declaration and declare its components."""
         match type_declaration:
             case MutableSequence():
-                sub_names1: Final = list(
+                sub_names1 = list(
                     dict.fromkeys([self.type_loader(i).name for i in type_declaration])
                 )
                 return self.declare_type(
@@ -427,76 +426,31 @@ if _errors__:
                     )
                 )
             case {"type": "array" | "https://w3id.org/cwl/salad#array", "items": items, **rest}:
-                i1: Final = self.type_loader(items)
-                if "original_items" in rest:
-                    original_type = self.safe_name(shortname(cast(str, rest["original_items"])))
-                    self.declare_type(
-                        TypeDef(
-                            f"{original_type}Loader",
-                            i1.name,
-                            abstract=True,
-                        )
+                i1: Final = self.type_loader(
+                    items,
+                )
+                return self.declare_type(
+                    TypeDef(
+                        f"array_of_{i1.name}",
+                        f"_ArrayLoader({i1.name})",
                     )
-                    self.declare_type(
-                        TypeDef(
-                            f"{original_type}ProxyLoader",
-                            '_ProxyLoader("{}")'.format(original_type + "Loader"),
-                        )
-                    )
-                    return self.declare_type(
-                        TypeDef(
-                            f"array_of_{original_type}",
-                            f"_ArrayLoader({original_type}ProxyLoader)",
-                        )
-                    )
-                else:
-                    return self.declare_type(
-                        TypeDef(
-                            f"array_of_{i1.name}",
-                            f"_ArrayLoader({i1.name})",
-                        )
-                    )
+                )
             case {"type": "map" | "https://w3id.org/cwl/salad#map", "values": values, **rest}:
-                i2: Final = self.type_loader(values)
+                i2: Final = self.type_loader(
+                    values,
+                )
                 name = self.safe_name(str(rest["name"])) if "name" in rest else None
-                if "original_values" in rest:
-                    original_type = self.safe_name(shortname(cast(str, rest["original_values"])))
-                    self.declare_type(
-                        TypeDef(
-                            original_type + "Loader",
+                anon_type = self.declare_type(
+                    TypeDef(
+                        f"map_of_{i2.name}",
+                        "_MapLoader({}, {}, {}, {})".format(
                             i2.name,
-                            abstract=True,
-                        )
+                            f"'{name}'",  # noqa: B907
+                            f"'{container}'" if container is not None else None,  # noqa: B907
+                            no_link_check,
+                        ),
                     )
-                    self.declare_type(
-                        TypeDef(
-                            f"{original_type}ProxyLoader",
-                            '_ProxyLoader("{}")'.format(original_type + "Loader"),
-                        )
-                    )
-                    anon_type = self.declare_type(
-                        TypeDef(
-                            f"map_of_{original_type}",
-                            "_MapLoader({}, {}, {}, {})".format(
-                                f"{original_type}ProxyLoader",
-                                f"'{name}'",  # noqa: B907
-                                f"'{container}'" if container is not None else None,  # noqa: B907
-                                no_link_check,
-                            ),
-                        )
-                    )
-                else:
-                    anon_type = self.declare_type(
-                        TypeDef(
-                            f"map_of_{i2.name}",
-                            "_MapLoader({}, {}, {}, {})".format(
-                                i2.name,
-                                f"'{name}'",  # noqa: B907
-                                f"'{container}'" if container is not None else None,  # noqa: B907
-                                no_link_check,
-                            ),
-                        )
-                    )
+                )
                 if "name" in rest:
                     return self.declare_type(
                         TypeDef(self.safe_name(str(rest["name"])) + "Loader", anon_type.name)
@@ -594,7 +548,27 @@ if _errors__:
                     )
                 )
             case str(decl):
-                return self.collected_types[self.safe_name(decl) + "Loader"]
+                if decl in self.extended_by:
+                    i3: Final = self.type_loader(
+                        list(self.extended_by[decl])
+                        if len(self.extended_by[decl]) > 1
+                        else next(iter(self.extended_by[decl]))
+                    )
+                    self.declare_type(
+                        TypeDef(
+                            f"{self.safe_name(decl)}Loader",
+                            i3.name,
+                            abstract=True,
+                        )
+                    )
+                    return self.declare_type(
+                        TypeDef(
+                            f"{self.safe_name(decl)}ProxyLoader",
+                            '_ProxyLoader("{}")'.format(self.safe_name(decl) + "Loader"),
+                        )
+                    )
+                else:
+                    return self.collected_types[f"{self.safe_name(decl)}Loader"]
             case _ as decl:
                 raise SchemaException(f"wtf {decl}")
 

--- a/src/schema_salad/schema.py
+++ b/src/schema_salad/schema.py
@@ -19,7 +19,6 @@ from schema_salad.utils import (
     json_dumps,
     yaml_no_ts,
 )
-
 from . import _logger, jsonld_context, ref_resolver, validate
 from .avro.schema import Names, SchemaParseException, is_subtype, make_avsc_object
 from .exceptions import (
@@ -466,7 +465,6 @@ def replace_type(
             items["name"] = get_anon_name(items)
         for name in ("type", "items", "fields", "values"):
             if name in items:
-                old_type = items[name]
                 new_type = replace_type(
                     items[name],
                     spec,
@@ -475,8 +473,6 @@ def replace_type(
                     find_embeds=find_embeds,
                     deepen=find_embeds,
                 )
-                if isinstance(old_type, str) and not isinstance(new_type, str):
-                    items[f"original_{name}"] = old_type
                 items[name] = new_type
                 if isinstance(items[name], MutableSequence):
                     items[name] = flatten(items[name])
@@ -605,7 +601,9 @@ def deepcopy_strip(item: Any) -> Any:
     return item
 
 
-def extend_and_specialize(items: list[dict[str, Any]], loader: Loader) -> list[dict[str, Any]]:
+def extend_and_specialize(
+    items: list[dict[str, Any]], loader: Loader, expand_subtypes: bool = True
+) -> list[dict[str, Any]]:
     """Apply 'extend' and 'specialize' to fully materialize derived record types."""
     items2: Final = deepcopy_strip(items)
     types: dict[str, Any] = {
@@ -722,9 +720,13 @@ def extend_and_specialize(items: list[dict[str, Any]], loader: Loader) -> list[d
 
     for result in results:
         if "fields" in result:
-            result["fields"] = replace_type(result["fields"], extended_by, loader, set())
+            result["fields"] = replace_type(
+                result["fields"], extended_by if expand_subtypes else {}, loader, set()
+            )
         elif "values" in result:
-            result["values"] = replace_type(result["values"], extended_by, loader, set())
+            result["values"] = replace_type(
+                result["values"], extended_by if expand_subtypes else {}, loader, set()
+            )
 
     return results
 

--- a/src/schema_salad/tests/test_python_codegen.py
+++ b/src/schema_salad/tests/test_python_codegen.py
@@ -34,6 +34,7 @@ def test_cwl_gen(tmp_path: Path) -> None:
     assert "class CWLArraySchema(ArraySchema)" in content
     assert "class Workflow(Process)" in content
     assert "EnumSchemaLoader: Final = _RecordLoader(EnumSchema, None, None)" in content
+    assert "union_of_ProcessRequirementProxyLoader_or_Any_type: Final = _UnionLoader(" in content
 
 
 def test_cwl_gen_with_inheritance(tmp_path: Path) -> None:
@@ -55,6 +56,7 @@ def test_cwl_gen_with_inheritance(tmp_path: Path) -> None:
         "EnumSchemaLoader: Final = _RecordLoader(schema_salad.metaschema.EnumSchema, None, None)"
         in content
     )
+    assert "union_of_ProcessRequirementProxyLoader_or_Any_type: Final = _UnionLoader(" in content
 
 
 def test_meta_schema_gen(tmp_path: Path) -> None:


### PR DESCRIPTION
Instead of embedding original type info into the schema during `extend_and_specialize` (via `original_items`/`original_values`), capture the un-expanded schema alongside the specialized one and propagate original types through `type_loader` directly. This makes `ProxyLoader` generation more robust by deriving it from the original type declaration rather than relying on markers written into the schema.

- Add `expand_subtypes` flag to `extend_and_specialize` to keep an un-specialized copy for codegen
- Drop `original_items`/`original_values` mutation in `replace_type`
- Thread `original_type` through type_loader in all codegen backends
- Expand `PythonCodeGen.type_loader` to build proxy loaders from original types, including union membership via inherited (`extended_by`) types
- Track record inheritance with `add_extend`/`extended_by`