### PR TITLE
Adapt test schemas to newest CWL version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,6 @@ test-command = "python -m pytest -n 0 --junitxml={project}/test-results/junit_$(
 [tool.black]
 line-length = 100
 target-version = [ "py310" ]
+
+[tool.pytest.ini_options]
+testpaths = ["src/schema_salad/tests"]

--- a/src/schema_salad/avro/schema.py
+++ b/src/schema_salad/avro/schema.py
@@ -43,10 +43,9 @@ from schema_salad.exceptions import SchemaException
 #
 
 PRIMITIVE_TYPES = ("null", "boolean", "string", "int", "long", "float", "double")
-
 NAMED_TYPES = ("enum", "record")
-
-VALID_TYPES = PRIMITIVE_TYPES + NAMED_TYPES + ("array", "map", "union")
+MAYBE_NAMED_TYPES = ("map", "union")
+VALID_TYPES = PRIMITIVE_TYPES + NAMED_TYPES + MAYBE_NAMED_TYPES + ("array",)
 
 SCHEMA_RESERVED_PROPS = (
     "type",
@@ -232,7 +231,7 @@ class Names:
 
 
 class NamedSchema(Schema):
-    """Named Schemas specified in NAMED_TYPES."""
+    """Named Schemas specified in NAMED_TYPES or MAYBE_NAMED_TYPES."""
 
     def __init__(
         self,
@@ -527,6 +526,9 @@ def _build_schema_objects(schemas: list[JsonDataType], names: Names) -> list[Sch
         if (
             new_schema.type in VALID_TYPES
             and new_schema.type not in NAMED_TYPES
+            and not (
+                new_schema.type in MAYBE_NAMED_TYPES and new_schema.get_prop("name") is not None
+            )
             and new_schema.type in [schema.type for schema in schema_objects]
         ):
             raise SchemaParseException(f"{new_schema.type} type already in Union")

--- a/src/schema_salad/schema.py
+++ b/src/schema_salad/schema.py
@@ -646,7 +646,11 @@ def extend_and_specialize(
             if stype["type"] == "record":
                 stype = copy.copy(stype)
                 combined_fields = []
-                fields = stype.get("fields", [])
+                fields = (
+                    replace_type(stype.get("fields", []), {}, loader, set())
+                    if specs
+                    else stype.get("fields", [])
+                )
                 # We use short names here so that if a type inherits a field
                 # (e.g. Child#id) from a parent (Parent#id) we avoid adding
                 # the same field twice (previously we had just

--- a/src/schema_salad/tests/cwl-pre.yml
+++ b/src/schema_salad/tests/cwl-pre.yml
@@ -563,7 +563,7 @@
       },
       {
         "name": "https://w3id.org/cwl/cwl#File/format",
-        "doc": "The format of the file: this must be an IRI of a concept node that\nrepresents the file format, preferrably defined within an ontology.\nIf no ontology is available, file formats may be tested by exact match.\n\nReasoning about format compatability must be done by checking that an\ninput file format is the same, `owl:equivalentClass` or\n`rdfs:subClassOf` the format required by the input parameter.\n`owl:equivalentClass` is transitive with `rdfs:subClassOf`, e.g. if\n`<B> owl:equivalentClass <C>` and `<B> owl:subclassOf <A>` then infer\n`<C> owl:subclassOf <A>`.\n\nFile format ontologies may be provided in the \"$schemas\" metadata at the\nroot of the document.  If no ontologies are specified in `$schemas`, the\nruntime may perform exact file format matches.\n",
+        "doc": "The format of the file: this must be an IRI of a concept node that\nrepresents the file format, preferably defined within an ontology.\nIf no ontology is available, file formats may be tested by exact match.\n\nReasoning about format compatability must be done by checking that an\ninput file format is the same, `owl:equivalentClass` or\n`rdfs:subClassOf` the format required by the input parameter.\n`owl:equivalentClass` is transitive with `rdfs:subClassOf`, e.g. if\n`<B> owl:equivalentClass <C>` and `<B> owl:subclassOf <A>` then infer\n`<C> owl:subclassOf <A>`.\n\nFile format ontologies may be provided in the \"$schemas\" metadata at the\nroot of the document.  If no ontologies are specified in `$schemas`, the\nruntime may perform exact file format matches.\n",
         "type": [
           "null",
           "string"
@@ -691,20 +691,6 @@
     "doc": "Generic type representing a valid CWL object. It is used to represent\n`default` values passed to CWL `InputParameter` and `WorkflowStepInput`\nrecord fields.\n"
   },
   {
-    "name": "https://w3id.org/cwl/cwl#CWLInputFile",
-    "type": "map",
-    "values": [
-      "null",
-      "https://w3id.org/cwl/cwl#CWLObjectType"
-    ],
-    "doc": "Type representing a valid CWL input file as a `map<string, CWLObjectType>`.\n",
-    "jsonldPredicate": {
-      "_id": "https://w3id.org/cwl/cwl#inputfile",
-      "_container": "@list",
-      "noLinkCheck": true
-    }
-  },
-  {
     "name": "https://w3id.org/cwl/cwl#BaseTypesDoc",
     "doc": "## Base types\n",
     "docChild": [
@@ -716,21 +702,10 @@
   {
     "name": "https://w3id.org/cwl/cwl#CWLVersion",
     "symbols": [
-      "https://w3id.org/cwl/cwl#draft-2",
-      "https://w3id.org/cwl/cwl#draft-3.dev1",
-      "https://w3id.org/cwl/cwl#draft-3.dev2",
-      "https://w3id.org/cwl/cwl#draft-3.dev3",
-      "https://w3id.org/cwl/cwl#draft-3.dev4",
-      "https://w3id.org/cwl/cwl#draft-3.dev5",
-      "https://w3id.org/cwl/cwl#draft-3",
-      "https://w3id.org/cwl/cwl#draft-4.dev1",
-      "https://w3id.org/cwl/cwl#draft-4.dev2",
-      "https://w3id.org/cwl/cwl#draft-4.dev3",
-      "https://w3id.org/cwl/cwl#v1.0.dev4",
       "https://w3id.org/cwl/cwl#v1.0"
     ],
     "type": "enum",
-    "doc": "Version symbols for published CWL document versions."
+    "doc": "Current version symbol for CWL documents."
   },
   {
     "name": "https://w3id.org/cwl/cwl#SchemaBase",
@@ -966,6 +941,28 @@
     ]
   },
   {
+    "doc": "Type schema for the CWL `WorkflowInputParameter` class.\n",
+    "name": "https://w3id.org/cwl/cwl#InputParameterType",
+    "names": [
+      "https://w3id.org/cwl/cwl#CWLType",
+      "https://w3id.org/cwl/cwl#InputRecordSchema",
+      "https://w3id.org/cwl/cwl#InputEnumSchema",
+      "https://w3id.org/cwl/cwl#InputArraySchema",
+      "string",
+      {
+        "items": [
+          "https://w3id.org/cwl/cwl#CWLType",
+          "https://w3id.org/cwl/cwl#InputRecordSchema",
+          "https://w3id.org/cwl/cwl#InputEnumSchema",
+          "https://w3id.org/cwl/cwl#InputArraySchema",
+          "string"
+        ],
+        "type": "array"
+      }
+    ],
+    "type": "union"
+  },
+  {
     "name": "https://w3id.org/cwl/cwl#OutputRecordField",
     "fields": [
       {
@@ -1070,6 +1067,28 @@
     ]
   },
   {
+    "doc": "Type schema for the CWL `WorkflowOutputParameter` class.\n",
+    "name": "https://w3id.org/cwl/cwl#OutputParameterType",
+    "names": [
+      "https://w3id.org/cwl/cwl#CWLType",
+      "https://w3id.org/cwl/cwl#OutputRecordSchema",
+      "https://w3id.org/cwl/cwl#OutputEnumSchema",
+      "https://w3id.org/cwl/cwl#OutputArraySchema",
+      "string",
+      {
+        "items": [
+          "https://w3id.org/cwl/cwl#CWLType",
+          "https://w3id.org/cwl/cwl#OutputRecordSchema",
+          "https://w3id.org/cwl/cwl#OutputEnumSchema",
+          "https://w3id.org/cwl/cwl#OutputArraySchema",
+          "string"
+        ],
+        "type": "array"
+      }
+    ],
+    "type": "union"
+  },
+  {
     "name": "https://w3id.org/cwl/cwl#InputParameter",
     "fields": [
       {
@@ -1080,7 +1099,7 @@
       },
       {
         "name": "https://w3id.org/cwl/cwl#InputParameter/format",
-        "doc": "Only valid when `type: File` or is an array of `items: File`.\n\nThis must be one or more IRIs of concept nodes\nthat represents file formats which are allowed as input to this\nparameter, preferrably defined within an ontology.  If no ontology is\navailable, file formats may be tested by exact match.\n",
+        "doc": "Only valid when `type: File` or is an array of `items: File`.\n\nThis must be one or more IRIs of concept nodes\nthat represents file formats which are allowed as input to this\nparameter, preferably defined within an ontology.  If no ontology is\navailable, file formats may be tested by exact match.\n",
         "type": [
           "null",
           "string",
@@ -1124,21 +1143,7 @@
         "doc": "Specify valid types of data that may be assigned to this parameter.\n",
         "type": [
           "null",
-          "https://w3id.org/cwl/cwl#CWLType",
-          "https://w3id.org/cwl/cwl#InputRecordSchema",
-          "https://w3id.org/cwl/cwl#InputEnumSchema",
-          "https://w3id.org/cwl/cwl#InputArraySchema",
-          "string",
-          {
-            "items": [
-              "https://w3id.org/cwl/cwl#CWLType",
-              "https://w3id.org/cwl/cwl#InputRecordSchema",
-              "https://w3id.org/cwl/cwl#InputEnumSchema",
-              "https://w3id.org/cwl/cwl#InputArraySchema",
-              "string"
-            ],
-            "type": "array"
-          }
+          "https://w3id.org/cwl/cwl#InputParameterType"
         ],
         "jsonldPredicate": {
           "_id": "https://w3id.org/cwl/salad#type",
@@ -1375,7 +1380,7 @@
       "\n\n",
       "# Abstract\n\nA Command Line Tool is a non-interactive executable program that reads\nsome input, performs a computation, and terminates after producing some\noutput.  Command line programs are a flexible unit of code sharing and\nreuse, unfortunately the syntax and input/output semantics among command\nline programs is extremely heterogeneous. A common layer for describing\nthe syntax and semantics of programs can reduce this incidental\ncomplexity by providing a consistent way to connect programs together.\nThis specification defines the Common Workflow Language (CWL) Command\nLine Tool Description, a vendor-neutral standard for describing the\nsyntax and input/output semantics of command line programs.\n",
       "\n",
-      "## Introduction to CWL Command Line Tool standard v1.0.2\n\nThis specification represents the third stable release from the CWL\ngroup.  Since the initial v1.0 release, v1.0.2 introduces the following\nupdates to the CWL Command Line Tool standard.  Documents should continue\nto use `cwlVersion: v1.0` and existing v1.0 documents remain valid,\nhowever CWL documents that relied on previously undefined or\nunderspecified behavior may have slightly different behavior in v1.0.2.\n\n  * 13 July 2016: Mark `baseCommand` as optional and update descriptive text.\n  * 14 November 2016: Clarify [SoftwareRequirement](#SoftwareRequirement)\n    `spec` fields.\n  * 12 March 2017:\n    * Mark `default` as not required for link checking.\n    * Add note that files in InitialWorkDir must have path in output directory.\n    * Add note that writable: true applies recursively.\n  * 23 July 2017: (v1.0.1)\n    * Add clarification about scattering over empty arrays.\n    * Clarify interpretation of `secondaryFiles` on inputs.\n    * Expanded discussion of semantics of `File` and `Directory` types\n    * Fixed typo \"EMACScript\" to \"ECMAScript\"\n    * Clarified application of input parameter default values when the input is `null` or undefined.\n    * Clarified valid types and meaning of the format field on inputs versus outputs\n    * Clarify that command line arguments must not interpreted as shell except when shellQuote: false\n    * Clarify behavior of `entryname`\n  * 10 August 2017: (v1.0.2)\n    * Clarify behavior resolving expressions in `secondaryFile`\n\nSince draft-3, v1.0 introduces the following changes and additions\nto the CWL Command Line Tool standard:\n\n  * The [Directory](#Directory) type.\n  * Syntax simplifcations: denoted by the `map<>` syntax. Example: inputs\n    contains a list of items, each with an id. Now one can specify\n    a mapping of that identifier to the corresponding\n    `CommandInputParameter`.\n    ```\n    inputs:\n     - id: one\n       type: string\n       doc: First input parameter\n     - id: two\n       type: int\n       doc: Second input parameter\n    ```\n    can be\n    ```\n    inputs:\n     one:\n      type: string\n      doc: First input parameter\n     two:\n      type: int\n      doc: Second input parameter\n    ```\n  * [InitialWorkDirRequirement](#InitialWorkDirRequirement): list of\n    files and subdirectories to be present in the output directory prior\n    to execution.\n  * Shortcuts for specifying the standard [output](#stdout) and/or\n    [error](#stderr) streams as a (streamable) File output.\n  * [SoftwareRequirement](#SoftwareRequirement) for describing software\n    dependencies of a tool.\n  * The common `description` field has been renamed to `doc`.\n\n\n## Purpose\n\nStandalone programs are a flexible and interoperable form of code reuse.\nUnlike monolithic applications, applications and analysis workflows which\nare composed of multiple separate programs can be written in multiple\nlanguages and execute concurrently on multiple hosts.  However, POSIX\ndoes not dictate computer-readable grammar or semantics for program input\nand output, resulting in extremely heterogeneous command line grammar and\ninput/output semantics among program.  This is a particular problem in\ndistributed computing (multi-node compute clusters) and virtualized\nenvironments (such as Docker containers) where it is often necessary to\nprovision resources such as input files before executing the program.\n\nOften this gap is filled by hard coding program invocation and\nimplicitly assuming requirements will be met, or abstracting program\ninvocation with wrapper scripts or descriptor documents.  Unfortunately,\nwhere these approaches are application or platform specific it creates a\nsignificant barrier to reproducibility and portability, as methods\ndeveloped for one platform must be manually ported to be used on new\nplatforms.  Similarly it creates redundant work, as wrappers for popular\ntools must be rewritten for each application or platform in use.\n\nThe Common Workflow Language Command Line Tool Description is designed to\nprovide a common standard description of grammar and semantics for\ninvoking programs used in data-intensive fields such as Bioinformatics,\nChemistry, Physics, Astronomy, and Statistics.  This specification\ndefines a precise data and execution model for Command Line Tools that\ncan be implemented on a variety of computing platforms, ranging from a\nsingle workstation to cluster, grid, cloud, and high performance\ncomputing platforms.\n",
+      "## Introduction to CWL Command Line Tool standard v1.0.2\n\nThis specification represents the third stable release from the CWL\ngroup.  Since the initial v1.0 release, v1.0.2 introduces the following\nupdates to the CWL Command Line Tool standard.  Documents should continue\nto use `cwlVersion: v1.0` and existing v1.0 documents remain valid,\nhowever CWL documents that relied on previously undefined or\nunderspecified behavior may have slightly different behavior in v1.0.2.\n\n  * 13 July 2016: Mark `baseCommand` as optional and update descriptive text.\n  * 14 November 2016: Clarify [SoftwareRequirement](#SoftwareRequirement)\n    `spec` fields.\n  * 12 March 2017:\n    * Mark `default` as not required for link checking.\n    * Add note that files in InitialWorkDir must have path in output directory.\n    * Add note that writable: true applies recursively.\n  * 23 July 2017: (v1.0.1)\n    * Add clarification about scattering over empty arrays.\n    * Clarify interpretation of `secondaryFiles` on inputs.\n    * Expanded discussion of semantics of `File` and `Directory` types\n    * Fixed typo \"EMACScript\" to \"ECMAScript\"\n    * Clarified application of input parameter default values when the input is `null` or undefined.\n    * Clarified valid types and meaning of the format field on inputs versus outputs\n    * Clarify that command line arguments must not interpreted as shell except when shellQuote: false\n    * Clarify behavior of `entryname`\n  * 10 August 2017: (v1.0.2)\n    * Clarify behavior resolving expressions in `secondaryFile`\n\nSince draft-3, v1.0 introduces the following changes and additions\nto the CWL Command Line Tool standard:\n\n  * The [Directory](#Directory) type.\n  * Syntax simplifications: denoted by the `map<>` syntax. Example: inputs\n    contains a list of items, each with an id. Now one can specify\n    a mapping of that identifier to the corresponding\n    `CommandInputParameter`.\n    ```\n    inputs:\n     - id: one\n       type: string\n       doc: First input parameter\n     - id: two\n       type: int\n       doc: Second input parameter\n    ```\n    can be\n    ```\n    inputs:\n     one:\n      type: string\n      doc: First input parameter\n     two:\n      type: int\n      doc: Second input parameter\n    ```\n  * [InitialWorkDirRequirement](#InitialWorkDirRequirement): list of\n    files and subdirectories to be present in the output directory prior\n    to execution.\n  * Shortcuts for specifying the standard [output](#stdout) and/or\n    [error](#stderr) streams as a (streamable) File output.\n  * [SoftwareRequirement](#SoftwareRequirement) for describing software\n    dependencies of a tool.\n  * The common `description` field has been renamed to `doc`.\n\n\n## Purpose\n\nStandalone programs are a flexible and interoperable form of code reuse.\nUnlike monolithic applications, applications and analysis workflows which\nare composed of multiple separate programs can be written in multiple\nlanguages and execute concurrently on multiple hosts.  However, POSIX\ndoes not dictate computer-readable grammar or semantics for program input\nand output, resulting in extremely heterogeneous command line grammar and\ninput/output semantics among program.  This is a particular problem in\ndistributed computing (multi-node compute clusters) and virtualized\nenvironments (such as Docker containers) where it is often necessary to\nprovision resources such as input files before executing the program.\n\nOften this gap is filled by hard coding program invocation and\nimplicitly assuming requirements will be met, or abstracting program\ninvocation with wrapper scripts or descriptor documents.  Unfortunately,\nwhere these approaches are application or platform specific it creates a\nsignificant barrier to reproducibility and portability, as methods\ndeveloped for one platform must be manually ported to be used on new\nplatforms.  Similarly it creates redundant work, as wrappers for popular\ntools must be rewritten for each application or platform in use.\n\nThe Common Workflow Language Command Line Tool Description is designed to\nprovide a common standard description of grammar and semantics for\ninvoking programs used in data-intensive fields such as Bioinformatics,\nChemistry, Physics, Astronomy, and Statistics.  This specification\ndefines a precise data and execution model for Command Line Tools that\ncan be implemented on a variety of computing platforms, ranging from a\nsingle workstation to cluster, grid, cloud, and high performance\ncomputing platforms.\n",
       "\n",
       "\n"
     ],
@@ -1660,70 +1665,52 @@
     ]
   },
   {
+    "doc": "Type schema for the CWL `CommandInputParameter` class.\n",
+    "name": "https://w3id.org/cwl/cwl#CommandInputParameterType",
+    "names": [
+      "https://w3id.org/cwl/cwl#CWLType",
+      "https://w3id.org/cwl/cwl#CommandInputRecordSchema",
+      "https://w3id.org/cwl/cwl#CommandInputEnumSchema",
+      "https://w3id.org/cwl/cwl#CommandInputArraySchema",
+      "string",
+      {
+        "items": [
+          "https://w3id.org/cwl/cwl#CWLType",
+          "https://w3id.org/cwl/cwl#CommandInputRecordSchema",
+          "https://w3id.org/cwl/cwl#CommandInputEnumSchema",
+          "https://w3id.org/cwl/cwl#CommandInputArraySchema",
+          "string"
+        ],
+        "type": "array"
+      }
+    ],
+    "type": "union"
+  },
+  {
     "name": "https://w3id.org/cwl/cwl#CommandInputParameter",
     "type": "record",
     "doc": "An input parameter for a CommandLineTool.",
     "extends": "https://w3id.org/cwl/cwl#InputParameter",
-    "specialize": [
-      {
-        "specializeFrom": "https://w3id.org/cwl/cwl#InputRecordSchema",
-        "specializeTo": "https://w3id.org/cwl/cwl#CommandInputRecordSchema"
-      },
-      {
-        "specializeFrom": "https://w3id.org/cwl/cwl#InputEnumSchema",
-        "specializeTo": "https://w3id.org/cwl/cwl#CommandInputEnumSchema"
-      },
-      {
-        "specializeFrom": "https://w3id.org/cwl/cwl#InputArraySchema",
-        "specializeTo": "https://w3id.org/cwl/cwl#CommandInputArraySchema"
-      },
-      {
-        "specializeFrom": "https://w3id.org/cwl/cwl#InputBinding",
-        "specializeTo": "https://w3id.org/cwl/cwl#CommandLineBinding"
-      }
-    ]
-  },
-  {
-    "name": "https://w3id.org/cwl/cwl#CommandOutputParameter",
     "fields": [
       {
-        "name": "https://w3id.org/cwl/cwl#CommandOutputParameter/type",
         "doc": "Specify valid types of data that may be assigned to this parameter.\n",
-        "type": [
-          "null",
-          "https://w3id.org/cwl/cwl#CWLType",
-          "https://w3id.org/cwl/cwl#stdout",
-          "https://w3id.org/cwl/cwl#stderr",
-          "https://w3id.org/cwl/cwl#CommandOutputRecordSchema",
-          "https://w3id.org/cwl/cwl#CommandOutputEnumSchema",
-          "https://w3id.org/cwl/cwl#CommandOutputArraySchema",
-          "string",
-          {
-            "items": [
-              "https://w3id.org/cwl/cwl#CWLType",
-              "https://w3id.org/cwl/cwl#CommandOutputRecordSchema",
-              "https://w3id.org/cwl/cwl#CommandOutputEnumSchema",
-              "https://w3id.org/cwl/cwl#CommandOutputArraySchema",
-              "string"
-            ],
-            "type": "array"
-          }
-        ],
         "jsonldPredicate": {
-          "_id": "https://w3id.org/cwl/cwl#CommandOutputParameter/type/type",
+          "_id": "https://w3id.org/cwl/cwl#CommandInputParameter/type/type",
           "_type": "@vocab",
           "refScope": 2,
           "typeDSL": true
-        }
+        },
+        "name": "https://w3id.org/cwl/cwl#CommandInputParameter/type",
+        "type": [
+          "null",
+          "https://w3id.org/cwl/cwl#CommandInputParameterType"
+        ]
       }
     ],
-    "type": "record",
-    "doc": "An output parameter for a CommandLineTool.",
-    "extends": "https://w3id.org/cwl/cwl#OutputParameter",
     "specialize": [
       {
-        "specializeFrom": "https://w3id.org/cwl/cwl#OutputBinding",
-        "specializeTo": "https://w3id.org/cwl/cwl#CommandOutputBinding"
+        "specializeFrom": "https://w3id.org/cwl/cwl#InputBinding",
+        "specializeTo": "https://w3id.org/cwl/cwl#CommandLineBinding"
       }
     ]
   },
@@ -1744,6 +1731,58 @@
     "type": "enum",
     "doc": "Only valid as a `type` for a `CommandLineTool` output with no\n`outputBinding` set.\n\nThe following\n```\noutputs:\n  an_output_name:\n  type: stderr\n\nstderr: a_stderr_file\n```\nis equivalent to\n```\noutputs:\n  an_output_name:\n    type: File\n    streamable: true\n    outputBinding:\n      glob: a_stderr_file\n\nstderr: a_stderr_file\n```\n\nIf there is no `stderr` name provided, a random filename will be created.\nFor example, the following\n```\noutputs:\n  an_output_name:\n    type: stderr\n```\nis equivalent to\n```\noutputs:\n  an_output_name:\n    type: File\n    streamable: true\n    outputBinding:\n      glob: random_stderr_filenameABCDEFG\n\nstderr: random_stderr_filenameABCDEFG\n```\n",
     "docParent": "https://w3id.org/cwl/cwl#CommandOutputParameter"
+  },
+  {
+    "doc": "Type schema for the CWL `CommandInputParameter` class.\n",
+    "name": "https://w3id.org/cwl/cwl#CommandOutputParameterType",
+    "names": [
+      "https://w3id.org/cwl/cwl#CWLType",
+      "https://w3id.org/cwl/cwl#stdout",
+      "https://w3id.org/cwl/cwl#stderr",
+      "https://w3id.org/cwl/cwl#CommandOutputRecordSchema",
+      "https://w3id.org/cwl/cwl#CommandOutputEnumSchema",
+      "https://w3id.org/cwl/cwl#CommandOutputArraySchema",
+      "string",
+      {
+        "items": [
+          "https://w3id.org/cwl/cwl#CWLType",
+          "https://w3id.org/cwl/cwl#CommandOutputRecordSchema",
+          "https://w3id.org/cwl/cwl#CommandOutputEnumSchema",
+          "https://w3id.org/cwl/cwl#CommandOutputArraySchema",
+          "string"
+        ],
+        "type": "array"
+      }
+    ],
+    "type": "union"
+  },
+  {
+    "name": "https://w3id.org/cwl/cwl#CommandOutputParameter",
+    "fields": [
+      {
+        "name": "https://w3id.org/cwl/cwl#CommandOutputParameter/type",
+        "doc": "Specify valid types of data that may be assigned to this parameter.\n",
+        "type": [
+          "null",
+          "https://w3id.org/cwl/cwl#CommandOutputParameterType"
+        ],
+        "jsonldPredicate": {
+          "_id": "https://w3id.org/cwl/cwl#CommandOutputParameter/type/type",
+          "_type": "@vocab",
+          "refScope": 2,
+          "typeDSL": true
+        }
+      }
+    ],
+    "type": "record",
+    "doc": "An output parameter for a CommandLineTool.",
+    "extends": "https://w3id.org/cwl/cwl#OutputParameter",
+    "specialize": [
+      {
+        "specializeFrom": "https://w3id.org/cwl/cwl#OutputBinding",
+        "specializeTo": "https://w3id.org/cwl/cwl#CommandOutputBinding"
+      }
+    ]
   },
   {
     "name": "https://w3id.org/cwl/cwl#CommandLineTool",
@@ -2002,7 +2041,7 @@
       },
       {
         "name": "https://w3id.org/cwl/cwl#SoftwarePackage/specs",
-        "doc": "One or more [IRI](https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier)s\nidentifying resources for installing or enabling the software named in\nthe `package` field. Implementations may provide resolvers which map\nthese software identifer IRIs to some configuration action; or they can\nuse only the name from the `package` field on a best effort basis.\n\nFor example, the IRI https://packages.debian.org/bowtie could\nbe resolved with `apt-get install bowtie`. The IRI\nhttps://anaconda.org/bioconda/bowtie could be resolved with `conda\ninstall -c bioconda bowtie`.\n\nIRIs can also be system independent and used to map to a specific\nsoftware installation or selection mechanism.\nUsing [RRID](https://www.identifiers.org/rrid/) as an example:\nhttps://identifiers.org/rrid/RRID:SCR_005476\ncould be fulfilled using the above mentioned Debian or bioconda\npackage, a local installation managed by [Environement Modules](http://modules.sourceforge.net/),\nor any other mechanism the platform chooses. IRIs can also be from\nidentifer sources that are discipline specific yet still system\nindependent. As an example, the equivalent [ELIXIR Tools and Data\nService Registry](https://bio.tools) IRI to the previous RRID example is\nhttps://bio.tools/tool/bowtie2/version/2.2.8.\nIf supported by a given registry, implementations are encouraged to\nquery these system independent sofware identifier IRIs directly for\nlinks to packaging systems.\n\nA site specific IRI can be listed as well. For example, an academic\ncomputing cluster using Environement Modules could list the IRI\n`https://hpc.example.edu/modules/bowtie-tbb/1.22` to indicate that\n`module load bowtie-tbb/1.1.2` should be executed to make available\n`bowtie` version 1.1.2 compiled with the TBB library prior to running\nthe accompanying Workflow or CommandLineTool. Note that the example IRI\nis specific to a particular institution and computing environment as\nthe Environment Modules system does not have a common namespace or\nstandardized naming convention.\n\nThis last example is the least portable and should only be used if\nmechanisms based off of the `package` field or more generic IRIs are\nunavailable or unsuitable. While harmless to other sites, site specific\nsoftware IRIs should be left out of shared CWL descriptions to avoid\nclutter.\n",
+        "doc": "One or more [IRI](https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier)s\nidentifying resources for installing or enabling the software named in\nthe `package` field. Implementations may provide resolvers which map\nthese software identifier IRIs to some configuration action; or they can\nuse only the name from the `package` field on a best effort basis.\n\nFor example, the IRI https://packages.debian.org/bowtie could\nbe resolved with `apt-get install bowtie`. The IRI\nhttps://anaconda.org/bioconda/bowtie could be resolved with `conda\ninstall -c bioconda bowtie`.\n\nIRIs can also be system independent and used to map to a specific\nsoftware installation or selection mechanism.\nUsing [RRID](https://www.identifiers.org/rrid/) as an example:\nhttps://identifiers.org/rrid/RRID:SCR_005476\ncould be fulfilled using the above mentioned Debian or bioconda\npackage, a local installation managed by [Environment Modules](http://modules.sourceforge.net/),\nor any other mechanism the platform chooses. IRIs can also be from\nidentifier sources that are discipline specific yet still system\nindependent. As an example, the equivalent [ELIXIR Tools and Data\nService Registry](https://bio.tools) IRI to the previous RRID example is\nhttps://bio.tools/tool/bowtie2/version/2.2.8.\nIf supported by a given registry, implementations are encouraged to\nquery these system independent software identifier IRIs directly for\nlinks to packaging systems.\n\nA site specific IRI can be listed as well. For example, an academic\ncomputing cluster using Environment Modules could list the IRI\n`https://hpc.example.edu/modules/bowtie-tbb/1.22` to indicate that\n`module load bowtie-tbb/1.1.2` should be executed to make available\n`bowtie` version 1.1.2 compiled with the TBB library prior to running\nthe accompanying Workflow or CommandLineTool. Note that the example IRI\nis specific to a particular institution and computing environment as\nthe Environment Modules system does not have a common namespace or\nstandardized naming convention.\n\nThis last example is the least portable and should only be used if\nmechanisms based off of the `package` field or more generic IRIs are\nunavailable or unsuitable. While harmless to other sites, site specific\nsoftware IRIs should be left out of shared CWL descriptions to avoid\nclutter.\n",
         "type": [
           "null",
           {
@@ -2156,7 +2195,7 @@
       }
     ],
     "type": "record",
-    "doc": "Modify the behavior of CommandLineTool to generate a single string\ncontaining a shell command line.  Each item in the argument list must be\njoined into a string separated by single spaces and quoted to prevent\nintepretation by the shell, unless `CommandLineBinding` for that argument\ncontains `shellQuote: false`.  If `shellQuote: false` is specified, the\nargument is joined into the command string without quoting, which allows\nthe use of shell metacharacters such as `|` for pipes.\n",
+    "doc": "Modify the behavior of CommandLineTool to generate a single string\ncontaining a shell command line.  Each item in the argument list must be\njoined into a string separated by single spaces and quoted to prevent\ninterpretation by the shell, unless `CommandLineBinding` for that argument\ncontains `shellQuote: false`.  If `shellQuote: false` is specified, the\nargument is joined into the command string without quoting, which allows\nthe use of shell metacharacters such as `|` for pipes.\n",
     "extends": "https://w3id.org/cwl/cwl#ProcessRequirement"
   },
   {
@@ -2277,7 +2316,7 @@
       "\n\n",
       "# Abstract\n\nOne way to define a workflow is: an analysis task represented by a\ndirected graph describing a sequence of operations that transform an\ninput data set to output. This specification defines the Common Workflow\nLanguage (CWL) Workflow description, a vendor-neutral standard for\nrepresenting workflows intended to be portable across a variety of\ncomputing platforms.\n",
       "\n",
-      "\n## Introduction to CWL Workflow standard v1.0.2\n\nThis specification represents the third stable release from the CWL\ngroup.  Since the initial v1.0 release, v1.0.2 introduces the following\nupdates to the CWL Command Line Tool standard.  Documents should continue\nto use `cwlVersion: v1.0` and existing v1.0 documents remain valid,\nhowever CWL documents that relied on previously undefined or\nunderspecified behavior may have slightly different behavior in v1.0.2.\n\n  * 12 March 2017:\n    * Mark `default` as not required for link checking.\n    * Add note that recursive subworkflows is not allowed.\n    * Fix mistake in discussion of extracting field names from workflow step ids.\n  * 23 July 2017: (v1.0.1)\n    * Add clarification about scattering over empty arrays.\n    * Clarify interpretation of `secondaryFiles` on inputs.\n    * Expanded discussion of semantics of `File` and `Directory` types\n    * Fixed typo \"EMACScript\" to \"ECMAScript\"\n    * Clarified application of input parameter default values when the input is `null` or undefined.\n  * 10 August 2017: (v1.0.2)\n    * Clarify behavior resolving expressions in `secondaryFile`\n\nSince draft-3, v1.0 introduces the following changes and additions\nto the CWL Workflow standard:\n\n  * The `inputs` and `outputs` fields have been renamed `in` and `out`.\n  * Syntax simplifcations: denoted by the `map<>` syntax. Example: `in`\n    contains a list of items, each with an id. Now one can specify\n    a mapping of that identifier to the corresponding\n    `InputParameter`.\n    ```\n    in:\n     - id: one\n       type: string\n       doc: First input parameter\n     - id: two\n       type: int\n       doc: Second input parameter\n    ```\n    can be\n    ```\n    in:\n     one:\n      type: string\n      doc: First input parameter\n     two:\n      type: int\n      doc: Second input parameter\n    ```\n  * The common field `description` has been renamed to `doc`.\n\n## Purpose\n\nThe Common Workflow Language Command Line Tool Description express\nworkflows for data-intensive science, such as Bioinformatics, Chemistry,\nPhysics, and Astronomy.  This specification is intended to define a data\nand execution model for Workflows that can be implemented on top of a\nvariety of computing platforms, ranging from an individual workstation to\ncluster, grid, cloud, and high performance computing systems.\n",
+      "\n## Introduction to CWL Workflow standard v1.0.2\n\nThis specification represents the third stable release from the CWL\ngroup.  Since the initial v1.0 release, v1.0.2 introduces the following\nupdates to the CWL Command Line Tool standard.  Documents should continue\nto use `cwlVersion: v1.0` and existing v1.0 documents remain valid,\nhowever CWL documents that relied on previously undefined or\nunderspecified behavior may have slightly different behavior in v1.0.2.\n\n  * 12 March 2017:\n    * Mark `default` as not required for link checking.\n    * Add note that recursive subworkflows is not allowed.\n    * Fix mistake in discussion of extracting field names from workflow step ids.\n  * 23 July 2017: (v1.0.1)\n    * Add clarification about scattering over empty arrays.\n    * Clarify interpretation of `secondaryFiles` on inputs.\n    * Expanded discussion of semantics of `File` and `Directory` types\n    * Fixed typo \"EMACScript\" to \"ECMAScript\"\n    * Clarified application of input parameter default values when the input is `null` or undefined.\n  * 10 August 2017: (v1.0.2)\n    * Clarify behavior resolving expressions in `secondaryFile`\n\nSince draft-3, v1.0 introduces the following changes and additions\nto the CWL Workflow standard:\n\n  * The `inputs` and `outputs` fields have been renamed `in` and `out`.\n  * Syntax simplifications: denoted by the `map<>` syntax. Example: `in`\n    contains a list of items, each with an id. Now one can specify\n    a mapping of that identifier to the corresponding\n    `InputParameter`.\n    ```\n    in:\n     - id: one\n       type: string\n       doc: First input parameter\n     - id: two\n       type: int\n       doc: Second input parameter\n    ```\n    can be\n    ```\n    in:\n     one:\n      type: string\n      doc: First input parameter\n     two:\n      type: int\n      doc: Second input parameter\n    ```\n  * The common field `description` has been renamed to `doc`.\n\n## Purpose\n\nThe Common Workflow Language Command Line Tool Description express\nworkflows for data-intensive science, such as Bioinformatics, Chemistry,\nPhysics, and Astronomy.  This specification is intended to define a data\nand execution model for Workflows that can be implemented on top of a\nvariety of computing platforms, ranging from an individual workstation to\ncluster, grid, cloud, and high performance computing systems.\n",
       "\n"
     ],
     "type": "documentation"
@@ -2398,21 +2437,7 @@
         "doc": "Specify valid types of data that may be assigned to this parameter.\n",
         "type": [
           "null",
-          "https://w3id.org/cwl/cwl#CWLType",
-          "https://w3id.org/cwl/cwl#OutputRecordSchema",
-          "https://w3id.org/cwl/cwl#OutputEnumSchema",
-          "https://w3id.org/cwl/cwl#OutputArraySchema",
-          "string",
-          {
-            "items": [
-              "https://w3id.org/cwl/cwl#CWLType",
-              "https://w3id.org/cwl/cwl#OutputRecordSchema",
-              "https://w3id.org/cwl/cwl#OutputEnumSchema",
-              "https://w3id.org/cwl/cwl#OutputArraySchema",
-              "string"
-            ],
-            "type": "array"
-          }
+          "https://w3id.org/cwl/cwl#OutputParameterType"
         ],
         "jsonldPredicate": {
           "_id": "https://w3id.org/cwl/cwl#WorkflowOutputParameter/type/type",
@@ -2484,7 +2509,7 @@
       },
       {
         "name": "https://w3id.org/cwl/cwl#WorkflowStepInput/valueFrom",
-        "doc": "To use valueFrom, [StepInputExpressionRequirement](#StepInputExpressionRequirement) must\nbe specified in the workflow or workflow step requirements.\n\nIf `valueFrom` is a constant string value, use this as the value for\nthis input parameter.\n\nIf `valueFrom` is a parameter reference or expression, it must be\nevaluated to yield the actual value to be assiged to the input field.\n\nThe `self` value in the parameter reference or expression must be\n1. `null` if there is no `source` field\n2. the value of the parameter(s) specified in the `source` field when this\nworkflow input parameter **is not** specified in this workflow step's `scatter` field.\n3. an element of the parameter specified in the `source` field when this workflow input\nparameter **is** specified in this workflow step's `scatter` field.\n\nThe value of `inputs` in the parameter reference or expression must be\nthe input object to the workflow step after assigning the `source`\nvalues, applying `default`, and then scattering.  The order of\nevaluating `valueFrom` among step input parameters is undefined and the\nresult of evaluating `valueFrom` on a parameter must not be visible to\nevaluation of `valueFrom` on other parameters.\n",
+        "doc": "To use valueFrom, [StepInputExpressionRequirement](#StepInputExpressionRequirement) must\nbe specified in the workflow or workflow step requirements.\n\nIf `valueFrom` is a constant string value, use this as the value for\nthis input parameter.\n\nIf `valueFrom` is a parameter reference or expression, it must be\nevaluated to yield the actual value to be assigned to the input field.\n\nThe `self` value in the parameter reference or expression must be\n1. `null` if there is no `source` field\n2. the value of the parameter(s) specified in the `source` field when this\nworkflow input parameter **is not** specified in this workflow step's `scatter` field.\n3. an element of the parameter specified in the `source` field when this workflow input\nparameter **is** specified in this workflow step's `scatter` field.\n\nThe value of `inputs` in the parameter reference or expression must be\nthe input object to the workflow step after assigning the `source`\nvalues, applying `default`, and then scattering.  The order of\nevaluating `valueFrom` among step input parameters is undefined and the\nresult of evaluating `valueFrom` on a parameter must not be visible to\nevaluation of `valueFrom` on other parameters.\n",
         "type": [
           "null",
           "string",
@@ -2677,7 +2702,7 @@
       },
       {
         "name": "https://w3id.org/cwl/cwl#Workflow/steps",
-        "doc": "The individual steps that make up the workflow.  Each step is executed when all of its\ninput data links are fufilled.  An implementation may choose to execute\nthe steps in a different order than listed and/or execute steps\nconcurrently, provided that dependencies between steps are met.\n",
+        "doc": "The individual steps that make up the workflow.  Each step is executed when all of its\ninput data links are fulfilled.  An implementation may choose to execute\nthe steps in a different order than listed and/or execute steps\nconcurrently, provided that dependencies between steps are met.\n",
         "type": [
           {
             "items": "https://w3id.org/cwl/cwl#WorkflowStep",
@@ -2690,7 +2715,7 @@
       }
     ],
     "type": "record",
-    "doc": "A workflow describes a set of **steps** and the **dependencies** between\nthose steps.  When a step produces output that will be consumed by a\nsecond step, the first step is a dependency of the second step.\n\nWhen there is a dependency, the workflow engine must execute the preceding\nstep and wait for it to successfully produce output before executing the\ndependent step.  If two steps are defined in the workflow graph that\nare not directly or indirectly dependent, these steps are **independent**,\nand may execute in any order or execute concurrently.  A workflow is\ncomplete when all steps have been executed.\n\nDependencies between parameters are expressed using the `source` field on\n[workflow step input parameters](#WorkflowStepInput) and [workflow output\nparameters](#WorkflowOutputParameter).\n\nThe `source` field expresses the dependency of one parameter on another\nsuch that when a value is associated with the parameter specified by\n`source`, that value is propagated to the destination parameter.  When all\ndata links inbound to a given step are fufilled, the step is ready to\nexecute.\n\n## Workflow success and failure\n\nA completed step must result in one of `success`, `temporaryFailure` or\n`permanentFailure` states.  An implementation may choose to retry a step\nexecution which resulted in `temporaryFailure`.  An implementation may\nchoose to either continue running other steps of a workflow, or terminate\nimmediately upon `permanentFailure`.\n\n* If any step of a workflow execution results in `permanentFailure`, then\nthe workflow status is `permanentFailure`.\n\n* If one or more steps result in `temporaryFailure` and all other steps\ncomplete `success` or are not executed, then the workflow status is\n`temporaryFailure`.\n\n* If all workflow steps are executed and complete with `success`, then the\nworkflow status is `success`.\n\n# Extensions\n\n[ScatterFeatureRequirement](#ScatterFeatureRequirement) and\n[SubworkflowFeatureRequirement](#SubworkflowFeatureRequirement) are\navailable as standard [extensions](#Extensions_and_Metadata) to core\nworkflow semantics.\n",
+    "doc": "A workflow describes a set of **steps** and the **dependencies** between\nthose steps.  When a step produces output that will be consumed by a\nsecond step, the first step is a dependency of the second step.\n\nWhen there is a dependency, the workflow engine must execute the preceding\nstep and wait for it to successfully produce output before executing the\ndependent step.  If two steps are defined in the workflow graph that\nare not directly or indirectly dependent, these steps are **independent**,\nand may execute in any order or execute concurrently.  A workflow is\ncomplete when all steps have been executed.\n\nDependencies between parameters are expressed using the `source` field on\n[workflow step input parameters](#WorkflowStepInput) and [workflow output\nparameters](#WorkflowOutputParameter).\n\nThe `source` field expresses the dependency of one parameter on another\nsuch that when a value is associated with the parameter specified by\n`source`, that value is propagated to the destination parameter.  When all\ndata links inbound to a given step are fulfilled, the step is ready to\nexecute.\n\n## Workflow success and failure\n\nA completed step must result in one of `success`, `temporaryFailure` or\n`permanentFailure` states.  An implementation may choose to retry a step\nexecution which resulted in `temporaryFailure`.  An implementation may\nchoose to either continue running other steps of a workflow, or terminate\nimmediately upon `permanentFailure`.\n\n* If any step of a workflow execution results in `permanentFailure`, then\nthe workflow status is `permanentFailure`.\n\n* If one or more steps result in `temporaryFailure` and all other steps\ncomplete `success` or are not executed, then the workflow status is\n`temporaryFailure`.\n\n* If all workflow steps are executed and complete with `success`, then the\nworkflow status is `success`.\n\n# Extensions\n\n[ScatterFeatureRequirement](#ScatterFeatureRequirement) and\n[SubworkflowFeatureRequirement](#SubworkflowFeatureRequirement) are\navailable as standard [extensions](#Extensions_and_Metadata) to core\nworkflow semantics.\n",
     "documentRoot": true,
     "extends": "https://w3id.org/cwl/cwl#Process",
     "specialize": [
@@ -2791,5 +2816,19 @@
     "type": "record",
     "doc": "Indicate that the workflow platform must support the `valueFrom` field\nof [WorkflowStepInput](#WorkflowStepInput).\n",
     "extends": "https://w3id.org/cwl/cwl#ProcessRequirement"
+  },
+  {
+    "name": "https://w3id.org/cwl/cwl#CWLInputFile",
+    "type": "map",
+    "values": [
+      "null",
+      "https://w3id.org/cwl/cwl#CWLObjectType"
+    ],
+    "doc": "Type representing a valid CWL input file as a `map<string, CWLObjectType>`.\n",
+    "jsonldPredicate": {
+      "_id": "https://w3id.org/cwl/cwl#inputfile",
+      "_container": "@list",
+      "noLinkCheck": true
+    }
   }
 ]

--- a/src/schema_salad/tests/test_schema/Base.yml
+++ b/src/schema_salad/tests/test_schema/Base.yml
@@ -286,7 +286,7 @@ $graph:
         noLinkCheck: true
       doc: |
         The format of the file: this must be an IRI of a concept node that
-        represents the file format, preferrably defined within an ontology.
+        represents the file format, preferably defined within an ontology.
         If no ontology is available, file formats may be tested by exact match.
 
         Reasoning about format compatability must be done by checking that an
@@ -469,15 +469,3 @@ $graph:
     Generic type representing a valid CWL object. It is used to represent
     `default` values passed to CWL `InputParameter` and `WorkflowStepInput`
     record fields.
-
-- name: CWLInputFile
-  type: map
-  values:
-    - "null"
-    - CWLObjectType
-  doc: |
-    Type representing a valid CWL input file as a `map<string, CWLObjectType>`.
-  jsonldPredicate:
-    _id: "cwl:inputfile"
-    _container: "@list"
-    noLinkCheck: true

--- a/src/schema_salad/tests/test_schema/CommandLineTool.yml
+++ b/src/schema_salad/tests/test_schema/CommandLineTool.yml
@@ -68,7 +68,7 @@ $graph:
       to the CWL Command Line Tool standard:
 
         * The [Directory](#Directory) type.
-        * Syntax simplifcations: denoted by the `map<>` syntax. Example: inputs
+        * Syntax simplifications: denoted by the `map<>` syntax. Example: inputs
           contains a list of items, each with an id. Now one can specify
           a mapping of that identifier to the corresponding
           `CommandInputParameter`.
@@ -391,46 +391,36 @@ $graph:
     - specializeFrom: OutputBinding
       specializeTo: CommandOutputBinding
 
+- name: CommandInputParameterType
+  type: union
+  names:
+    - CWLType
+    - CommandInputRecordSchema
+    - CommandInputEnumSchema
+    - CommandInputArraySchema
+    - string
+    - type: array
+      items:
+        - CWLType
+        - CommandInputRecordSchema
+        - CommandInputEnumSchema
+        - CommandInputArraySchema
+        - string
+  doc: |
+    Type schema for the CWL `CommandInputParameter` class.
 
 - type: record
   name: CommandInputParameter
   extends: InputParameter
   doc: An input parameter for a CommandLineTool.
   specialize:
-    - specializeFrom: InputRecordSchema
-      specializeTo: CommandInputRecordSchema
-    - specializeFrom: InputEnumSchema
-      specializeTo: CommandInputEnumSchema
-    - specializeFrom: InputArraySchema
-      specializeTo: CommandInputArraySchema
     - specializeFrom: InputBinding
       specializeTo: CommandLineBinding
-
-- type: record
-  name: CommandOutputParameter
-  extends: OutputParameter
-  doc: An output parameter for a CommandLineTool.
-  specialize:
-    - specializeFrom: OutputBinding
-      specializeTo: CommandOutputBinding
   fields:
     - name: type
       type:
         - "null"
-        - CWLType
-        - stdout
-        - stderr
-        - CommandOutputRecordSchema
-        - CommandOutputEnumSchema
-        - CommandOutputArraySchema
-        - string
-        - type: array
-          items:
-            - CWLType
-            - CommandOutputRecordSchema
-            - CommandOutputEnumSchema
-            - CommandOutputArraySchema
-            - string
+        - CommandInputParameterType
       jsonldPredicate:
         "_id": "sld:type"
         "_type": "@vocab"
@@ -534,6 +524,45 @@ $graph:
     stderr: random_stderr_filenameABCDEFG
     ```
 
+- name: CommandOutputParameterType
+  type: union
+  names:
+    - CWLType
+    - stdout
+    - stderr
+    - CommandOutputRecordSchema
+    - CommandOutputEnumSchema
+    - CommandOutputArraySchema
+    - string
+    - type: array
+      items:
+        - CWLType
+        - CommandOutputRecordSchema
+        - CommandOutputEnumSchema
+        - CommandOutputArraySchema
+        - string
+  doc: |
+    Type schema for the CWL `CommandInputParameter` class.
+
+- type: record
+  name: CommandOutputParameter
+  extends: OutputParameter
+  doc: An output parameter for a CommandLineTool.
+  specialize:
+    - specializeFrom: OutputBinding
+      specializeTo: CommandOutputBinding
+  fields:
+    - name: type
+      type:
+        - "null"
+        - CommandOutputParameterType
+      jsonldPredicate:
+        "_id": "sld:type"
+        "_type": "@vocab"
+        refScope: 2
+        typeDSL: True
+      doc: |
+        Specify valid types of data that may be assigned to this parameter.
 
 - type: record
   name: CommandLineTool
@@ -761,7 +790,7 @@ $graph:
         One or more [IRI](https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier)s
         identifying resources for installing or enabling the software named in
         the `package` field. Implementations may provide resolvers which map
-        these software identifer IRIs to some configuration action; or they can
+        these software identifier IRIs to some configuration action; or they can
         use only the name from the `package` field on a best effort basis.
 
         For example, the IRI https://packages.debian.org/bowtie could
@@ -774,18 +803,18 @@ $graph:
         Using [RRID](https://www.identifiers.org/rrid/) as an example:
         https://identifiers.org/rrid/RRID:SCR_005476
         could be fulfilled using the above mentioned Debian or bioconda
-        package, a local installation managed by [Environement Modules](http://modules.sourceforge.net/),
+        package, a local installation managed by [Environment Modules](http://modules.sourceforge.net/),
         or any other mechanism the platform chooses. IRIs can also be from
-        identifer sources that are discipline specific yet still system
+        identifier sources that are discipline specific yet still system
         independent. As an example, the equivalent [ELIXIR Tools and Data
         Service Registry](https://bio.tools) IRI to the previous RRID example is
         https://bio.tools/tool/bowtie2/version/2.2.8.
         If supported by a given registry, implementations are encouraged to
-        query these system independent sofware identifier IRIs directly for
+        query these system independent software identifier IRIs directly for
         links to packaging systems.
 
         A site specific IRI can be listed as well. For example, an academic
-        computing cluster using Environement Modules could list the IRI
+        computing cluster using Environment Modules could list the IRI
         `https://hpc.example.edu/modules/bowtie-tbb/1.22` to indicate that
         `module load bowtie-tbb/1.1.2` should be executed to make available
         `bowtie` version 1.1.2 compiled with the TBB library prior to running
@@ -922,7 +951,7 @@ $graph:
     Modify the behavior of CommandLineTool to generate a single string
     containing a shell command line.  Each item in the argument list must be
     joined into a string separated by single spaces and quoted to prevent
-    intepretation by the shell, unless `CommandLineBinding` for that argument
+    interpretation by the shell, unless `CommandLineBinding` for that argument
     contains `shellQuote: false`.  If `shellQuote: false` is specified, the
     argument is joined into the command string without quoting, which allows
     the use of shell metacharacters such as `|` for pipes.

--- a/src/schema_salad/tests/test_schema/CommonWorkflowLanguage.yml
+++ b/src/schema_salad/tests/test_schema/CommonWorkflowLanguage.yml
@@ -9,3 +9,15 @@ $graph:
 - $import: Process.yml
 - $import: CommandLineTool.yml
 - $import: Workflow.yml
+
+- name: CWLInputFile
+  type: map
+  values:
+    - "null"
+    - CWLObjectType
+  doc: |
+    Type representing a valid CWL input file as a `map<string, CWLObjectType>`.
+  jsonldPredicate:
+    _id: "cwl:inputfile"
+    _container: "@list"
+    noLinkCheck: true

--- a/src/schema_salad/tests/test_schema/Process.yml
+++ b/src/schema_salad/tests/test_schema/Process.yml
@@ -25,19 +25,8 @@ $graph:
 
 - type: enum
   name: CWLVersion
-  doc: "Version symbols for published CWL document versions."
+  doc: "Current version symbol for CWL documents."
   symbols:
-    - cwl:draft-2
-    - cwl:draft-3.dev1
-    - cwl:draft-3.dev2
-    - cwl:draft-3.dev3
-    - cwl:draft-3.dev4
-    - cwl:draft-3.dev5
-    - cwl:draft-3
-    - cwl:draft-4.dev1
-    - cwl:draft-4.dev2
-    - cwl:draft-4.dev3
-    - cwl:v1.0.dev4
     - cwl:v1.0
 
 
@@ -228,6 +217,23 @@ $graph:
       type: InputBinding?
       jsonldPredicate: "cwl:inputBinding"
 
+- name: InputParameterType
+  type: union
+  names:
+    - CWLType
+    - InputRecordSchema
+    - InputEnumSchema
+    - InputArraySchema
+    - string
+    - type: array
+      items:
+        - CWLType
+        - InputRecordSchema
+        - InputEnumSchema
+        - InputArraySchema
+        - string
+  doc: |
+    Type schema for the CWL `WorkflowInputParameter` class.
 
 - name: OutputRecordField
   type: record
@@ -283,6 +289,23 @@ $graph:
       type: OutputBinding?
       jsonldPredicate: "cwl:outputBinding"
 
+- name: OutputParameterType
+  type: union
+  names:
+    - CWLType
+    - OutputRecordSchema
+    - OutputEnumSchema
+    - OutputArraySchema
+    - string
+    - type: array
+      items:
+        - CWLType
+        - OutputRecordSchema
+        - OutputEnumSchema
+        - OutputArraySchema
+        - string
+  doc: |
+    Type schema for the CWL `WorkflowOutputParameter` class.
 
 - name: InputParameter
   type: record
@@ -310,7 +333,7 @@ $graph:
 
         This must be one or more IRIs of concept nodes
         that represents file formats which are allowed as input to this
-        parameter, preferrably defined within an ontology.  If no ontology is
+        parameter, preferably defined within an ontology.  If no ontology is
         available, file formats may be tested by exact match.
 
 
@@ -336,18 +359,7 @@ $graph:
     - name: type
       type:
         - "null"
-        - CWLType
-        - InputRecordSchema
-        - InputEnumSchema
-        - InputArraySchema
-        - string
-        - type: array
-          items:
-            - CWLType
-            - InputRecordSchema
-            - InputEnumSchema
-            - InputArraySchema
-            - string
+        - InputParameterType
       jsonldPredicate:
         "_id": "sld:type"
         "_type": "@vocab"

--- a/src/schema_salad/tests/test_schema/Workflow.yml
+++ b/src/schema_salad/tests/test_schema/Workflow.yml
@@ -60,7 +60,7 @@ $graph:
       to the CWL Workflow standard:
 
         * The `inputs` and `outputs` fields have been renamed `in` and `out`.
-        * Syntax simplifcations: denoted by the `map<>` syntax. Example: `in`
+        * Syntax simplifications: denoted by the `map<>` syntax. Example: `in`
           contains a list of items, each with an id. Now one can specify
           a mapping of that identifier to the corresponding
           `InputParameter`.
@@ -186,18 +186,7 @@ $graph:
     - name: type
       type:
         - "null"
-        - "#CWLType"
-        - "#OutputRecordSchema"
-        - "#OutputEnumSchema"
-        - "#OutputArraySchema"
-        - string
-        - type: array
-          items:
-            - "#CWLType"
-            - "#OutputRecordSchema"
-            - "#OutputEnumSchema"
-            - "#OutputArraySchema"
-            - string
+        - OutputParameterType
       jsonldPredicate:
         "_id": "sld:type"
         "_type": "@vocab"
@@ -304,7 +293,7 @@ $graph:
         this input parameter.
 
         If `valueFrom` is a parameter reference or expression, it must be
-        evaluated to yield the actual value to be assiged to the input field.
+        evaluated to yield the actual value to be assigned to the input field.
 
         The `self` value in the parameter reference or expression must be
         1. `null` if there is no `source` field
@@ -519,7 +508,7 @@ $graph:
     The `source` field expresses the dependency of one parameter on another
     such that when a value is associated with the parameter specified by
     `source`, that value is propagated to the destination parameter.  When all
-    data links inbound to a given step are fufilled, the step is ready to
+    data links inbound to a given step are fulfilled, the step is ready to
     execute.
 
     ## Workflow success and failure
@@ -560,7 +549,7 @@ $graph:
     - name: steps
       doc: |
         The individual steps that make up the workflow.  Each step is executed when all of its
-        input data links are fufilled.  An implementation may choose to execute
+        input data links are fulfilled.  An implementation may choose to execute
         the steps in a different order than listed and/or execute steps
         concurrently, provided that dependencies between steps are met.
       type:


### PR DESCRIPTION
- Sync test schema files with the latest CWL schemas from the CWL v1.0 codegen branch, and adapt cwl-pre.yml accordingly
- Allow map/union to be treated as named types in avro schema validation
- Add pytest testpaths configuration